### PR TITLE
Additional advisories for telegraf-1.26

### DIFF
--- a/telegraf-1.26.advisories.yaml
+++ b/telegraf-1.26.advisories.yaml
@@ -7,3 +7,13 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.
+
+  CVE-2023-34231:
+    - timestamp: 2023-08-25T16:13:42.36298-07:00
+      status: under_investigation
+
+  GHSA-2w8w-qhg4-f78j:
+    - timestamp: 2023-08-25T15:21:50.625645-07:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This vulnerability only affects Jaeger UI, not the library code imported by telegraf.


### PR DESCRIPTION
The investigation for CVE-2023-34231 will be tracked by #197