### PR TITLE
Update `tekton-pipelines` advisory to apply to the origin package

### DIFF
--- a/tekton-pipelines.advisories.yaml
+++ b/tekton-pipelines.advisories.yaml
@@ -1,5 +1,5 @@
 package:
-  name: tekton-pipelines-resolvers
+  name: tekton-pipelines
 
 advisories:
   CVE-2023-1732:


### PR DESCRIPTION
The origin package is `tekton-pipelines`, the CVE was applied one `tekton-pipelines-resolvers`