### PR TITLE
NAK CVE-2023-3603 in libssh and libssh2

### DIFF
--- a/libssh.advisories.yaml
+++ b/libssh.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: libssh
+
+advisories:
+  CVE-2023-3603:
+    - timestamp: 2023-08-11T15:37:30.618212-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This CVE pertains to a defect in an example program and is unrelated to the library.

--- a/libssh2.advisories.yaml
+++ b/libssh2.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: libssh2
+
+advisories:
+  CVE-2023-3603:
+    - timestamp: 2023-08-11T15:39:49.474346-07:00
+      status: not_affected
+      justification: component_not_present
+      impact: This CVE pertains to a defect in an example program in libssh, not libssh2.


### PR DESCRIPTION
In libssh, the CVE pertains to an example program.

The example program is not present in libssh2, which is an entirely unrelated library.