### PR TITLE
gradle-8: CVE-2023-35116

### DIFF
--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -25,3 +25,9 @@ advisories:
     - timestamp: 2023-08-10T18:11:57.628638-04:00
       status: fixed
       fixed-version: 8.2.1-r1
+
+  CVE-2023-35116:
+    - timestamp: 2023-08-11T11:36:11.286307-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386


### PR DESCRIPTION
Create advisory for CVE-2023-35116 in Gradle.

According to discussion in https://github.com/FasterXML/jackson-databind/issues/3972, this is being considered a false positive by the Jackson maintainers. Sonatype is not reporting it as an issue in either of the [versions used by Gradle](https://github.com/gradle/gradle/network/dependencies?q=databind): [jackson-databind@2.14.1](https://ossindex.sonatype.org/component/pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1) or [jackson-databind@2.12.7.1](https://ossindex.sonatype.org/component/pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.12.7.1). Dependency Check has also [excluded it as a false positive](https://github.com/jeremylong/DependencyCheck/issues/5779).