### PR TITLE
Mark CVE-2023-38037 as fixed in kube-fluentd-operator

### DIFF
--- a/kube-fluentd-operator.advisories.yaml
+++ b/kube-fluentd-operator.advisories.yaml
@@ -12,3 +12,8 @@ advisories:
     - timestamp: 2023-07-25T17:20:01.132149+02:00
       status: affected
       action: This has been fixed upstream (commit dd73fe077cae077808e820f4765a12b1f4660521) and we're waiting for a release.
+
+  CVE-2023-38037:
+    - timestamp: 2023-08-29T09:45:48.823065-07:00
+      status: fixed
+      fixed-version: 1.17.6-r2


### PR DESCRIPTION
Related to https://github.com/wolfi-dev/os/pull/4906