### PR TITLE
Add advisories for recent Nodejs security releases

### DIFF
--- a/nodejs-16.advisories.yaml
+++ b/nodejs-16.advisories.yaml
@@ -1,0 +1,28 @@
+package:
+  name: nodejs-16
+
+advisories:
+  CVE-2023-30581:
+    - timestamp: 2023-06-20T13:11:00-04:00
+      status: fixed
+      fixed-version: 16.20.1-r0
+
+  CVE-2023-30585:
+    - timestamp: 2023-06-20T13:11:00-04:00
+      status: fixed
+      fixed-version: 16.20.1-r0
+
+  CVE-2023-30588:
+    - timestamp: 2023-06-20T13:11:00-04:00
+      status: fixed
+      fixed-version: 16.20.1-r0
+
+  CVE-2023-30589:
+    - timestamp: 2023-06-20T13:11:00-04:00
+      status: fixed
+      fixed-version: 16.20.1-r0
+
+  CVE-2023-30590:
+    - timestamp: 2023-06-20T13:11:00-04:00
+      status: fixed
+      fixed-version: 16.20.1-r0

--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -1,0 +1,28 @@
+package:
+  name: nodejs-18
+
+advisories:
+  CVE-2023-30581:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 18.16.1-r0
+
+  CVE-2023-30585:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 18.16.1-r0
+
+  CVE-2023-30588:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 18.16.1-r0
+
+  CVE-2023-30589:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 18.16.1-r0
+
+  CVE-2023-30590:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 18.16.1-r0

--- a/nodejs-20.advisories.yaml
+++ b/nodejs-20.advisories.yaml
@@ -1,0 +1,53 @@
+package:
+  name: nodejs-20
+
+advisories:
+  CVE-2023-30581:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 20.3.1-r0
+
+  CVE-2023-30584:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 20.3.1-r0
+
+  CVE-2023-30587:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 20.3.1-r0
+
+  CVE-2023-30582:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 20.3.1-r0
+
+  CVE-2023-30583:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 20.3.1-r0
+
+  CVE-2023-30585:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 20.3.1-r0
+
+  CVE-2023-30586:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 20.3.1-r0
+
+  CVE-2023-30588:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 20.3.1-r0
+
+  CVE-2023-30589:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 20.3.1-r0
+
+  CVE-2023-30590:
+    - timestamp: 2023-06-20T15:07:00-04:00
+      status: fixed
+      fixed-version: 20.3.1-r0


### PR DESCRIPTION
For reference: https://nodejs.org/en/blog/vulnerability/june-2023-security-releases

- https://github.com/wolfi-dev/os/pull/2982
- https://github.com/wolfi-dev/os/pull/2990
- https://github.com/wolfi-dev/os/pull/2991