### PR TITLE
tkn advisories for GHSA-2h5h-59f5-c5x9 and GHSA-frqx-jfcm-6jjr

### DIFF
--- a/tkn.advisories.yaml
+++ b/tkn.advisories.yaml
@@ -1,0 +1,15 @@
+package:
+  name: tkn
+
+advisories:
+  GHSA-2h5h-59f5-c5x9:
+    - timestamp: 2023-07-24T14:38:06.711297-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: The libraries this CVE impacts are not used by the Tekton project
+
+  GHSA-frqx-jfcm-6jjr:
+    - timestamp: 2023-07-24T14:43:30.33793-07:00
+      status: not_affected
+      justification: vulnerable_code_cannot_be_controlled_by_adversary
+      impact: Malformed entry requests can cause panics, but Tekton doesn't allow users to generate custom requests


### PR DESCRIPTION
GHSA-2h5h-59f5-c5x9 : this effects the jar and apk libraries in Rekor, but Tekton doesn't use those libraries for anything

GHSA-frqx-jfcm-6jjr: This causes a panic in rekor if malformed requests to the log are sent, but Tekton doesn't allow users to customize requests so this can't happen.