### PR TITLE
NACK GHSA-2w8w-qhg4-f78j for telegraf

### DIFF
--- a/telegraf.advisories.yaml
+++ b/telegraf.advisories.yaml
@@ -6,3 +6,9 @@ advisories:
     - timestamp: 2023-06-13T07:37:43.741941-04:00
       status: fixed
       fixed-version: 1.27.0-r1
+
+  GHSA-2w8w-qhg4-f78j:
+    - timestamp: 2023-08-11T16:14:50.544767-07:00
+      status: not_affected
+      justification: component_not_present
+      impact: This only affects jaegertracing/jaeger-ui (TypeScript), not jaegertracing/jaeger Go library which telegraf depends on


### PR DESCRIPTION
This only affects jaegertracing/jaeger-ui (TypeScript), not jaegertracing/jaeger Go library which telegraf depends on

