### PR TITLE
CVE-2022-46751: update advisory with link to issue

### DIFF
--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -22,6 +22,9 @@ advisories:
   CVE-2022-46751:
     - timestamp: 2023-08-25T14:31:33.045497-07:00
       status: under_investigation
+    - timestamp: 2023-08-29T11:10:21.039797-04:00
+      status: affected
+      action: The fix for this vulnerability is in version 2.5.2 of the Apache Ivy dependency. A fix for Gradle was asked via https://github.com/gradle/gradle/issues/24795#issuecomment-1695916608 and is awaiting for a response.
 
   CVE-2023-2976:
     - timestamp: 2023-08-08T17:07:36.957515-04:00


### PR DESCRIPTION
Update advisory and add link to issue where the fix was requested.