### PR TITLE
gradle-8: CVE-2022-45868

### DIFF
--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -13,6 +13,12 @@ advisories:
       justification: vulnerable_code_not_in_execute_path
       impact: 'Gradle is not vulnerable because it does not leverage the Apache Ivy dependency cache: https://github.com/gradle/gradle/issues/24795#issuecomment-1623594418'
 
+  CVE-2022-45868:
+    - timestamp: 2023-08-11T10:07:24.992685-04:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path
+      impact: "CVE is disputed. It relates to exposed passwords when using h2 via command-line. h2 is in use by Gradle as a library, and there is no reference of the CVE-related CLI argument being used in the codebase. Project maintainer's position: https://github.com/gradle/gradle/issues/24708#issuecomment-1508321833"
+
   CVE-2023-2976:
     - timestamp: 2023-08-08T17:07:36.957515-04:00
       status: under_investigation


### PR DESCRIPTION
Include CVE-2022-45868 to the Gradle advisories. This CVE is disputed and both h2database and Gradle state that this is not a vulnerability, since exposure of passwords in the command-line is not a product-specific problem and its use is discouraged by h2.

Relevant upstream issues and PRs:
* https://github.com/gradle/gradle/issues/24708#issuecomment-1508321833
* https://github.com/h2database/h2database/pull/3833
* https://github.com/h2database/h2database/issues/3686