### PR TITLE
haproxy: Advisory for CVE-2023-40225

### DIFF
--- a/haproxy.advisories.yaml
+++ b/haproxy.advisories.yaml
@@ -19,3 +19,8 @@ advisories:
     - timestamp: 2023-02-15T16:12:20.024784027+07:00
       status: fixed
       fixed-version: 2.6.9-r0
+
+  CVE-2023-40225:
+    - timestamp: 2023-08-22T09:38:16.806572-07:00
+      status: fixed
+      fixed-version: 2.8.2-r0


### PR DESCRIPTION
We picked up the update for haproxy a few hours ago: https://github.com/wolfi-dev/os/blob/main/haproxy.yaml

CVE-2023-40225 is a true positive: https://github.com/haproxy/haproxy/issues/2237