### PR TITLE
OpenSSL CVE-2023-2650: Possible DoS translating ASN.1 object identifiers

### DIFF
--- a/openssl.advisories.yaml
+++ b/openssl.advisories.yaml
@@ -82,3 +82,8 @@ advisories:
     - timestamp: 2023-04-20T09:29:24.558074-07:00
       status: fixed
       fixed-version: 3.1.0-r5
+
+  CVE-2023-2650:
+    - timestamp: 2023-05-30T11:31:01.558074-05:00
+      status: fixed
+      fixed-version: 3.1.1-r0


### PR DESCRIPTION
Reference: https://www.openssl.org/news/secadv/20230530.txt
Related: https://github.com/wolfi-dev/os/pull/2422