### PR TITLE
Kubernetes 1.28 advisory

### DIFF
--- a/kubernetes-1.28.advisories.yaml
+++ b/kubernetes-1.28.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: kubernetes-1.28
+
+advisories:
+  CVE-2019-11255:
+    - timestamp: 2023-08-17T16:02:48.680058-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: Exploit requires bundling vulnerable versions of csi-providers with our distribution which we do not do


### PR DESCRIPTION
This is the same CVE reported on our other versions of Kubernetes.