### PR TITLE
Revert "kubernetes: clarify impact scope of CVE-2019-11255"

### DIFF
--- a/kubernetes-1.24.advisories.yaml
+++ b/kubernetes-1.24.advisories.yaml
@@ -7,6 +7,3 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: Exploit requires bundling vulnerable versions of csi-providers with our distribution which we do not do
-    - timestamp: 2023-08-14T20:58:00.451222-04:00
-      status: affected
-      action: See https://github.com/kubernetes/kubernetes/issues/85233 for mitigation instructions. (Note that kubectl is unaffected.)

--- a/kubernetes-1.25.advisories.yaml
+++ b/kubernetes-1.25.advisories.yaml
@@ -7,6 +7,3 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: Exploit requires bundling vulnerable versions of csi-providers with our distribution which we do not do
-    - timestamp: 2023-08-14T20:55:50.350931-04:00
-      status: affected
-      action: See https://github.com/kubernetes/kubernetes/issues/85233 for mitigation instructions. (Note that kubectl is unaffected.)

--- a/kubernetes-1.26.advisories.yaml
+++ b/kubernetes-1.26.advisories.yaml
@@ -7,6 +7,3 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: Exploit requires bundling vulnerable versions of csi-providers with our distribution which we do not do
-    - timestamp: 2023-08-14T20:56:13.971768-04:00
-      status: affected
-      action: See https://github.com/kubernetes/kubernetes/issues/85233 for mitigation instructions. (Note that kubectl is unaffected.)

--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -7,6 +7,3 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: Exploit requires bundling vulnerable versions of csi-providers with our distribution which we do not do
-    - timestamp: 2023-08-14T20:58:12.927303-04:00
-      status: affected
-      action: See https://github.com/kubernetes/kubernetes/issues/85233 for mitigation instructions. (Note that kubectl is unaffected.)


### PR DESCRIPTION
This reverts commit 08f2aa06acd1c24eff7d28e4aea8df1e06b673da.

I had misunderstood the impact of the vulnerability — thanks to @nsmith5 for straightening me out!