### PR TITLE
CVE-2019-3826 advisories for `telegraf`

### DIFF
--- a/telegraf-1.26.advisories.yaml
+++ b/telegraf-1.26.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: telegraf-1.26
+
+advisories:
+  CVE-2019-3826:
+    - timestamp: 2023-08-25T15:09:21.35593-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.

--- a/telegraf-1.27.advisories.yaml
+++ b/telegraf-1.27.advisories.yaml
@@ -1,0 +1,9 @@
+package:
+  name: telegraf-1.27
+
+advisories:
+  CVE-2019-3826:
+    - timestamp: 2023-08-25T15:09:52.665698-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.


### PR DESCRIPTION
The only library imported from Prometheus for both versions is:

github.com/prometheus/prometheus/prompb