### PR TITLE
[kubectl] Add CVE-2019-11255

### DIFF
--- a/kubectl.advisories.yaml
+++ b/kubectl.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: kubectl
+
+advisories:
+  CVE-2019-11255:
+    - timestamp: 2023-08-07T15:07:36.090523-04:00
+      status: not_affected
+      justification: component_not_present
+      impact: Vuln only present in Kubernets CSI sidecars external-provisioner, external-snapshotter, external-resizer


### PR DESCRIPTION
Vulnerability only present in Kubernetes CSI Sidecars: https://github.com/advisories/GHSA-f4w6-3rh6-6q4q