### PR TITLE
Nack CVE-2022-3647 for redis 6.2.

### DIFF
--- a/redis-6.2.advisories.yaml
+++ b/redis-6.2.advisories.yaml
@@ -1,0 +1,8 @@
+package:
+  name: redis-6.2
+
+advisories:
+  CVE-2022-3647:
+    - timestamp: 2023-05-22T06:35:07.758435-04:00
+      status: vulnerable_code_not_present
+      impact: The vulnerability is disputed upstream, indicating that this is expected behavior.

--- a/redis-6.2.advisories.yaml
+++ b/redis-6.2.advisories.yaml
@@ -4,5 +4,10 @@ package:
 advisories:
   CVE-2022-3647:
     - timestamp: 2023-05-22T06:35:07.758435-04:00
-      status: vulnerable_code_not_present
+      status: not_affected
+      justification: vulnerable_code_not_present
       impact: The vulnerability is disputed upstream, indicating that this is expected behavior.
+
+secfixes:
+  "0":
+    - CVE-2022-3647


### PR DESCRIPTION
We already nacked this for the main redis package. The CVE is disputed and not valid.