### PR TITLE
Add GHSA-mjmj-j48q-9wg2 to Jenkins advisory

### DIFF
--- a/jenkins.advisories.yaml
+++ b/jenkins.advisories.yaml
@@ -45,3 +45,9 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
       impact: CVE disputed by upstream developers, nothing specific to this application.
+
+  GHSA-mjmj-j48q-9wg2:
+    - timestamp: 2023-07-24T11:14:08.315835-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: The vulnerable code is not present in the Jenkins snakeyaml plugin, see https://github.com/jenkinsci/snakeyaml-api-plugin/pull/75#issuecomment-1482964755.


### PR DESCRIPTION
This is a High CVE, mapping to [CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471).

The CVE is a RCE bug in snakeyaml, which is a plugin Jenkins pulls in. Based on this [comment](https://github.com/jenkinsci/snakeyaml-api-plugin/pull/75#issuecomment-1482964755) it looks like Jenkins has already verified that the vulnerable code is not present in the snakeyaml plugin. That PR would also pull in the CVE fix, but it hasn't been merged yet since it would create breaking changes.

>There is no vulnerability in snakeyaml - it works as expected - the vulnerability is in any libraries that use it insecurely with untrusted data. The Jenkins plugin ecosystem has been checked for this usage.