### PR TITLE
Advisory for CVE-2023-3518 in consul 1.16

### DIFF
--- a/consul-1.16.advisories.yaml
+++ b/consul-1.16.advisories.yaml
@@ -1,0 +1,8 @@
+package:
+  name: consul-1.16
+
+advisories:
+  CVE-2023-3518:
+    - timestamp: 2023-08-17T14:19:21.970657-07:00
+      status: fixed
+      fixed-version: 1.16.1-r0


### PR DESCRIPTION
Grype will still report this vulnerability in the fixed version. This is due to this static UI assets being bundled in the binary: https://github.com/hashicorp/consul/blob/main/agent/uiserver/dist/index.html#L13