### PR TITLE
kubernetes-1.2*: CVE-2019-11255

### DIFF
--- a/kubernetes-1.24.advisories.yaml
+++ b/kubernetes-1.24.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: kubernetes-1.24
+
+advisories:
+  CVE-2019-11255:
+    - timestamp: 2023-08-11T16:03:41.356036878-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: Exploit requires bundling vulnerable versions of csi-providers with our distribution which we do not do

--- a/kubernetes-1.25.advisories.yaml
+++ b/kubernetes-1.25.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: kubernetes-1.25
+
+advisories:
+  CVE-2019-11255:
+    - timestamp: 2023-08-11T16:03:41.356036878-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: Exploit requires bundling vulnerable versions of csi-providers with our distribution which we do not do

--- a/kubernetes-1.26.advisories.yaml
+++ b/kubernetes-1.26.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: kubernetes-1.26
+
+advisories:
+  CVE-2019-11255:
+    - timestamp: 2023-08-11T16:03:41.356036878-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: Exploit requires bundling vulnerable versions of csi-providers with our distribution which we do not do

--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: kubernetes-1.27
+
+advisories:
+  CVE-2019-11255:
+    - timestamp: 2023-08-11T16:03:41.356036878-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: Exploit requires bundling vulnerable versions of csi-providers with our distribution which we do not do


### PR DESCRIPTION
Set CVE-2019-11255 as not affected in `kubernetes-1.2{4,5,6,7}` packages. The CVE requires a vulnerable CSI driver to be bundled with the kubernetes distribution which we don't do.