### PR TITLE
[tkn] Add GHSA-w2h3-vvvq-3m53 as not_affected.

### DIFF
--- a/tkn.advisories.yaml
+++ b/tkn.advisories.yaml
@@ -13,3 +13,9 @@ advisories:
       status: not_affected
       justification: vulnerable_code_cannot_be_controlled_by_adversary
       impact: Malformed entry requests can cause panics, but Tekton doesn't allow users to generate custom requests
+
+  GHSA-w2h3-vvvq-3m53:
+    - timestamp: 2023-08-11T11:23:31.127149-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: Vulnerability only present in Tekton Pipelines controller code. Package only relies on client libraries / test utilities.


### PR DESCRIPTION
tkn only relies on client code / test libraries, not vulnerable controller code.

Fixes https://github.com/chainguard-dev/temp-cve-issues-by-package/issues/345