### PR TITLE
Advisories for latest `node-problem-detector` version

### DIFF
--- a/node-problem-detector.advisories.yaml
+++ b/node-problem-detector.advisories.yaml
@@ -46,6 +46,9 @@ advisories:
     - timestamp: 2023-08-11T12:45:22.307105-07:00
       status: affected
       action: Pending upstream project to pick up k8s.io/kubernetes 0.19.4+.
+    - timestamp: 2023-08-27T16:51:15.477346-07:00
+      status: fixed
+      fixed-version: 0.8.14-r0
 
   CVE-2021-25735:
     - timestamp: 2023-08-11T11:21:29.54486-07:00

--- a/node-problem-detector.advisories.yaml
+++ b/node-problem-detector.advisories.yaml
@@ -6,6 +6,9 @@ advisories:
     - timestamp: 2023-08-11T12:35:15.52539-07:00
       status: affected
       action: Waiting for upstream release, fixed with PR https://github.com/kubernetes/node-problem-detector/pull/760.
+    - timestamp: 2023-08-27T16:22:34.909365-07:00
+      status: fixed
+      fixed-version: 0.8.14-r0
 
   CVE-2020-8554:
     - timestamp: 2023-08-11T11:24:18.698345-07:00
@@ -35,6 +38,9 @@ advisories:
     - timestamp: 2023-08-11T12:46:01.969823-07:00
       status: affected
       action: Pending upstream project to pick up one of k8s.io/kubernetes 0.17.13+, 0.18.10+, 0.19.3+.
+    - timestamp: 2023-08-27T16:22:08.390785-07:00
+      status: fixed
+      fixed-version: 0.8.14-r0
 
   CVE-2020-8565:
     - timestamp: 2023-08-11T12:45:22.307105-07:00
@@ -81,3 +87,6 @@ advisories:
     - timestamp: 2023-08-11T12:27:05.856378-07:00
       status: affected
       action: Waiting for upstream release, fixed with PR https://github.com/kubernetes/node-problem-detector/pull/760.
+    - timestamp: 2023-08-27T16:21:24.431686-07:00
+      status: fixed
+      fixed-version: 0.8.14-r0


### PR DESCRIPTION
We picked up version 0.8.14, which fixes a few true positives we've been tracking: wolfi-dev/os#4840

Note that CVE-2020-8565 is now incorrectly reported on our package. [Per k8s](https://github.com/kubernetes/kubernetes/issues/95623), Kubernetes is affected until v1.17.13, and our newer version of the package is now at v1.17.17 (reported as v0.17.17 b/c that's how the library version is setup)

It'd be great to encode more information in our future of advisories.

```
wolfictl scan =(curl -sL https://packages.wolfi.dev/os/x86_64/node-problem-detector-0.8.14-r0.apk)
Will process: zshuRKwOc
└── 📄 /usr/bin/node-problem-detector
        📦 k8s.io/client-go v0.17.17 (go-module)
            Medium CVE-2020-8565 GHSA-8cfg-vx93-jvxw fixed in 0.20.0-alpha.2
```