### PR TITLE
NACK CVE-2019-3826 for thanos and telegraf

### DIFF
--- a/telegraf.advisories.yaml
+++ b/telegraf.advisories.yaml
@@ -3,9 +3,10 @@ package:
 
 advisories:
   CVE-2019-3826:
-    - timestamp: 2023-08-11T14:41:26.261081-07:00
-      status: fixed
-      fixed-version: 1.26.3-r0
+    - timestamp: 2023-08-11T19:48:34.107747-07:00
+      status: not_affected
+      justification: component_not_present
+      impact: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
 
   CVE-2023-34231:
     - timestamp: 2023-06-13T07:37:43.741941-04:00

--- a/telegraf.advisories.yaml
+++ b/telegraf.advisories.yaml
@@ -2,6 +2,11 @@ package:
   name: telegraf
 
 advisories:
+  CVE-2019-3826:
+    - timestamp: 2023-08-11T14:41:26.261081-07:00
+      status: fixed
+      fixed-version: 1.26.3-r0
+
   CVE-2023-34231:
     - timestamp: 2023-06-13T07:37:43.741941-04:00
       status: fixed

--- a/thanos-operator.advisories.yaml
+++ b/thanos-operator.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: thanos-operator
+
+advisories:
+  CVE-2019-3826:
+    - timestamp: 2023-08-11T14:45:02.177345-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This only affects prometheus 2.7 but the thanos package started with prometheus 0.42 (which is 2.42)

--- a/thanos-operator.advisories.yaml
+++ b/thanos-operator.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2019-3826:
     - timestamp: 2023-08-11T14:45:02.177345-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
-      impact: This only affects prometheus 2.7 but the thanos package started with prometheus 0.42 (which is 2.42)
+      justification: component_not_present
+      impact: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403


### PR DESCRIPTION
This CVE never affects the Go module but the UI JS code 

See: https://github.com/prometheus/prometheus/issues/12403#issuecomment-1595658680
https://github.com/prometheus/prometheus/pull/5163/files