### PR TITLE
Advisories for Maven fixes in 3.9.3

### DIFF
--- a/maven.advisories.yaml
+++ b/maven.advisories.yaml
@@ -1,0 +1,13 @@
+package:
+  name: maven
+
+advisories:
+  CVE-2020-8908:
+    - timestamp: 2023-08-18T14:06:28.607474-07:00
+      status: fixed
+      fixed-version: 3.9.3-r1
+
+  CVE-2023-2976:
+    - timestamp: 2023-08-18T14:06:59.102688-07:00
+      status: fixed
+      fixed-version: 3.9.3-r1


### PR DESCRIPTION
We've had the fix for those since `3.9.3-r1` - the corresponding commit is here: https://github.com/wolfi-dev/os/commit/7102e1632b6f35c5293d01de7c548be76f3927c2

```
[~/chainguard/addl-cve-data] ❱❱❱ wolfictl scan =(curl -sL https://packages.wolfi.dev/os/x86_64/maven-3.9.3-r0.apk)
Will process: zshFX0Bb0
└── 📄 /usr/share/java/maven/lib/guava-31.1-jre.jar
        📦 guava 31.1-jre (java-archive)
            Low CVE-2020-8908
            High CVE-2023-2976
            Medium CVE-2023-2976 GHSA-7g45-4rm6-3mm3 fixed in 32.0.0

[~/chainguard/addl-cve-data] ❱❱❱ wolfictl scan =(curl -sL https://packages.wolfi.dev/os/x86_64/maven-3.9.3-r1.apk)
Will process: zshpf22Ba
✅ No vulnerabilities found
```