### PR TITLE
Add advisories for consul 1.15

### DIFF
--- a/consul-1.15.advisories.yaml
+++ b/consul-1.15.advisories.yaml
@@ -3,25 +3,21 @@ package:
 
 advisories:
   CVE-2022-3920:
-    - timestamp: 2023-08-11T11:28:42.267808-07:00
-      status: not_affected
-      justification: vulnerable_code_not_present
-      impact: consul-1.15 now default builds to 1.15.5, mitigating vulnerabilities reported on 1.15.3
+    - timestamp: 2023-08-11T12:51:12.468487-07:00
+      status: fixed
+      fixed-version: 1.15.5-r0
 
   CVE-2022-40716:
-    - timestamp: 2023-08-11T11:29:49.710288-07:00
-      status: not_affected
-      justification: vulnerable_code_not_present
-      impact: consul-1.15 now default builds to 1.15.5, mitigating vulnerabilities reported on 1.15.3
+    - timestamp: 2023-08-11T12:51:56.645324-07:00
+      status: fixed
+      fixed-version: 1.15.5-r0
 
   CVE-2023-0845:
-    - timestamp: 2023-08-11T11:30:25.873513-07:00
-      status: not_affected
-      justification: vulnerable_code_not_present
-      impact: consul-1.15 now default builds to 1.15.5, mitigating vulnerabilities reported on 1.15.3
+    - timestamp: 2023-08-11T12:52:24.57547-07:00
+      status: fixed
+      fixed-version: 1.15.5-r0
 
   CVE-2023-1297:
-    - timestamp: 2023-08-11T11:31:17.535667-07:00
-      status: not_affected
-      justification: vulnerable_code_not_present
-      impact: consul-1.15 now default builds to 1.15.5, mitigating vulnerabilities reported on 1.15.3
+    - timestamp: 2023-08-11T12:52:43.239399-07:00
+      status: fixed
+      fixed-version: 1.15.5-r0

--- a/consul-1.15.advisories.yaml
+++ b/consul-1.15.advisories.yaml
@@ -1,0 +1,27 @@
+package:
+  name: consul-1.15
+
+advisories:
+  CVE-2022-3920:
+    - timestamp: 2023-08-11T11:28:42.267808-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: consul-1.15 now default builds to 1.15.5, mitigating vulnerabilities reported on 1.15.3
+
+  CVE-2022-40716:
+    - timestamp: 2023-08-11T11:29:49.710288-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: consul-1.15 now default builds to 1.15.5, mitigating vulnerabilities reported on 1.15.3
+
+  CVE-2023-0845:
+    - timestamp: 2023-08-11T11:30:25.873513-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: consul-1.15 now default builds to 1.15.5, mitigating vulnerabilities reported on 1.15.3
+
+  CVE-2023-1297:
+    - timestamp: 2023-08-11T11:31:17.535667-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: consul-1.15 now default builds to 1.15.5, mitigating vulnerabilities reported on 1.15.3


### PR DESCRIPTION
Running `make package/consul-1.15 BUILDWORLD=no USE_CACHE=no` builds consul 1.15 to 1.15.5 per https://github.com/wolfi-dev/os/blob/2b779442287776cd9a24b1958b8f5ff1980b6cb9/consul-1.15.yaml#L3. Running `wolfictl scan`, `grype`, and `syft` on `consul-1.15-1.15.5-r0.apk` no longer reports the CVEs listed in https://github.com/chainguard-dev/temp-cve-issues-by-package/issues/335.