### PR TITLE
Nack a CVE in libtiff, this was fixed but also marked as not a vulner…

### DIFF
--- a/tiff.advisories.yaml
+++ b/tiff.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: tiff
+
+advisories:
+  CVE-2015-7313:
+    - timestamp: 2023-08-18T12:10:08.055914-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This was fixed upstream sometime around the 4.0.7 release, prior to wolfi packaging. It was also deemed not a security issue, but it was fixed anyway.


### PR DESCRIPTION
…ability.

Reference on the fix/nack: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=800124