### PR TITLE
NACK CVE-2019-3826 prom-{operator,config-reloader}

### DIFF
--- a/prometheus-config-reloader.advisories.yaml
+++ b/prometheus-config-reloader.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: prometheus-config-reloader
+
+advisories:
+  CVE-2019-3826:
+    - timestamp: 2023-08-11T14:17:56.238481-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This CVE only impacts prometheus 2.7 but our prometheus-config-reloader is using v0.46.0 Go library which is in fact prometheus 2.46

--- a/prometheus-operator.advisories.yaml
+++ b/prometheus-operator.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: prometheus-operator
+
+advisories:
+  CVE-2019-3826:
+    - timestamp: 2023-08-11T14:13:07.826089-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This CVE only impacts prometheus 2.7 but our prometheus-operator is using v0.46.0 Go library which is in fact prothemeus 2.46


### PR DESCRIPTION
There seems to be a version confusion between the prometheus Go library version (v0.46.0) and their binary version v2.46.0, causing these packages to be flagged with a very old CVE that has since been fixed in v2.7.