### PR TITLE
node-problem-detector: advisory for affected vulns

### DIFF
--- a/node-problem-detector.advisories.yaml
+++ b/node-problem-detector.advisories.yaml
@@ -2,6 +2,11 @@ package:
   name: node-problem-detector
 
 advisories:
+  CVE-2019-11250:
+    - timestamp: 2023-08-11T12:35:15.52539-07:00
+      status: affected
+      action: Waiting for upstream release.
+
   CVE-2020-8554:
     - timestamp: 2023-08-11T11:24:18.698345-07:00
       status: not_affected
@@ -25,6 +30,16 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+
+  CVE-2020-8564:
+    - timestamp: 2023-08-11T12:46:01.969823-07:00
+      status: affected
+      action: Pending upstream fix.
+
+  CVE-2020-8565:
+    - timestamp: 2023-08-11T12:45:22.307105-07:00
+      status: affected
+      action: Pending upstream fix.
 
   CVE-2021-25735:
     - timestamp: 2023-08-11T11:21:29.54486-07:00
@@ -61,3 +76,8 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+
+  GHSA-74fp-r6jw-h4mp:
+    - timestamp: 2023-08-11T12:27:05.856378-07:00
+      status: affected
+      action: Waiting for upstream release.

--- a/node-problem-detector.advisories.yaml
+++ b/node-problem-detector.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2019-11250:
     - timestamp: 2023-08-11T12:35:15.52539-07:00
       status: affected
-      action: Waiting for upstream release.
+      action: Waiting for upstream release, fixed with PR https://github.com/kubernetes/node-problem-detector/pull/760.
 
   CVE-2020-8554:
     - timestamp: 2023-08-11T11:24:18.698345-07:00
@@ -34,12 +34,12 @@ advisories:
   CVE-2020-8564:
     - timestamp: 2023-08-11T12:46:01.969823-07:00
       status: affected
-      action: Pending upstream fix.
+      action: Pending upstream project to pick up one of k8s.io/kubernetes 0.17.13+, 0.18.10+, 0.19.3+.
 
   CVE-2020-8565:
     - timestamp: 2023-08-11T12:45:22.307105-07:00
       status: affected
-      action: Pending upstream fix.
+      action: Pending upstream project to pick up k8s.io/kubernetes 0.19.4+.
 
   CVE-2021-25735:
     - timestamp: 2023-08-11T11:21:29.54486-07:00
@@ -80,4 +80,4 @@ advisories:
   GHSA-74fp-r6jw-h4mp:
     - timestamp: 2023-08-11T12:27:05.856378-07:00
       status: affected
-      action: Waiting for upstream release.
+      action: Waiting for upstream release, fixed with PR https://github.com/kubernetes/node-problem-detector/pull/760.


### PR DESCRIPTION
CVE-2019-11250 and GHSA-74fp-r6jw-h4mp will be fixed once a release is cut

CVE-2020-8564 and CVE-2020-8565 will be addressed when upstream picks up newer k8s.io deps, head is at 0.17.2, which still contains these vulns, need 0.19.4+ to fix both