### PR TITLE
CVE-2018-20225 Pulumi advisory

### DIFF
--- a/pulumi.advisories.yaml
+++ b/pulumi.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: pulumi
+
+advisories:
+  CVE-2018-20225:
+    - timestamp: 2023-07-27T16:10:39.129113-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.


### PR DESCRIPTION
This python CVE has been [disputed](https://nvd.nist.gov/vuln/detail/CVE-2018-20225), and we've said the same thing about it for other packages too (conda, py3.10-pip, py3.11-pip). 