### PR TITLE
NACK CVE-2019-11255 for nodetaint

### DIFF
--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: nodetaint
+
+advisories:
+  CVE-2019-11255:
+    - timestamp: 2023-08-11T10:53:13.239852-07:00
+      status: not_affected
+      justification: component_not_present
+      impact: Vuln only present in Kubernets CSI sidecars external-provisioner, external-snapshotter, external-resizer


### PR DESCRIPTION
This only affects Kubernets CSI sidecars external-provisioner, external-snapshotter, external-resizer.

Also marked as EFFECTIVELY_PRIVATE in [golang/vulndb](https://github.com/golang/vulndb/blob/master/data/excluded/GO-2023-1943.yaml)