### PR TITLE
Add advisory data for CVE-2023-1428 for kube-fluentd-operator

### DIFF
--- a/kube-fluentd-operator.advisories.yaml
+++ b/kube-fluentd-operator.advisories.yaml
@@ -7,3 +7,7 @@ advisories:
       status: not_affected
       justification: component_not_present
       impact: The CVE was against an older version of ruby itself which included this in the stdlib.
+
+  CVE-2023-1428:
+    - timestamp: 2023-07-24T16:18:10.348888+02:00
+      status: under_investigation


### PR DESCRIPTION
Related to issue: #102 