### PR TITLE
Advisories for `grpcurl` `1.8.7`

### DIFF
--- a/grpcurl.advisories.yaml
+++ b/grpcurl.advisories.yaml
@@ -1,0 +1,33 @@
+package:
+  name: grpcurl
+
+advisories:
+  CVE-2021-31525:
+    - timestamp: 2023-08-11T14:20:17.843561-07:00
+      status: fixed
+      fixed-version: 1.8.7-r7
+
+  CVE-2021-33194:
+    - timestamp: 2023-08-11T14:19:46.312532-07:00
+      status: fixed
+      fixed-version: 1.8.7-r7
+
+  CVE-2022-27664:
+    - timestamp: 2023-08-11T14:18:47.729099-07:00
+      status: fixed
+      fixed-version: 1.8.7-r7
+
+  CVE-2022-29526:
+    - timestamp: 2023-08-11T14:21:21.255018-07:00
+      status: fixed
+      fixed-version: 1.8.7-r7
+
+  CVE-2022-32149:
+    - timestamp: 2023-08-11T14:21:48.171142-07:00
+      status: fixed
+      fixed-version: 1.8.7-r7
+
+  CVE-2022-41723:
+    - timestamp: 2023-08-11T14:20:57.929088-07:00
+      status: fixed
+      fixed-version: 1.8.7-r7


### PR DESCRIPTION
Documents fixes in https://github.com/wolfi-dev/os/pull/4395.
Fixes https://github.com/chainguard-dev/temp-cve-issues-by-package/issues/390.