### PR TITLE
Add CVE-2023-38408 for OpenSSH 9.2p1

### DIFF
--- a/openssh.advisories.yaml
+++ b/openssh.advisories.yaml
@@ -6,6 +6,7 @@ advisories:
     - timestamp: 2023-02-06T13:39:35.322093-05:00
       status: fixed
       fixed-version: 9.2_p1-r0
+
   CVE-2023-38408:
     - timestamp: 2023-07-19T11:06:22.022093-05:00
       status: fixed

--- a/openssh.advisories.yaml
+++ b/openssh.advisories.yaml
@@ -10,4 +10,4 @@ advisories:
   CVE-2023-38408:
     - timestamp: 2023-07-19T11:06:22.022093-05:00
       status: fixed
-      fixed-version: 9.2_p2-r0
+      fixed-version: 9.3_p2-r0

--- a/openssh.advisories.yaml
+++ b/openssh.advisories.yaml
@@ -6,3 +6,7 @@ advisories:
     - timestamp: 2023-02-06T13:39:35.322093-05:00
       status: fixed
       fixed-version: 9.2_p1-r0
+  CVE-2023-38408:
+    - timestamp: 2023-07-19T11:06:22.022093-05:00
+      status: fixed
+      fixed-version: 9.2_p2-r0


### PR DESCRIPTION
https://www.openssh.com/releasenotes.html#9.3p2

Fix CVE-2023-38408 - a condition where specific libaries loaded via
[ssh-agent(1)](https://man.openbsd.org/ssh-agent.1)'s PKCS#11 support could be abused to achieve remote
code execution via a forwarded agent socket if the following
conditions are met:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38408