### PR TITLE
Advisory for CVE-2019-11255 on `kubernetes-dns-node-cache`

### DIFF
--- a/kubernetes-dns-node-cache.advisories.yaml
+++ b/kubernetes-dns-node-cache.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: kubernetes-dns-node-cache
+
+advisories:
+  CVE-2019-11255:
+    - timestamp: 2023-08-21T09:27:12.008255-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: Vulnerable code is part of external-csi-driver and not included in kubernetes-dns-node-cache


### PR DESCRIPTION
This CVE affects `external-csi-driver`