### PR TITLE
NACK CVE-2020-8561 CVE-2023-2727 CVE-2023-2728 for nodetaint

### DIFF
--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -14,6 +14,12 @@ advisories:
       justification: component_not_present
       impact: This is a Kubernetes API flaw, but we don't include an API server in this package.
 
+  CVE-2020-8561:
+    - timestamp: 2023-08-11T12:02:42.993043-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This only affects kube-apiserver logs, and code was marked NOT_IMPORTABLE in Golang vulndb
+
   CVE-2021-25740:
     - timestamp: 2023-08-11T11:11:11.384955-07:00
       status: not_affected
@@ -25,3 +31,9 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
       impact: This bug affects Kubelet, which isn't in nodetaint -- also Golang vulndb marked as EFFECTIVELY_PRIVATE
+
+  CVE-2023-2727:
+    - timestamp: 2023-08-11T11:58:45.324372-07:00
+      status: not_affected
+      justification: component_not_present
+      impact: This is only affecting Kubernetes, and was also mark NOT_IMPORTABLE in Golang vulndb

--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -37,3 +37,9 @@ advisories:
       status: not_affected
       justification: component_not_present
       impact: This is only affecting Kubernetes, and was also mark NOT_IMPORTABLE in Golang vulndb
+
+  CVE-2023-2728:
+    - timestamp: 2023-08-11T12:05:59.729557-07:00
+      status: not_affected
+      justification: component_not_present
+      impact: This only impacts Kubernetes itself, and was also marked NOT_IMPORTABLE by Golang vulndb


### PR DESCRIPTION
These only affects Kubernetes, and were all marked NOT_IMPORTABLE in Golang vulndb.