### PR TITLE
wavefront-proxy: CVE-2023-35116 and CVE-2023-34462

### DIFF
--- a/wavefront-proxy.advisories.yaml
+++ b/wavefront-proxy.advisories.yaml
@@ -1,0 +1,16 @@
+package:
+  name: wavefront-proxy
+
+advisories:
+  CVE-2023-34462:
+    - timestamp: 2023-08-11T14:20:24.152317-04:00
+      status: under_investigation
+    - timestamp: 2023-08-11T15:56:03.368506-04:00
+      status: fixed
+      fixed-version: 13.1-r1
+
+  CVE-2023-35116:
+    - timestamp: 2023-08-11T14:19:16.019833-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386


### PR DESCRIPTION
Record CVE-2023-35116 and CVE-2023-34462 for wavefront-proxy.

CVE-2023-35116: According to discussion in https://github.com/FasterXML/jackson-databind/issues/3972, this is being considered a false positive by the Jackson maintainers. Sonatype is [not reporting it as an issue in version 2.15.2](https://ossindex.sonatype.org/component/pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2), [used by Wavefront Proxy](https://github.com/wavefrontHQ/wavefront-proxy/network/dependencies?q=jackson) as a transitive dependency from `com.fasterxml.jackson.module:jackson-module-afterburner`, as shown by
`mvn -f proxy dependency:tree -Dincludes=com.fasterxml.jackson.core:jackson-databind`:
```shell
[INFO] --- dependency:3.6.0:tree (default-cli) @ proxy ---
[INFO] com.wavefront:proxy:jar:13.0
[INFO] \- com.fasterxml.jackson.module:jackson-module-afterburner:jar:2.14.0:compile
[INFO]    \- com.fasterxml.jackson.core:jackson-databind:jar:2.15.2:compile
```

Dependency Check has also [excluded it as a false positive](https://github.com/jeremylong/DependencyCheck/issues/5779).

CVE-2023-34462: patch via wolfi-dev/os#4391