### PR TITLE
Nack a jetty vulnerability in Jenkins.

### DIFF
--- a/jenkins.advisories.yaml
+++ b/jenkins.advisories.yaml
@@ -46,6 +46,12 @@ advisories:
       justification: vulnerable_code_not_in_execute_path
       impact: CVE disputed by upstream developers, nothing specific to this application.
 
+  GHSA-58qw-p7qm-5rvh:
+    - timestamp: 2023-08-14T08:56:28.871454-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This was deemed to not be a vulnerability in the code itself. Applications can use it incorrectly, but there's no evidence of that here.
+
   GHSA-mjmj-j48q-9wg2:
     - timestamp: 2023-07-24T11:14:08.315835-07:00
       status: not_affected


### PR DESCRIPTION
There is no CVE for this GHSA, and it was deemed to not be an issue.