### PR TITLE
Finalize transition to new advisories repo

### DIFF
--- a/.github/workflows/build-and-publish-secdb.yaml
+++ b/.github/workflows/build-and-publish-secdb.yaml
@@ -1,0 +1,48 @@
+name: Build and publish secdb
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-publish:
+    name: Build and publish security database
+    runs-on: ubuntu-latest
+    if: github.repository == 'wolfi-dev/advisories'
+
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: auth
+        name: 'Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
+          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
+
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: prod-images-c6e5
+
+      - name: 'Check that GCloud is properly configured'
+        run: |
+          gcloud info
+          gcloud --quiet alpha storage ls
+
+      # TODO: Image digest needs to be updated to include the new `db` command.
+      - name: Build the security database
+        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:067bff7dd012394072c58761219ddbcb1717e4550a937419e60bef63f2ceaffb
+        with:
+          entrypoint: wolfictl
+          args: "advisory db -o security.json"
+
+      - name: 'Upload the security database to a bucket'
+        run: |
+          gcloud --quiet alpha storage cp --recursive ${{ github.workspace }}/security.json gs://wolfi-production-registry-destination/os/

--- a/.github/workflows/build-and-publish-secdb.yaml
+++ b/.github/workflows/build-and-publish-secdb.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:067bff7dd012394072c58761219ddbcb1717e4550a937419e60bef63f2ceaffb
         with:
           entrypoint: wolfictl
-          args: "advisory db -o security.json"
+          args: "advisory db --arch x86_64 --arch aarch64 -o security.json"
 
       - name: 'Upload the security database to a bucket'
         run: |

--- a/.github/workflows/build-and-publish-secdb.yaml
+++ b/.github/workflows/build-and-publish-secdb.yaml
@@ -36,9 +36,8 @@ jobs:
           gcloud info
           gcloud --quiet alpha storage ls
 
-      # TODO: Image digest needs to be updated to include the new `db` command.
       - name: Build the security database
-        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:067bff7dd012394072c58761219ddbcb1717e4550a937419e60bef63f2ceaffb
+        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:1b3ff62685952d3f776ccd526bc1ee8fd0b27cc28d5ccab8443f4ea355067840
         with:
           entrypoint: wolfictl
           args: "advisory db --arch x86_64 --arch aarch64 -o security.json"

--- a/.github/workflows/build-and-publish-secdb.yaml
+++ b/.github/workflows/build-and-publish-secdb.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:1b3ff62685952d3f776ccd526bc1ee8fd0b27cc28d5ccab8443f4ea355067840
         with:
           entrypoint: wolfictl
-          args: "advisory db --arch x86_64 --arch aarch64 -o security.json"
+          args: "advisory db --advisories-repo-dir . --arch x86_64 --arch aarch64 -o security.json"
 
       - name: 'Upload the security database to a bucket'
         run: |

--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -1,0 +1,23 @@
+name: Image digest update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
+
+jobs:
+  image-update:
+    name: Image digest update
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+      actions: write
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: chainguard-dev/actions/digesta-bot@main
+      with:
+        token: ${{ secrets.DIGEST_BOT_WOLFI_PAT }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: ['main']
+  push:
+    branches:
+      - gh-readonly-queue/main/**
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Check YAML formatting
+      id: lint-yaml
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:067bff7dd012394072c58761219ddbcb1717e4550a937419e60bef63f2ceaffb
+      with:
+        entrypoint: wolfictl
+        args: lint yam
+
+    - name: Check secfixes synchronization
+      id: sync-secfixes
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:067bff7dd012394072c58761219ddbcb1717e4550a937419e60bef63f2ceaffb
+      with:
+        entrypoint: wolfictl
+        args: "advisory sync-secfixes --warn"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,14 +20,14 @@ jobs:
 
     - name: Check YAML formatting
       id: lint-yaml
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:067bff7dd012394072c58761219ddbcb1717e4550a937419e60bef63f2ceaffb
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:1b3ff62685952d3f776ccd526bc1ee8fd0b27cc28d5ccab8443f4ea355067840
       with:
         entrypoint: wolfictl
         args: lint yam
 
     - name: Check secfixes synchronization
       id: sync-secfixes
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:067bff7dd012394072c58761219ddbcb1717e4550a937419e60bef63f2ceaffb
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:1b3ff62685952d3f776ccd526bc1ee8fd0b27cc28d5ccab8443f4ea355067840
       with:
         entrypoint: wolfictl
         args: "advisory sync-secfixes --warn"

--- a/apko.advisories.yaml
+++ b/apko.advisories.yaml
@@ -6,6 +6,8 @@ secfixes:
     - CVE-2023-28840
     - CVE-2023-28841
     - CVE-2023-28842
+  0.8.0-r1:
+    - CVE-2023-30551
 
 advisories:
   CVE-2023-28840:
@@ -22,3 +24,8 @@ advisories:
     - timestamp: 2023-04-05T10:22:32.318046-04:00
       status: fixed
       fixed-version: 0.7.3-r1
+
+  CVE-2023-30551:
+    - timestamp: 2023-05-04T12:30:46.874822-04:00
+      status: fixed
+      fixed-version: 0.8.0-r1


### PR DESCRIPTION
This adds:

- CI (lint checks)
- Build/publish production secdb job

**IMPORTANT:** Before finalizing this move, we also need to run `./hack/import-data.sh` one final time, to import the latest advisory and secfixes data from `wolfi-dev/os`.