### PR TITLE
gradle-8: CVE-2022-37866

### DIFF
--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -7,6 +7,12 @@ advisories:
       status: fixed
       fixed-version: 8.2.1-r1
 
+  CVE-2022-37866:
+    - timestamp: 2023-08-11T10:59:21.033003-04:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path
+      impact: 'Gradle is not vulnerable because it does not leverage the Apache Ivy dependency cache: https://github.com/gradle/gradle/issues/24795#issuecomment-1623594418'
+
   CVE-2023-2976:
     - timestamp: 2023-08-08T17:07:36.957515-04:00
       status: under_investigation


### PR DESCRIPTION
Include CVE-2022-37866 in the gradle-8 package advisories. As per https://github.com/gradle/gradle/issues/24795#issuecomment-1623594418, Gradle is not affected by this specific CVE as it does not leverage the vulnerable code.