### PR TITLE
NACK CVEs in Cassandra

### DIFF
--- a/cassandra.advisories.yaml
+++ b/cassandra.advisories.yaml
@@ -1,0 +1,33 @@
+package:
+  name: cassandra
+
+advisories:
+  CVE-2020-8908:
+    - timestamp: 2023-08-21T08:36:47.259234-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
+
+  CVE-2020-13946:
+    - timestamp: 2023-08-21T08:48:08.972744-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: Vulnerable cocode was fixed in Cassandra 2.1.22, 2.2.18, 3.0.22, 3.11.8 and 4.0-beta2. Earliest Wolfi package is 4.1.3
+
+  CVE-2022-1471:
+    - timestamp: 2023-08-21T08:40:21.674948-07:00
+      status: not_affected
+      justification: vulnerable_code_cannot_be_controlled_by_adversary
+      impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
+
+  CVE-2023-2976:
+    - timestamp: 2023-08-21T08:38:09.840391-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
+
+  CVE-2023-35116:
+    - timestamp: 2023-08-21T08:38:35.833982-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'


### PR DESCRIPTION
These vulnerabilities have been tagged as false-positive inside the Cassandra 4.1 branch: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml

CVE-2022-1471 contains more information in Jira, indicating that an attacker cannot trigger the vulnerability.