### PR TITLE
Create advisory for Kyverno

### DIFF
--- a/kyverno.advisories.yaml
+++ b/kyverno.advisories.yaml
@@ -1,0 +1,15 @@
+package:
+  name: kyverno
+
+advisories:
+  CVE-2023-30551:
+    - timestamp: 2023-08-08T16:51:19.398968-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: The vulnerable code in Rekor cannot be imported.
+
+  CVE-2023-33199:
+    - timestamp: 2023-08-08T16:51:19.398968-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: The vulnerable code is effectively private. The vulnerable code is unlikely to ever be imported.


### PR DESCRIPTION
Update - after watching Dan's video, I looked up those vulnerabilities in the go vulndb:

- https://github.com/golang/vulndb/blob/master/data/excluded/GO-2023-1795.yaml
- https://github.com/golang/vulndb/blob/master/data/excluded/GO-2023-1754.yaml

Marking both as `not_affected`, aligning with the Golang determination.

~Kyverno imports an affected version of github.com/sigstore/rekor. Trying to update the dependency with melange doesn't work in this case. I'm not familiar enough with Kyverno to figure out if they use the code affected by GHSA-2h5h-59f5-c5x9. I would guess they're not, but I'm erring on the side of caution with the advisory information. We've analyzed the same vulnerabilities for `tkn` - @priyawadhwa may have an opinion here!~

Quick FYI also: Kyverno is working on upgrading to cosign 2.0: https://github.com/kyverno/kyverno/pull/7248