### PR TITLE
NACK redis CVE entries

### DIFF
--- a/redis-6.2.advisories.yaml
+++ b/redis-6.2.advisories.yaml
@@ -2,8 +2,20 @@ package:
   name: redis-6.2
 
 advisories:
+  CVE-2022-0543:
+    - timestamp: 2023-07-12T12:05:46.282906-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This is a Debian-specific issue and does not affect Wolfi.
+
   CVE-2022-3647:
     - timestamp: 2023-05-22T06:35:07.758435-04:00
       status: not_affected
       justification: vulnerable_code_not_present
       impact: The vulnerability is disputed upstream, indicating that this is expected behavior.
+
+  CVE-2022-3734:
+    - timestamp: 2023-07-12T12:07:06.829221-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This is a disputed CVE entry that does not actually affect Redis.

--- a/redis.advisories.yaml
+++ b/redis.advisories.yaml
@@ -6,6 +6,10 @@ advisories:
     - timestamp: 2022-12-24T13:35:15-05:00
       status: fixed
       fixed-version: 7.0.7-r0
+    - timestamp: 2023-07-12T12:05:46.282906-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This is a Debian-specific issue and does not affect Wolfi.
 
   CVE-2022-3647:
     - timestamp: 2022-12-24T13:35:15-05:00
@@ -16,6 +20,10 @@ advisories:
     - timestamp: 2022-12-24T13:35:15-05:00
       status: fixed
       fixed-version: 7.0.7-r0
+    - timestamp: 2023-07-12T12:07:06.829221-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This is a disputed CVE entry that does not actually affect Redis.
 
   CVE-2022-35977:
     - timestamp: 2023-02-20T14:37:55.058122-05:00


### PR DESCRIPTION
Adds new advisories for `redis-6.2`, and propagates those status updates to the `redis` package