### PR TITLE
NACK CVE-2020-8565 & 2020-8564 for nodetaint

### DIFF
--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -15,14 +15,16 @@ advisories:
       impact: This is a Kubernetes API flaw, but we don't include an API server in this package.
 
   CVE-2020-8564:
-    - timestamp: 2023-08-11T11:38:54.02141-07:00
-      status: fixed
-      fixed-version: 0.0.4-r0
+    - timestamp: 2023-08-11T12:22:26.031395-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This does not affect k8s.io/client-go@v0.20.0-alpha.2
 
   CVE-2020-8565:
-    - timestamp: 2023-08-11T11:47:45.365053-07:00
-      status: fixed
-      fixed-version: 0.0.4-r0
+    - timestamp: 2023-08-11T12:17:00.292793-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This does not affect k8s.io/client-go@v0.20.0-alpha.2
 
   CVE-2021-25740:
     - timestamp: 2023-08-11T11:11:11.384955-07:00

--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -14,6 +14,16 @@ advisories:
       justification: component_not_present
       impact: This is a Kubernetes API flaw, but we don't include an API server in this package.
 
+  CVE-2020-8564:
+    - timestamp: 2023-08-11T11:38:54.02141-07:00
+      status: fixed
+      fixed-version: 0.0.4-r0
+
+  CVE-2020-8565:
+    - timestamp: 2023-08-11T11:47:45.365053-07:00
+      status: fixed
+      fixed-version: 0.0.4-r0
+
   CVE-2021-25740:
     - timestamp: 2023-08-11T11:11:11.384955-07:00
       status: not_affected


### PR DESCRIPTION
Both patched in k8s.io/client-go@v0.20.0-alpha.2

See https://github.com/golang/vulndb/blob/1e5f087d110c4ae7fdd0d48fe2d09750f25aef53/data/osv/GO-2021-0066.json#L7 and https://github.com/golang/vulndb/blob/1e5f087d110c4ae7fdd0d48fe2d09750f25aef53/data/osv/GO-2021-0064.json#L5