### PR TITLE
Nack CVE-2023-21968 in openjdk-8. This was fixed prior to our packaging.

### DIFF
--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: openjdk-8
+
+advisories:
+  CVE-2023-21968:
+    - timestamp: 2023-08-11T16:23:47.720726-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: The vulnerability was patched upstream in 362, prior to Wolfi packaging.


### PR DESCRIPTION
https://openjdk.org/groups/vulnerability/advisories/2023-04-18