### PR TITLE
[tekton-pipelines-resolvers] Add CVE-2023-1732 as not_affected.

### DIFF
--- a/tekton-pipelines-resolvers.advisories.yaml
+++ b/tekton-pipelines-resolvers.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: tekton-pipelines-resolvers
+
+advisories:
+  CVE-2023-1732:
+    - timestamp: 2023-08-11T13:23:33.940995-04:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path
+      impact: Vulnerable packages not in dependency tree.


### PR DESCRIPTION
Dependency tree for circl:

```sh
$ go list -deps -json all | jq -r .ImportPath | grep circl
github.com/cloudflare/circl/internal/conv
github.com/cloudflare/circl/math/fp25519
github.com/cloudflare/circl/dh/x25519
github.com/cloudflare/circl/math/fp448
github.com/cloudflare/circl/dh/x448
github.com/cloudflare/circl/math
github.com/cloudflare/circl/sign
github.com/cloudflare/circl/sign/ed25519
github.com/cloudflare/circl/math/mlsbset
github.com/cloudflare/circl/ecc/goldilocks
github.com/cloudflare/circl/internal/sha3
github.com/cloudflare/circl/sign/ed448
```

which does not include vulnerable packages under:

- abe
- blindsign
- kem

Fixes https://github.com/chainguard-dev/temp-cve-issues-by-package/issues/392