### PR TITLE
Update `thanos` advisory to correct package

### DIFF
--- a/thanos.advisories.yaml
+++ b/thanos.advisories.yaml
@@ -1,5 +1,5 @@
 package:
-  name: thanos-operator
+  name: thanos
 
 advisories:
   CVE-2019-3826:


### PR DESCRIPTION
The advisory has been filed to `thanos-operator` by accident. Our scanning indicates the vulnerability is reported on the `thanos` package.