### PR TITLE
Nack CVE-2020-21469 in postgres 12.

### DIFF
--- a/postgresql-12.advisories.yaml
+++ b/postgresql-12.advisories.yaml
@@ -7,3 +7,9 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: This CVE appears to impact only Debian/Ubuntu.
+
+  CVE-2020-21469:
+    - timestamp: 2023-08-29T18:47:14.7929-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: Sanity dictates (and the maintainers agree) that this is neither a vulnerability nor a bug. https://www.postgresql.org/about/news/cve-2020-21469-is-not-a-security-vulnerability-2701/


### PR DESCRIPTION
https://www.postgresql.org/about/news/cve-2020-21469-is-not-a-security-vulnerability-2701/