### PR TITLE
[gradle-8] CVE-2023-2976 & CVE-2020-8908

### DIFF
--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -1,0 +1,10 @@
+package:
+  name: gradle-8
+
+advisories:
+  CVE-2023-2976:
+    - timestamp: 2023-08-08T17:07:36.957515-04:00
+      status: under_investigation
+    - timestamp: 2023-08-10T18:11:57.628638-04:00
+      status: fixed
+      fixed-version: 8.2.1-r1

--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -2,6 +2,11 @@ package:
   name: gradle-8
 
 advisories:
+  CVE-2020-8908:
+    - timestamp: 2023-08-10T18:12:46.040472-04:00
+      status: fixed
+      fixed-version: 8.2.1-r1
+
   CVE-2023-2976:
     - timestamp: 2023-08-08T17:07:36.957515-04:00
       status: under_investigation


### PR DESCRIPTION
Update advisories for CVE-2023-2976 and CVE-2020-8908 in the `gradle-8` package.