### PR TITLE
python-3.{10,11}: add advisories for some open CVEs

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -31,3 +31,9 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: The vendor's perspective is that this is neither a vulnerability nor a bug.
+
+  CVE-2023-27043:
+    - timestamp: 2023-08-14T17:08:51.900138-04:00
+      status: affected
+      action: A fix for this has not yet been released upstream.
+

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -31,3 +31,9 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: The vendor's perspective is that this is neither a vulnerability nor a bug.
+
+  CVE-2023-27043:
+    - timestamp: 2023-08-14T17:08:51.900138-04:00
+      status: affected
+      action: A fix for this has not yet been released upstream.
+


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/temp-cve-issues-by-package/issues/349 for 3.10

python-3.11 is also `affected` based on my reading of NVD: https://nvd.nist.gov/vuln/detail/CVE-2023-27043

A fix for these has not yet been released.