### PR TITLE
nodejs: add advisories for aug 9 releases

### DIFF
--- a/nodejs-16.advisories.yaml
+++ b/nodejs-16.advisories.yaml
@@ -26,3 +26,18 @@ advisories:
     - timestamp: 2023-06-20T13:11:00-04:00
       status: fixed
       fixed-version: 16.20.1-r0
+
+  CVE-2023-32002:
+    - timestamp: 2023-08-10T08:00:44.454427-04:00
+      status: fixed
+      fixed-version: 16.20.2-r0
+
+  CVE-2023-32006:
+    - timestamp: 2023-08-10T08:00:44.454427-04:00
+      status: fixed
+      fixed-version: 16.20.2-r0
+
+  CVE-2023-32559:
+    - timestamp: 2023-08-10T08:00:44.454427-04:00
+      status: fixed
+      fixed-version: 16.20.2-r0

--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -26,3 +26,18 @@ advisories:
     - timestamp: 2023-06-20T15:07:00-04:00
       status: fixed
       fixed-version: 18.16.1-r0
+
+  CVE-2023-32002:
+    - timestamp: 2023-08-10T08:00:44.454427-04:00
+      status: fixed
+      fixed-version: 18.17.1-r0
+
+  CVE-2023-32006:
+    - timestamp: 2023-08-10T08:00:44.454427-04:00
+      status: fixed
+      fixed-version: 18.17.1-r0
+
+  CVE-2023-32559:
+    - timestamp: 2023-08-10T08:00:44.454427-04:00
+      status: fixed
+      fixed-version: 18.17.1-r0

--- a/nodejs-20.advisories.yaml
+++ b/nodejs-20.advisories.yaml
@@ -51,3 +51,18 @@ advisories:
     - timestamp: 2023-06-20T15:07:00-04:00
       status: fixed
       fixed-version: 20.3.1-r0
+
+  CVE-2023-32002:
+    - timestamp: 2023-08-10T08:00:44.454427-04:00
+      status: fixed
+      fixed-version: 20.5.1-r0
+
+  CVE-2023-32006:
+    - timestamp: 2023-08-10T08:00:44.454427-04:00
+      status: fixed
+      fixed-version: 20.5.1-r0
+
+  CVE-2023-32559:
+    - timestamp: 2023-08-10T08:00:44.454427-04:00
+      status: fixed
+      fixed-version: 20.5.1-r0


### PR DESCRIPTION
Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases