### PR TITLE
cloudwatch-exporter: CVE-2023-34462

### DIFF
--- a/cloudwatch-exporter.advisories.yaml
+++ b/cloudwatch-exporter.advisories.yaml
@@ -1,0 +1,7 @@
+package:
+  name: cloudwatch-exporter
+
+advisories:
+  CVE-2023-34462:
+    - timestamp: 2023-08-11T17:39:51.275715-04:00
+      status: under_investigation


### PR DESCRIPTION
Add advisory for CVE-2023-34462 in cloudwatch-exporter package as under investigation.