### PR TITLE
Migrate to schema v2

### DIFF
--- a/.github/workflows/build-and-publish-secdb.yaml
+++ b/.github/workflows/build-and-publish-secdb.yaml
@@ -37,7 +37,7 @@ jobs:
           gcloud --quiet alpha storage ls
 
       - name: Build the security database
-        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:b35b8f1746a04c15eaa46c31a338dc0e0b4b597a70db97bc8afffb791027208c
+        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:4ee6e87bd566dce9d5743de6ce7733ea80856a0e11884fead4cc79bfd18fa7f1
         with:
           entrypoint: wolfictl
           args: "advisory db --advisories-repo-dir . --arch x86_64 --arch aarch64 -o security.json"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Check YAML formatting
       id: lint-yaml
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:b35b8f1746a04c15eaa46c31a338dc0e0b4b597a70db97bc8afffb791027208c
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:4ee6e87bd566dce9d5743de6ce7733ea80856a0e11884fead4cc79bfd18fa7f1
       with:
         entrypoint: wolfictl
         args: lint yam

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Validate advisory data
       id: validate
-      uses: docker://ghcr.io/wolfi-dev/wolfictl@sha256:6d228e1857362cb1e7818187d297bdeb59ba51515c839baa40d039e5982ce4c2
+      uses: docker://ghcr.io/wolfi-dev/wolfictl@sha256:4ee6e87bd566dce9d5743de6ce7733ea80856a0e11884fead4cc79bfd18fa7f1
       with:
         entrypoint: wolfictl
         args: advisory validate --no-distro-detection --advisories-repo-dir .

--- a/apko.advisories.yaml
+++ b/apko.advisories.yaml
@@ -1,23 +1,33 @@
+schema-version: "2"
+
 package:
   name: apko
 
 advisories:
-  CVE-2023-28840:
-    - timestamp: 2023-04-05T10:22:32.316309-04:00
-      status: fixed
-      fixed-version: 0.7.3-r1
+  - id: CVE-2023-28840
+    events:
+      - timestamp: 2023-04-05T14:22:32Z
+        type: fixed
+        data:
+          fixed-version: 0.7.3-r1
 
-  CVE-2023-28841:
-    - timestamp: 2023-04-05T10:22:32.31759-04:00
-      status: fixed
-      fixed-version: 0.7.3-r1
+  - id: CVE-2023-28841
+    events:
+      - timestamp: 2023-04-05T14:22:32Z
+        type: fixed
+        data:
+          fixed-version: 0.7.3-r1
 
-  CVE-2023-28842:
-    - timestamp: 2023-04-05T10:22:32.318046-04:00
-      status: fixed
-      fixed-version: 0.7.3-r1
+  - id: CVE-2023-28842
+    events:
+      - timestamp: 2023-04-05T14:22:32Z
+        type: fixed
+        data:
+          fixed-version: 0.7.3-r1
 
-  CVE-2023-30551:
-    - timestamp: 2023-05-04T12:30:46.874822-04:00
-      status: fixed
-      fixed-version: 0.8.0-r1
+  - id: CVE-2023-30551
+    events:
+      - timestamp: 2023-05-04T16:30:46Z
+        type: fixed
+        data:
+          fixed-version: 0.8.0-r1

--- a/argo-cd.advisories.yaml
+++ b/argo-cd.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-11T13:38:26.861088874-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: Vulnerable code is part of external-csi-driver which is not included in argo-cd
 
   CVE-2023-1732:

--- a/argo-cd.advisories.yaml
+++ b/argo-cd.advisories.yaml
@@ -1,24 +1,34 @@
+schema-version: "2"
+
 package:
   name: argo-cd
 
 advisories:
-  CVE-2019-11255:
-    - timestamp: 2023-08-11T13:38:26.861088874-07:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: Vulnerable code is part of external-csi-driver which is not included in argo-cd
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-11T20:38:26Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerable code is part of external-csi-driver which is not included in argo-cd
 
-  CVE-2023-1732:
-    - timestamp: 2023-05-29T11:53:49.085163-07:00
-      status: fixed
-      fixed-version: 2.7.3-r1
+  - id: CVE-2023-1732
+    events:
+      - timestamp: 2023-05-29T18:53:49Z
+        type: fixed
+        data:
+          fixed-version: 2.7.3-r1
 
-  CVE-2023-2727:
-    - timestamp: 2023-07-12T10:31:27.92589-04:00
-      status: fixed
-      fixed-version: 2.7.7-r1
+  - id: CVE-2023-2727
+    events:
+      - timestamp: 2023-07-12T14:31:27Z
+        type: fixed
+        data:
+          fixed-version: 2.7.7-r1
 
-  CVE-2023-2728:
-    - timestamp: 2023-07-12T10:30:52.215336-04:00
-      status: fixed
-      fixed-version: 2.7.7-r1
+  - id: CVE-2023-2728
+    events:
+      - timestamp: 2023-07-12T14:30:52Z
+        type: fixed
+        data:
+          fixed-version: 2.7.7-r1

--- a/avahi.advisories.yaml
+++ b/avahi.advisories.yaml
@@ -14,5 +14,5 @@ advisories:
       status: under_investigation
     - timestamp: 2023-06-20T12:14:51.01368-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: The CVE is only present in a Debian-specific packaging script.

--- a/avahi.advisories.yaml
+++ b/avahi.advisories.yaml
@@ -1,18 +1,28 @@
+schema-version: "2"
+
 package:
   name: avahi
 
 advisories:
-  CVE-2021-3468:
-    - timestamp: 2023-06-20T10:47:42.760317-04:00
-      status: under_investigation
-    - timestamp: 2023-06-20T12:14:33.473378-04:00
-      status: fixed
-      fixed-version: 0.8-r1
+  - id: CVE-2021-26720
+    events:
+      - timestamp: 2023-06-20T14:47:42Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-06-20T16:14:51Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The CVE is only present in a Debian-specific packaging script.
 
-  CVE-2021-26720:
-    - timestamp: 2023-06-20T10:47:42.75825-04:00
-      status: under_investigation
-    - timestamp: 2023-06-20T12:14:51.01368-04:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: The CVE is only present in a Debian-specific packaging script.
+  - id: CVE-2021-3468
+    events:
+      - timestamp: 2023-06-20T14:47:42Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-06-20T16:14:33Z
+        type: fixed
+        data:
+          fixed-version: 0.8-r1

--- a/aws-ebs-csi-driver.advisories.yaml
+++ b/aws-ebs-csi-driver.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-11T13:10:42.588947119-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: Vulnerable code is present in external-csi-driver which is outside of aws-ebs-csi-driver

--- a/aws-ebs-csi-driver.advisories.yaml
+++ b/aws-ebs-csi-driver.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: aws-ebs-csi-driver
 
 advisories:
-  CVE-2019-11255:
-    - timestamp: 2023-08-11T13:10:42.588947119-07:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: Vulnerable code is present in external-csi-driver which is outside of aws-ebs-csi-driver
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-11T20:10:42Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerable code is present in external-csi-driver which is outside of aws-ebs-csi-driver

--- a/aws-efs-csi-driver.advisories.yaml
+++ b/aws-efs-csi-driver.advisories.yaml
@@ -1,27 +1,37 @@
+schema-version: "2"
+
 package:
   name: aws-efs-csi-driver
 
 advisories:
-  CVE-2019-11255:
-    - timestamp: 2023-08-11T12:43:11.828286343-07:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: Vulnerable code is part of an external csi driver outside of Kubernetes source repository
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-11T19:43:11Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerable code is part of an external csi driver outside of Kubernetes source repository
 
-  CVE-2023-2431:
-    - timestamp: 2023-08-11T12:38:34.477968396-07:00
-      status: not_affected
-      justification: vulnerable-code-not-in-execution-path
-      impact: Vulnerable code is part of the Kubernetes kubelet which is not in the execution path of the aws-efs-csi-driver
+  - id: CVE-2023-2431
+    events:
+      - timestamp: 2023-08-11T19:38:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Vulnerable code is part of the Kubernetes kubelet which is not in the execution path of the aws-efs-csi-driver
 
-  CVE-2023-2727:
-    - timestamp: 2023-08-11T12:41:17.238138-07:00
-      status: not_affected
-      justification: vulnerable-code-not-in-execution-path
-      impact: Vulnerable code is part of the Kubernetes API server which is not in the execution path of aws-efs-csi-driver
+  - id: CVE-2023-2727
+    events:
+      - timestamp: 2023-08-11T19:41:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Vulnerable code is part of the Kubernetes API server which is not in the execution path of aws-efs-csi-driver
 
-  CVE-2023-2728:
-    - timestamp: 2023-08-11T12:45:18.103576038-07:00
-      status: not_affected
-      justification: vulnerable-code-not-in-execution-path
-      impact: Vulnerable code is part of the Kubernetes ServiceAccount admission plugin which is not in the execution path of aws-efs-csi-driver
+  - id: CVE-2023-2728
+    events:
+      - timestamp: 2023-08-11T19:45:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Vulnerable code is part of the Kubernetes ServiceAccount admission plugin which is not in the execution path of aws-efs-csi-driver

--- a/aws-efs-csi-driver.advisories.yaml
+++ b/aws-efs-csi-driver.advisories.yaml
@@ -5,23 +5,23 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-11T12:43:11.828286343-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: Vulnerable code is part of an external csi driver outside of Kubernetes source repository
 
   CVE-2023-2431:
     - timestamp: 2023-08-11T12:38:34.477968396-07:00
       status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+      justification: vulnerable-code-not-in-execution-path
       impact: Vulnerable code is part of the Kubernetes kubelet which is not in the execution path of the aws-efs-csi-driver
 
   CVE-2023-2727:
     - timestamp: 2023-08-11T12:41:17.238138-07:00
       status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+      justification: vulnerable-code-not-in-execution-path
       impact: Vulnerable code is part of the Kubernetes API server which is not in the execution path of aws-efs-csi-driver
 
   CVE-2023-2728:
     - timestamp: 2023-08-11T12:45:18.103576038-07:00
       status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+      justification: vulnerable-code-not-in-execution-path
       impact: Vulnerable code is part of the Kubernetes ServiceAccount admission plugin which is not in the execution path of aws-efs-csi-driver

--- a/bind.advisories.yaml
+++ b/bind.advisories.yaml
@@ -1,238 +1,334 @@
+schema-version: "2"
+
 package:
   name: bind
 
 advisories:
-  CVE-2016-9131:
-    - timestamp: 2023-01-15T00:59:03.585781Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2016-9131
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2016-9147:
-    - timestamp: 2023-01-15T00:59:03.587661Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2016-9147
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2016-9444:
-    - timestamp: 2023-01-15T00:59:03.589567Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2016-9444
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2017-3136:
-    - timestamp: 2023-01-15T00:59:03.580159Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2017-3136
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2017-3137:
-    - timestamp: 2023-01-15T00:59:03.58204Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2017-3137
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2017-3138:
-    - timestamp: 2023-01-15T00:59:03.58388Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2017-3138
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2017-3145:
-    - timestamp: 2023-01-15T00:59:03.57757Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2017-3145
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2018-5736:
-    - timestamp: 2023-01-15T00:59:03.575859Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2018-5736
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2018-5737:
-    - timestamp: 2023-01-15T00:59:03.574203Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2018-5737
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2018-5738:
-    - timestamp: 2023-01-15T00:59:03.572531Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2018-5738
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2018-5740:
-    - timestamp: 2023-01-15T00:59:03.570849Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2018-5740
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2018-5743:
-    - timestamp: 2023-01-15T00:59:03.564471Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2018-5743
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2018-5744:
-    - timestamp: 2023-01-15T00:59:03.569199Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2018-5744
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2018-5745:
-    - timestamp: 2023-01-15T00:59:03.567599Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2018-5745
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2019-6465:
-    - timestamp: 2023-01-15T00:59:03.566014Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2019-6465
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2019-6467:
-    - timestamp: 2023-01-15T00:59:03.562786Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2019-6467
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2019-6470:
-    - timestamp: 2023-01-15T00:59:03.591446Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2019-6470
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2019-6471:
-    - timestamp: 2023-01-15T00:59:03.560449Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2019-6471
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2019-6475:
-    - timestamp: 2023-01-15T00:59:03.557502Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2019-6475
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2019-6476:
-    - timestamp: 2023-01-15T00:59:03.558979Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2019-6476
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2019-6477:
-    - timestamp: 2023-01-15T00:59:03.55597Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2019-6477
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2020-8616:
-    - timestamp: 2023-01-15T00:59:03.553272Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2020-8616
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2020-8617:
-    - timestamp: 2023-01-15T00:59:03.554604Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2020-8617
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2020-8618:
-    - timestamp: 2023-01-15T00:59:03.550623Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2020-8618
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2020-8619:
-    - timestamp: 2023-01-15T00:59:03.551917Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2020-8619
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2020-8620:
-    - timestamp: 2023-01-15T00:59:03.544359Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2020-8620
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2020-8621:
-    - timestamp: 2023-01-15T00:59:03.545596Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2020-8621
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2020-8622:
-    - timestamp: 2023-01-15T00:59:03.546827Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2020-8622
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2020-8623:
-    - timestamp: 2023-01-15T00:59:03.548079Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2020-8623
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2020-8624:
-    - timestamp: 2023-01-15T00:59:03.549327Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2020-8624
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2020-8625:
-    - timestamp: 2023-01-15T00:59:03.542336Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2020-8625
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2021-25214:
-    - timestamp: 2023-01-15T00:59:03.538673Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2021-25214
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2021-25215:
-    - timestamp: 2023-01-15T00:59:03.539728Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2021-25215
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2021-25216:
-    - timestamp: 2023-01-15T00:59:03.541174Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2021-25216
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2021-25218:
-    - timestamp: 2023-01-15T00:59:03.537672Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2021-25218
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2021-25219:
-    - timestamp: 2023-01-15T00:59:03.536708Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2021-25219
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2021-25220:
-    - timestamp: 2023-01-15T00:59:03.535763Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2021-25220
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2022-0396:
-    - timestamp: 2023-01-15T00:59:03.53483Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2022-0396
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2022-2795:
-    - timestamp: 2023-01-15T00:59:03.529066Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2022-2795
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2022-2881:
-    - timestamp: 2023-01-15T00:59:03.530603Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2022-2881
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2022-2906:
-    - timestamp: 2023-01-15T00:59:03.531416Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2022-2906
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2022-3080:
-    - timestamp: 2023-01-15T00:59:03.532223Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2022-3080
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2022-3094:
-    - timestamp: 2023-01-25T18:13:41.284295996Z
-      status: fixed
-      fixed-version: 9.18.11-r0
+  - id: CVE-2022-3094
+    events:
+      - timestamp: 2023-01-25T18:13:41Z
+        type: fixed
+        data:
+          fixed-version: 9.18.11-r0
 
-  CVE-2022-3736:
-    - timestamp: 2023-01-25T18:13:41.304492625Z
-      status: fixed
-      fixed-version: 9.18.11-r0
+  - id: CVE-2022-3736
+    events:
+      - timestamp: 2023-01-25T18:13:41Z
+        type: fixed
+        data:
+          fixed-version: 9.18.11-r0
 
-  CVE-2022-3924:
-    - timestamp: 2023-01-25T18:13:41.321700474Z
-      status: fixed
-      fixed-version: 9.18.11-r0
+  - id: CVE-2022-38177
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2022-38177:
-    - timestamp: 2023-01-15T00:59:03.533077Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2022-38178
+    events:
+      - timestamp: 2023-01-15T00:59:03Z
+        type: fixed
+        data:
+          fixed-version: 9.18.10-r0
 
-  CVE-2022-38178:
-    - timestamp: 2023-01-15T00:59:03.533943Z
-      status: fixed
-      fixed-version: 9.18.10-r0
+  - id: CVE-2022-3924
+    events:
+      - timestamp: 2023-01-25T18:13:41Z
+        type: fixed
+        data:
+          fixed-version: 9.18.11-r0

--- a/binutils.advisories.yaml
+++ b/binutils.advisories.yaml
@@ -1,32 +1,48 @@
+schema-version: "2"
+
 package:
   name: binutils
 
 advisories:
-  CVE-2022-38126:
-    - timestamp: 2022-09-16T16:42:40Z
-      status: fixed
-      fixed-version: 2.39-r1
+  - id: CVE-2022-38126
+    events:
+      - timestamp: 2022-09-16T16:42:40Z
+        type: fixed
+        data:
+          fixed-version: 2.39-r1
 
-  CVE-2022-38128:
-    - timestamp: 2022-10-11T20:03:51Z
-      status: fixed
-      fixed-version: 2.39-r3
+  - id: CVE-2022-38128
+    events:
+      - timestamp: 2022-10-11T20:03:51Z
+        type: fixed
+        data:
+          fixed-version: 2.39-r3
 
-  CVE-2022-38533:
-    - timestamp: 2022-09-16T16:42:40Z
-      status: fixed
-      fixed-version: 2.39-r2
+  - id: CVE-2022-38533
+    events:
+      - timestamp: 2022-09-16T16:42:40Z
+        type: fixed
+        data:
+          fixed-version: 2.39-r2
 
-  CVE-2023-1579:
-    - timestamp: 2023-04-12T15:06:15.89895-04:00
-      status: under_investigation
-    - timestamp: 2023-04-12T15:46:39.789572-04:00
-      status: fixed
-      fixed-version: 2.40-r0
+  - id: CVE-2023-1579
+    events:
+      - timestamp: 2023-04-12T19:06:15Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-04-12T19:46:39Z
+        type: fixed
+        data:
+          fixed-version: 2.40-r0
 
-  CVE-2023-1972:
-    - timestamp: 2023-05-27T08:32:23.249775-04:00
-      status: under_investigation
-    - timestamp: 2023-05-27T08:46:17.30708-04:00
-      status: fixed
-      fixed-version: 2.40-r3
+  - id: CVE-2023-1972
+    events:
+      - timestamp: 2023-05-27T12:32:23Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-05-27T12:46:17Z
+        type: fixed
+        data:
+          fixed-version: 2.40-r3

--- a/brotli.advisories.yaml
+++ b/brotli.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: brotli
 
 advisories:
-  CVE-2020-8927:
-    - timestamp: 2022-09-15T02:40:18+00:00
-      status: fixed
-      fixed-version: 1.0.9-r0
+  - id: CVE-2020-8927
+    events:
+      - timestamp: 2022-09-15T02:40:18Z
+        type: fixed
+        data:
+          fixed-version: 1.0.9-r0

--- a/busybox.advisories.yaml
+++ b/busybox.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: busybox
 
 advisories:
-  CVE-2022-28391:
-    - timestamp: 2022-10-11T20:37:21+00:00
-      status: fixed
-      fixed-version: 1.35.0-r3
+  - id: CVE-2022-28391
+    events:
+      - timestamp: 2022-10-11T20:37:21Z
+        type: fixed
+        data:
+          fixed-version: 1.35.0-r3
 
-  CVE-2022-30065:
-    - timestamp: 2022-10-11T20:37:21+00:00
-      status: fixed
-      fixed-version: 1.35.0-r3
+  - id: CVE-2022-30065
+    events:
+      - timestamp: 2022-10-11T20:37:21Z
+        type: fixed
+        data:
+          fixed-version: 1.35.0-r3

--- a/c-ares.advisories.yaml
+++ b/c-ares.advisories.yaml
@@ -1,23 +1,33 @@
+schema-version: "2"
+
 package:
   name: c-ares
 
 advisories:
-  CVE-2023-31124:
-    - timestamp: 2023-05-27T08:23:25.199681-04:00
-      status: fixed
-      fixed-version: 1.19.1-r0
+  - id: CVE-2023-31124
+    events:
+      - timestamp: 2023-05-27T12:23:25Z
+        type: fixed
+        data:
+          fixed-version: 1.19.1-r0
 
-  CVE-2023-31130:
-    - timestamp: 2023-05-27T08:23:15.651364-04:00
-      status: fixed
-      fixed-version: 1.19.1-r0
+  - id: CVE-2023-31130
+    events:
+      - timestamp: 2023-05-27T12:23:15Z
+        type: fixed
+        data:
+          fixed-version: 1.19.1-r0
 
-  CVE-2023-31147:
-    - timestamp: 2023-05-27T08:23:07.756817-04:00
-      status: fixed
-      fixed-version: 1.19.1-r0
+  - id: CVE-2023-31147
+    events:
+      - timestamp: 2023-05-27T12:23:07Z
+        type: fixed
+        data:
+          fixed-version: 1.19.1-r0
 
-  CVE-2023-32067:
-    - timestamp: 2023-05-27T08:22:49.519406-04:00
-      status: fixed
-      fixed-version: 1.19.1-r0
+  - id: CVE-2023-32067
+    events:
+      - timestamp: 2023-05-27T12:22:49Z
+        type: fixed
+        data:
+          fixed-version: 1.19.1-r0

--- a/cadvisor.advisories.yaml
+++ b/cadvisor.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: cadvisor
 
 advisories:
-  CVE-2022-41723:
-    - timestamp: 2023-05-03T19:00:16.162280666Z
-      status: fixed
-      fixed-version: 0.47.1-r0
+  - id: CVE-2022-41723
+    events:
+      - timestamp: 2023-05-03T19:00:16Z
+        type: fixed
+        data:
+          fixed-version: 0.47.1-r0
 
-  CVE-2023-27561:
-    - timestamp: 2023-05-03T19:00:31.198743925Z
-      status: fixed
-      fixed-version: 0.47.1-r0
+  - id: CVE-2023-27561
+    events:
+      - timestamp: 2023-05-03T19:00:31Z
+        type: fixed
+        data:
+          fixed-version: 0.47.1-r0

--- a/calico.advisories.yaml
+++ b/calico.advisories.yaml
@@ -1,19 +1,27 @@
+schema-version: "2"
+
 package:
   name: calico
 
 advisories:
-  CVE-2019-11255:
-    - timestamp: 2023-08-11T14:07:34.51251271-07:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: Vulnerable code is part of external-csi-driver and not included in calico
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-11T21:07:34Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerable code is part of external-csi-driver and not included in calico
 
-  CVE-2023-2727:
-    - timestamp: 2023-07-06T15:08:57.573266-04:00
-      status: fixed
-      fixed-version: 3.26.1-r5
+  - id: CVE-2023-2727
+    events:
+      - timestamp: 2023-07-06T19:08:57Z
+        type: fixed
+        data:
+          fixed-version: 3.26.1-r5
 
-  CVE-2023-32731:
-    - timestamp: 2023-07-06T15:08:10.003465-04:00
-      status: fixed
-      fixed-version: 3.26.1-r5
+  - id: CVE-2023-32731
+    events:
+      - timestamp: 2023-07-06T19:08:10Z
+        type: fixed
+        data:
+          fixed-version: 3.26.1-r5

--- a/calico.advisories.yaml
+++ b/calico.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-11T14:07:34.51251271-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: Vulnerable code is part of external-csi-driver and not included in calico
 
   CVE-2023-2727:

--- a/cassandra.advisories.yaml
+++ b/cassandra.advisories.yaml
@@ -5,13 +5,13 @@ advisories:
   CVE-2020-8908:
     - timestamp: 2023-08-21T08:36:47.259234-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
 
   CVE-2020-13946:
     - timestamp: 2023-08-21T08:48:08.972744-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Vulnerable cocode was fixed in Cassandra 2.1.22, 2.2.18, 3.0.22, 3.11.8 and 4.0-beta2. Earliest Wolfi package is 4.1.3
 
   CVE-2022-1471:
@@ -23,11 +23,11 @@ advisories:
   CVE-2023-2976:
     - timestamp: 2023-08-21T08:38:09.840391-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
 
   CVE-2023-35116:
     - timestamp: 2023-08-21T08:38:35.833982-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'

--- a/cassandra.advisories.yaml
+++ b/cassandra.advisories.yaml
@@ -1,33 +1,45 @@
+schema-version: "2"
+
 package:
   name: cassandra
 
 advisories:
-  CVE-2020-8908:
-    - timestamp: 2023-08-21T08:36:47.259234-07:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
+  - id: CVE-2020-13946
+    events:
+      - timestamp: 2023-08-21T15:48:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Vulnerable cocode was fixed in Cassandra 2.1.22, 2.2.18, 3.0.22, 3.11.8 and 4.0-beta2. Earliest Wolfi package is 4.1.3
 
-  CVE-2020-13946:
-    - timestamp: 2023-08-21T08:48:08.972744-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Vulnerable cocode was fixed in Cassandra 2.1.22, 2.2.18, 3.0.22, 3.11.8 and 4.0-beta2. Earliest Wolfi package is 4.1.3
+  - id: CVE-2020-8908
+    events:
+      - timestamp: 2023-08-21T15:36:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
 
-  CVE-2022-1471:
-    - timestamp: 2023-08-21T08:40:21.674948-07:00
-      status: not_affected
-      justification: vulnerable_code_cannot_be_controlled_by_adversary
-      impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
+  - id: CVE-2022-1471
+    events:
+      - timestamp: 2023-08-21T15:40:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
 
-  CVE-2023-2976:
-    - timestamp: 2023-08-21T08:38:09.840391-07:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
+  - id: CVE-2023-2976
+    events:
+      - timestamp: 2023-08-21T15:38:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
 
-  CVE-2023-35116:
-    - timestamp: 2023-08-21T08:38:35.833982-07:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
+  - id: CVE-2023-35116
+    events:
+      - timestamp: 2023-08-21T15:38:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'

--- a/cloudwatch-exporter.advisories.yaml
+++ b/cloudwatch-exporter.advisories.yaml
@@ -1,10 +1,16 @@
+schema-version: "2"
+
 package:
   name: cloudwatch-exporter
 
 advisories:
-  CVE-2023-34462:
-    - timestamp: 2023-08-11T17:39:51.275715-04:00
-      status: under_investigation
-    - timestamp: 2023-08-14T11:53:34.958793-04:00
-      status: fixed
-      fixed-version: 0.15.4-r2
+  - id: CVE-2023-34462
+    events:
+      - timestamp: 2023-08-11T21:39:51Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-14T15:53:34Z
+        type: fixed
+        data:
+          fixed-version: 0.15.4-r2

--- a/cluster-autoscaler.advisories.yaml
+++ b/cluster-autoscaler.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: cluster-autoscaler
 
 advisories:
-  CVE-2019-11255:
-    - timestamp: 2023-08-11T13:57:24.554173701-07:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: Vulnerable code is part of external-csi-driver which is not included in cluster-autoscaler
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-11T20:57:24Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerable code is part of external-csi-driver which is not included in cluster-autoscaler

--- a/cluster-autoscaler.advisories.yaml
+++ b/cluster-autoscaler.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-11T13:57:24.554173701-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: Vulnerable code is part of external-csi-driver which is not included in cluster-autoscaler

--- a/conda.advisories.yaml
+++ b/conda.advisories.yaml
@@ -5,13 +5,13 @@ advisories:
   CVE-2007-4559:
     - timestamp: 2023-07-21T14:10:35.571982-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: We have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
   CVE-2018-20225:
     - timestamp: 2023-07-21T14:03:13.27815-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
 
   CVE-2023-27043:
@@ -22,7 +22,7 @@ advisories:
   CVE-2023-36632:
     - timestamp: 2023-07-21T14:06:11.323845-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The vendor's perspective is that this is neither a vulnerability nor a bug.
 
   CVE-2023-38325:

--- a/conda.advisories.yaml
+++ b/conda.advisories.yaml
@@ -1,46 +1,64 @@
+schema-version: "2"
+
 package:
   name: conda
 
 advisories:
-  CVE-2007-4559:
-    - timestamp: 2023-07-21T14:10:35.571982-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: We have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
+  - id: CVE-2007-4559
+    events:
+      - timestamp: 2023-07-21T18:10:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: We have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
-  CVE-2018-20225:
-    - timestamp: 2023-07-21T14:03:13.27815-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
+  - id: CVE-2018-20225
+    events:
+      - timestamp: 2023-07-21T18:03:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
 
-  CVE-2023-27043:
-    - timestamp: 2023-07-21T14:05:18.769495-04:00
-      status: affected
-      action: There doesn't appear to be a backport of the fix available for Python 3.10.x, see https://github.com/python/cpython/issues/102988.
+  - id: CVE-2023-27043
+    events:
+      - timestamp: 2023-07-21T18:05:18Z
+        type: true-positive-determination
+        data:
+          note: There doesn't appear to be a backport of the fix available for Python 3.10.x, see https://github.com/python/cpython/issues/102988.
 
-  CVE-2023-36632:
-    - timestamp: 2023-07-21T14:06:11.323845-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The vendor's perspective is that this is neither a vulnerability nor a bug.
+  - id: CVE-2023-36632
+    events:
+      - timestamp: 2023-07-21T18:06:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The vendor's perspective is that this is neither a vulnerability nor a bug.
 
-  CVE-2023-38325:
-    - timestamp: 2023-08-11T18:03:52.792669-04:00
-      status: fixed
-      fixed-version: 23.7.2-r1
+  - id: CVE-2023-38325
+    events:
+      - timestamp: 2023-08-11T22:03:52Z
+        type: fixed
+        data:
+          fixed-version: 23.7.2-r1
 
-  GHSA-5cpq-8wj7-hf2v:
-    - timestamp: 2023-08-11T18:03:30.529234-04:00
-      status: fixed
-      fixed-version: 23.7.2-r1
+  - id: GHSA-5cpq-8wj7-hf2v
+    events:
+      - timestamp: 2023-08-11T22:03:30Z
+        type: fixed
+        data:
+          fixed-version: 23.7.2-r1
 
-  GHSA-jm77-qphf-c4w8:
-    - timestamp: 2023-08-11T18:04:01.966033-04:00
-      status: fixed
-      fixed-version: 23.7.2-r1
+  - id: GHSA-jm77-qphf-c4w8
+    events:
+      - timestamp: 2023-08-11T22:04:01Z
+        type: fixed
+        data:
+          fixed-version: 23.7.2-r1
 
-  GHSA-xqr8-7jwr-rhp7:
-    - timestamp: 2023-08-11T18:01:28.788756-04:00
-      status: fixed
-      fixed-version: 23.7.2-r1
+  - id: GHSA-xqr8-7jwr-rhp7
+    events:
+      - timestamp: 2023-08-11T22:01:28Z
+        type: fixed
+        data:
+          fixed-version: 23.7.2-r1

--- a/consul-1.15.advisories.yaml
+++ b/consul-1.15.advisories.yaml
@@ -1,23 +1,33 @@
+schema-version: "2"
+
 package:
   name: consul-1.15
 
 advisories:
-  CVE-2022-3920:
-    - timestamp: 2023-08-11T12:51:12.468487-07:00
-      status: fixed
-      fixed-version: 1.15.5-r0
+  - id: CVE-2022-3920
+    events:
+      - timestamp: 2023-08-11T19:51:12Z
+        type: fixed
+        data:
+          fixed-version: 1.15.5-r0
 
-  CVE-2022-40716:
-    - timestamp: 2023-08-11T12:51:56.645324-07:00
-      status: fixed
-      fixed-version: 1.15.5-r0
+  - id: CVE-2022-40716
+    events:
+      - timestamp: 2023-08-11T19:51:56Z
+        type: fixed
+        data:
+          fixed-version: 1.15.5-r0
 
-  CVE-2023-0845:
-    - timestamp: 2023-08-11T12:52:24.57547-07:00
-      status: fixed
-      fixed-version: 1.15.5-r0
+  - id: CVE-2023-0845
+    events:
+      - timestamp: 2023-08-11T19:52:24Z
+        type: fixed
+        data:
+          fixed-version: 1.15.5-r0
 
-  CVE-2023-1297:
-    - timestamp: 2023-08-11T12:52:43.239399-07:00
-      status: fixed
-      fixed-version: 1.15.5-r0
+  - id: CVE-2023-1297
+    events:
+      - timestamp: 2023-08-11T19:52:43Z
+        type: fixed
+        data:
+          fixed-version: 1.15.5-r0

--- a/consul-1.16.advisories.yaml
+++ b/consul-1.16.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: consul-1.16
 
 advisories:
-  CVE-2023-3518:
-    - timestamp: 2023-08-17T14:19:21.970657-07:00
-      status: fixed
-      fixed-version: 1.16.1-r0
+  - id: CVE-2023-3518
+    events:
+      - timestamp: 2023-08-17T21:19:21Z
+        type: fixed
+        data:
+          fixed-version: 1.16.1-r0

--- a/coreutils.advisories.yaml
+++ b/coreutils.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2016-2781:
     - timestamp: 2022-10-11T20:29:31Z
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: |
         Fixed upstream prior to Wolfi packaging.
 

--- a/coreutils.advisories.yaml
+++ b/coreutils.advisories.yaml
@@ -1,18 +1,23 @@
+schema-version: "2"
+
 package:
   name: coreutils
 
 advisories:
-  CVE-2016-2781:
-    - timestamp: 2022-10-11T20:29:31Z
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: |
-        Fixed upstream prior to Wolfi packaging.
+  - id: CVE-2016-2781
+    events:
+      - timestamp: 2022-10-11T20:29:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: |
+            Fixed upstream prior to Wolfi packaging.
 
-        See https://git.savannah.gnu.org/cgit/coreutils.git/commit/?h=v9.1&id=8cb06d4b44a67f89f24b25e2394365533f6e5968
-    - timestamp: 2023-03-27T20:52:17.710834-04:00
-      status: affected
-      action: |
-        Prior fix was reverted upstream, standby for future fix.
+            See https://git.savannah.gnu.org/cgit/coreutils.git/commit/?h=v9.1&id=8cb06d4b44a67f89f24b25e2394365533f6e5968
+      - timestamp: 2023-03-28T00:52:17Z
+        type: true-positive-determination
+        data:
+          note: |
+            Prior fix was reverted upstream, standby for future fix.
 
-        See revert at https://git.savannah.gnu.org/cgit/coreutils.git/commit/?id=v8.27-101-gf5d7c0842
+            See revert at https://git.savannah.gnu.org/cgit/coreutils.git/commit/?id=v8.27-101-gf5d7c0842

--- a/cosign.advisories.yaml
+++ b/cosign.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: cosign
 
 advisories:
-  CVE-2007-2233:
-    - timestamp: 2023-06-05T10:08:31.892129-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: The vulnerability is in an ancient CGI script of the same name
+  - id: CVE-2007-2233
+    events:
+      - timestamp: 2023-06-05T17:08:31Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The vulnerability is in an ancient CGI script of the same name

--- a/cri-tools.advisories.yaml
+++ b/cri-tools.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-11T09:52:08.119929847-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included kubernetes/kubernetes library

--- a/cri-tools.advisories.yaml
+++ b/cri-tools.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: cri-tools
 
 advisories:
-  CVE-2019-11255:
-    - timestamp: 2023-08-11T09:52:08.119929847-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included kubernetes/kubernetes library
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-11T16:52:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included kubernetes/kubernetes library

--- a/cue.advisories.yaml
+++ b/cue.advisories.yaml
@@ -5,4 +5,4 @@ advisories:
   CVE-2008-4470:
     - timestamp: 2023-06-15T23:59:23.670672+03:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch

--- a/cue.advisories.yaml
+++ b/cue.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: cue
 
 advisories:
-  CVE-2008-4470:
-    - timestamp: 2023-06-15T23:59:23.670672+03:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
+  - id: CVE-2008-4470
+    events:
+      - timestamp: 2023-06-15T20:59:23Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch

--- a/cups.advisories.yaml
+++ b/cups.advisories.yaml
@@ -1,19 +1,27 @@
+schema-version: "2"
+
 package:
   name: cups
 
 advisories:
-  CVE-2018-6553:
-    - timestamp: 2023-07-03T16:39:32.074918-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: The vulnerability only applies to an ubuntu-specific app armor profile which is not included here.
+  - id: CVE-2018-6553
+    events:
+      - timestamp: 2023-07-03T20:39:32Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The vulnerability only applies to an ubuntu-specific app armor profile which is not included here.
 
-  CVE-2022-26691:
-    - timestamp: 2022-10-25T13:38:24-04:00
-      status: fixed
-      fixed-version: 2.4.2-r0
+  - id: CVE-2022-26691
+    events:
+      - timestamp: 2022-10-25T17:38:24Z
+        type: fixed
+        data:
+          fixed-version: 2.4.2-r0
 
-  CVE-2023-32324:
-    - timestamp: 2023-06-04T13:14:24.076905-04:00
-      status: fixed
-      fixed-version: 2.4.3-r0
+  - id: CVE-2023-32324
+    events:
+      - timestamp: 2023-06-04T17:14:24Z
+        type: fixed
+        data:
+          fixed-version: 2.4.3-r0

--- a/curl.advisories.yaml
+++ b/curl.advisories.yaml
@@ -1,28 +1,40 @@
+schema-version: "2"
+
 package:
   name: curl
 
 advisories:
-  CVE-2022-32221:
-    - timestamp: 2022-12-09T12:10:34-05:00
-      status: fixed
-      fixed-version: 7.86.0-r0
+  - id: CVE-2022-32221
+    events:
+      - timestamp: 2022-12-09T17:10:34Z
+        type: fixed
+        data:
+          fixed-version: 7.86.0-r0
 
-  CVE-2022-42916:
-    - timestamp: 2022-11-19T10:37:17-05:00
-      status: fixed
-      fixed-version: 7.86.0-r0
+  - id: CVE-2022-42916
+    events:
+      - timestamp: 2022-11-19T15:37:17Z
+        type: fixed
+        data:
+          fixed-version: 7.86.0-r0
 
-  CVE-2022-43551:
-    - timestamp: 2022-12-21T13:16:36Z
-      status: fixed
-      fixed-version: 7.87.0-r0
+  - id: CVE-2022-43551
+    events:
+      - timestamp: 2022-12-21T13:16:36Z
+        type: fixed
+        data:
+          fixed-version: 7.87.0-r0
 
-  CVE-2022-43552:
-    - timestamp: 2022-12-21T13:16:36Z
-      status: fixed
-      fixed-version: 7.87.0-r0
+  - id: CVE-2022-43552
+    events:
+      - timestamp: 2022-12-21T13:16:36Z
+        type: fixed
+        data:
+          fixed-version: 7.87.0-r0
 
-  CVE-2023-32001:
-    - timestamp: 2023-07-19T06:53:06.20702-04:00
-      status: fixed
-      fixed-version: 8.2.0-r0
+  - id: CVE-2023-32001
+    events:
+      - timestamp: 2023-07-19T10:53:06Z
+        type: fixed
+        data:
+          fixed-version: 8.2.0-r0

--- a/dbus.advisories.yaml
+++ b/dbus.advisories.yaml
@@ -1,18 +1,26 @@
+schema-version: "2"
+
 package:
   name: dbus
 
 advisories:
-  CVE-2022-42010:
-    - timestamp: 2022-10-25T13:38:24-04:00
-      status: fixed
-      fixed-version: 1.14.4-r0
+  - id: CVE-2022-42010
+    events:
+      - timestamp: 2022-10-25T17:38:24Z
+        type: fixed
+        data:
+          fixed-version: 1.14.4-r0
 
-  CVE-2022-42011:
-    - timestamp: 2022-10-25T13:38:24-04:00
-      status: fixed
-      fixed-version: 1.14.4-r0
+  - id: CVE-2022-42011
+    events:
+      - timestamp: 2022-10-25T17:38:24Z
+        type: fixed
+        data:
+          fixed-version: 1.14.4-r0
 
-  CVE-2022-42012:
-    - timestamp: 2022-10-25T13:38:24-04:00
-      status: fixed
-      fixed-version: 1.14.4-r0
+  - id: CVE-2022-42012
+    events:
+      - timestamp: 2022-10-25T17:38:24Z
+        type: fixed
+        data:
+          fixed-version: 1.14.4-r0

--- a/deno.advisories.yaml
+++ b/deno.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: deno
 
 advisories:
-  CVE-2023-22499:
-    - timestamp: 2023-02-11T12:51:24.232894-05:00
-      status: fixed
-      fixed-version: 1.30.0-r0
+  - id: CVE-2023-22499
+    events:
+      - timestamp: 2023-02-11T17:51:24Z
+        type: fixed
+        data:
+          fixed-version: 1.30.0-r0

--- a/dotnet-7.advisories.yaml
+++ b/dotnet-7.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: dotnet-7
 
 advisories:
-  CVE-2023-28260:
-    - timestamp: 2023-04-11T10:23:04.494184-07:00
-      status: fixed
-      fixed-version: 7.0.105-r0
+  - id: CVE-2023-28260
+    events:
+      - timestamp: 2023-04-11T17:23:04Z
+        type: fixed
+        data:
+          fixed-version: 7.0.105-r0

--- a/envoy.advisories.yaml
+++ b/envoy.advisories.yaml
@@ -1,45 +1,71 @@
+schema-version: "2"
+
 package:
   name: envoy
 
 advisories:
-  CVE-2023-27487:
-    - timestamp: 2023-04-11T16:37:16.620228-04:00
-      status: under_investigation
-    - timestamp: 2023-04-11T16:48:57.416409-04:00
-      status: fixed
-      fixed-version: 1.25.3-r0
+  - id: CVE-2023-27487
+    events:
+      - timestamp: 2023-04-11T20:37:16Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-04-11T20:48:57Z
+        type: fixed
+        data:
+          fixed-version: 1.25.3-r0
 
-  CVE-2023-27488:
-    - timestamp: 2023-04-11T16:37:16.620174-04:00
-      status: under_investigation
-    - timestamp: 2023-04-11T16:48:57.461209-04:00
-      status: fixed
-      fixed-version: 1.25.3-r0
+  - id: CVE-2023-27488
+    events:
+      - timestamp: 2023-04-11T20:37:16Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-04-11T20:48:57Z
+        type: fixed
+        data:
+          fixed-version: 1.25.3-r0
 
-  CVE-2023-27491:
-    - timestamp: 2023-04-11T16:37:16.620117-04:00
-      status: under_investigation
-    - timestamp: 2023-04-11T16:48:57.439497-04:00
-      status: fixed
-      fixed-version: 1.25.3-r0
+  - id: CVE-2023-27491
+    events:
+      - timestamp: 2023-04-11T20:37:16Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-04-11T20:48:57Z
+        type: fixed
+        data:
+          fixed-version: 1.25.3-r0
 
-  CVE-2023-27492:
-    - timestamp: 2023-04-11T16:37:16.620069-04:00
-      status: under_investigation
-    - timestamp: 2023-04-11T16:48:57.394771-04:00
-      status: fixed
-      fixed-version: 1.25.3-r0
+  - id: CVE-2023-27492
+    events:
+      - timestamp: 2023-04-11T20:37:16Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-04-11T20:48:57Z
+        type: fixed
+        data:
+          fixed-version: 1.25.3-r0
 
-  CVE-2023-27493:
-    - timestamp: 2023-04-11T16:37:16.620021-04:00
-      status: under_investigation
-    - timestamp: 2023-04-11T16:48:57.370639-04:00
-      status: fixed
-      fixed-version: 1.25.3-r0
+  - id: CVE-2023-27493
+    events:
+      - timestamp: 2023-04-11T20:37:16Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-04-11T20:48:57Z
+        type: fixed
+        data:
+          fixed-version: 1.25.3-r0
 
-  CVE-2023-27496:
-    - timestamp: 2023-04-11T16:37:16.61997-04:00
-      status: under_investigation
-    - timestamp: 2023-04-11T16:48:57.344825-04:00
-      status: fixed
-      fixed-version: 1.25.3-r0
+  - id: CVE-2023-27496
+    events:
+      - timestamp: 2023-04-11T20:37:16Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-04-11T20:48:57Z
+        type: fixed
+        data:
+          fixed-version: 1.25.3-r0

--- a/expat.advisories.yaml
+++ b/expat.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: expat
 
 advisories:
-  CVE-2022-40674:
-    - timestamp: 2022-09-21T11:05:50-05:00
-      status: fixed
-      fixed-version: 2.4.9-r0
+  - id: CVE-2022-40674
+    events:
+      - timestamp: 2022-09-21T16:05:50Z
+        type: fixed
+        data:
+          fixed-version: 2.4.9-r0
 
-  CVE-2022-43680:
-    - timestamp: 2022-10-26T11:51:12-04:00
-      status: fixed
-      fixed-version: 2.5.0-r0
+  - id: CVE-2022-43680
+    events:
+      - timestamp: 2022-10-26T15:51:12Z
+        type: fixed
+        data:
+          fixed-version: 2.5.0-r0

--- a/flex.advisories.yaml
+++ b/flex.advisories.yaml
@@ -1,14 +1,18 @@
+schema-version: "2"
+
 package:
   name: flex
 
 advisories:
-  CVE-2019-6293:
-    - timestamp: 2022-10-11T19:48:04+00:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: |
-        The VEX spec should include a better justification value for this scenario: the vulnerability itself is contested or invalid.
+  - id: CVE-2019-6293
+    events:
+      - timestamp: 2022-10-11T19:48:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: |
+            The VEX spec should include a better justification value for this scenario: the vulnerability itself is contested or invalid.
 
-        See for more context on CVE-2019-6293:
-        - https://github.com/westes/flex/issues/414#issuecomment-452593828
-        - https://github.com/NixOS/nixpkgs/issues/55386#issuecomment-683792976
+            See for more context on CVE-2019-6293:
+            - https://github.com/westes/flex/issues/414#issuecomment-452593828
+            - https://github.com/NixOS/nixpkgs/issues/55386#issuecomment-683792976

--- a/flex.advisories.yaml
+++ b/flex.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2019-6293:
     - timestamp: 2022-10-11T19:48:04+00:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: |
         The VEX spec should include a better justification value for this scenario: the vulnerability itself is contested or invalid.
 

--- a/freetype.advisories.yaml
+++ b/freetype.advisories.yaml
@@ -1,18 +1,26 @@
+schema-version: "2"
+
 package:
   name: freetype
 
 advisories:
-  CVE-2022-27404:
-    - timestamp: 2022-10-26T16:28:34-04:00
-      status: fixed
-      fixed-version: 2.12.1-r0
+  - id: CVE-2022-27404
+    events:
+      - timestamp: 2022-10-26T20:28:34Z
+        type: fixed
+        data:
+          fixed-version: 2.12.1-r0
 
-  CVE-2022-27405:
-    - timestamp: 2022-10-26T16:28:34-04:00
-      status: fixed
-      fixed-version: 2.12.1-r0
+  - id: CVE-2022-27405
+    events:
+      - timestamp: 2022-10-26T20:28:34Z
+        type: fixed
+        data:
+          fixed-version: 2.12.1-r0
 
-  CVE-2022-27406:
-    - timestamp: 2022-10-26T16:28:34-04:00
-      status: fixed
-      fixed-version: 2.12.1-r0
+  - id: CVE-2022-27406
+    events:
+      - timestamp: 2022-10-26T20:28:34Z
+        type: fixed
+        data:
+          fixed-version: 2.12.1-r0

--- a/gatekeeper-3.12.advisories.yaml
+++ b/gatekeeper-3.12.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: gatekeeper-3.12
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-30T12:52:44.147418145-07:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: This CVE affects the Prometheus UI (Javascript) and not the Go code
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-30T19:52:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This CVE affects the Prometheus UI (Javascript) and not the Go code

--- a/gatekeeper-3.13.advisories.yaml
+++ b/gatekeeper-3.13.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: gatekeeper-3.13
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-30T12:53:46.767763555-07:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: This CVE affects the Prometheus UI (Javascript) and not the Go code
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-30T19:53:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This CVE affects the Prometheus UI (Javascript) and not the Go code

--- a/gatekeeper.advisories.yaml
+++ b/gatekeeper.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2019-3826:
     - timestamp: 2023-08-13T15:46:51.598326-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This CVE affects the Prometheus UI (Javascript) and not the Go code. See prometheus/prometheus#12403 and prometheus/prometheus#5163

--- a/gatekeeper.advisories.yaml
+++ b/gatekeeper.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: gatekeeper
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-13T15:46:51.598326-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This CVE affects the Prometheus UI (Javascript) and not the Go code. See prometheus/prometheus#12403 and prometheus/prometheus#5163
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-13T22:46:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This CVE affects the Prometheus UI (Javascript) and not the Go code. See prometheus/prometheus#12403 and prometheus/prometheus#5163

--- a/gcc-6.advisories.yaml
+++ b/gcc-6.advisories.yaml
@@ -1,26 +1,40 @@
+schema-version: "2"
+
 package:
   name: gcc-6
 
 advisories:
-  CVE-2018-12886:
-    - timestamp: 2023-04-28T14:46:17.894915-04:00
-      status: under_investigation
-    - timestamp: 2023-04-28T15:03:15.115547-04:00
-      status: affected
-      action: We are affected.
+  - id: CVE-2018-12886
+    events:
+      - timestamp: 2023-04-28T18:46:17Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-04-28T19:03:15Z
+        type: true-positive-determination
+        data:
+          note: We are affected.
 
-  CVE-2019-15847:
-    - timestamp: 2023-04-28T14:46:17.894922-04:00
-      status: under_investigation
-    - timestamp: 2023-04-28T15:00:50.02253-04:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: We don't support POWER.
+  - id: CVE-2019-15847
+    events:
+      - timestamp: 2023-04-28T18:46:17Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-04-28T19:00:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: We don't support POWER.
 
-  CVE-2021-37322:
-    - timestamp: 2023-04-28T14:46:17.894929-04:00
-      status: under_investigation
-    - timestamp: 2023-04-28T15:02:29.41787-04:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: GCC doesn't use the vulnerable code path in libiberty.
+  - id: CVE-2021-37322
+    events:
+      - timestamp: 2023-04-28T18:46:17Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-04-28T19:02:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: GCC doesn't use the vulnerable code path in libiberty.

--- a/gcc-6.advisories.yaml
+++ b/gcc-6.advisories.yaml
@@ -14,7 +14,7 @@ advisories:
       status: under_investigation
     - timestamp: 2023-04-28T15:00:50.02253-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: We don't support POWER.
 
   CVE-2021-37322:

--- a/giflib.advisories.yaml
+++ b/giflib.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: giflib
 
 advisories:
-  CVE-2022-28506:
-    - timestamp: 2022-11-16T18:48:05+07:00
-      status: fixed
-      fixed-version: 5.2.1-r0
+  - id: CVE-2022-28506
+    events:
+      - timestamp: 2022-11-16T11:48:05Z
+        type: fixed
+        data:
+          fixed-version: 5.2.1-r0

--- a/git.advisories.yaml
+++ b/git.advisories.yaml
@@ -1,49 +1,69 @@
+schema-version: "2"
+
 package:
   name: git
 
 advisories:
-  CVE-2022-23521:
-    - timestamp: 2023-01-17T17:17:24.622307-05:00
-      status: fixed
-      fixed-version: 2.39.1-r0
+  - id: CVE-2022-23521
+    events:
+      - timestamp: 2023-01-17T22:17:24Z
+        type: fixed
+        data:
+          fixed-version: 2.39.1-r0
 
-  CVE-2022-39253:
-    - timestamp: 2022-10-19T21:10:17Z
-      status: fixed
-      fixed-version: 2.38.1-r0
+  - id: CVE-2022-39253
+    events:
+      - timestamp: 2022-10-19T21:10:17Z
+        type: fixed
+        data:
+          fixed-version: 2.38.1-r0
 
-  CVE-2022-39260:
-    - timestamp: 2022-10-19T21:10:17Z
-      status: fixed
-      fixed-version: 2.38.1-r0
+  - id: CVE-2022-39260
+    events:
+      - timestamp: 2022-10-19T21:10:17Z
+        type: fixed
+        data:
+          fixed-version: 2.38.1-r0
 
-  CVE-2022-41903:
-    - timestamp: 2023-01-17T17:17:24.623244-05:00
-      status: fixed
-      fixed-version: 2.39.1-r0
+  - id: CVE-2022-41903
+    events:
+      - timestamp: 2023-01-17T22:17:24Z
+        type: fixed
+        data:
+          fixed-version: 2.39.1-r0
 
-  CVE-2023-22490:
-    - timestamp: 2023-02-15T16:48:32.355662-05:00
-      status: fixed
-      fixed-version: 2.39.2-r0
+  - id: CVE-2023-22490
+    events:
+      - timestamp: 2023-02-15T21:48:32Z
+        type: fixed
+        data:
+          fixed-version: 2.39.2-r0
 
-  CVE-2023-22743:
-    - timestamp: 2023-03-07T21:25:45.597765-05:00
-      status: not_affected
-      justification: component_not_present
-      impact: This vulnerability refers to git-for-windows, not git.
+  - id: CVE-2023-22743
+    events:
+      - timestamp: 2023-03-08T02:25:45Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This vulnerability refers to git-for-windows, not git.
 
-  CVE-2023-23946:
-    - timestamp: 2023-02-15T16:48:52.217204-05:00
-      status: fixed
-      fixed-version: 2.39.2-r0
+  - id: CVE-2023-23946
+    events:
+      - timestamp: 2023-02-15T21:48:52Z
+        type: fixed
+        data:
+          fixed-version: 2.39.2-r0
 
-  CVE-2023-25652:
-    - timestamp: 2023-04-28T20:44:11.22969-04:00
-      status: fixed
-      fixed-version: 2.40.1-r0
+  - id: CVE-2023-25652
+    events:
+      - timestamp: 2023-04-29T00:44:11Z
+        type: fixed
+        data:
+          fixed-version: 2.40.1-r0
 
-  CVE-2023-29007:
-    - timestamp: 2023-04-28T20:44:23.501938-04:00
-      status: fixed
-      fixed-version: 2.40.1-r0
+  - id: CVE-2023-29007
+    events:
+      - timestamp: 2023-04-29T00:44:23Z
+        type: fixed
+        data:
+          fixed-version: 2.40.1-r0

--- a/glibc.advisories.yaml
+++ b/glibc.advisories.yaml
@@ -5,31 +5,31 @@ advisories:
   CVE-2010-4756:
     - timestamp: 2023-03-06T12:47:28.379717-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: Not a vulnerability. POSIX does not guarantee memory safety; resource limits should be appropriately set on applications which use untrusted inputs to glob. BSD GLOB_LIMIT extension is unreliable and was rejected by the GNU project.
 
   CVE-2019-1010022:
     - timestamp: 2023-03-06T08:22:06.931107-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The CVE itself is disputed and should not be considered a security vulnerability.
 
   CVE-2019-1010023:
     - timestamp: 2023-03-06T08:22:06.962374-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The CVE itself is disputed and should not be considered a security vulnerability.
 
   CVE-2019-1010024:
     - timestamp: 2023-03-06T08:22:06.99195-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The CVE itself is disputed and should not be considered a security vulnerability.
 
   CVE-2019-1010025:
     - timestamp: 2023-03-06T08:22:07.02221-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The CVE itself is disputed and should not be considered a security vulnerability.
 
   CVE-2022-39046:
@@ -40,7 +40,7 @@ advisories:
   CVE-2023-0687:
     - timestamp: 2023-08-01T16:33:30.855176-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The CVE itself is disputed and should not be considered a security vulnerability.
 
   CVE-2023-25139:

--- a/glibc.advisories.yaml
+++ b/glibc.advisories.yaml
@@ -1,49 +1,67 @@
+schema-version: "2"
+
 package:
   name: glibc
 
 advisories:
-  CVE-2010-4756:
-    - timestamp: 2023-03-06T12:47:28.379717-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: Not a vulnerability. POSIX does not guarantee memory safety; resource limits should be appropriately set on applications which use untrusted inputs to glob. BSD GLOB_LIMIT extension is unreliable and was rejected by the GNU project.
+  - id: CVE-2010-4756
+    events:
+      - timestamp: 2023-03-06T17:47:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: Not a vulnerability. POSIX does not guarantee memory safety; resource limits should be appropriately set on applications which use untrusted inputs to glob. BSD GLOB_LIMIT extension is unreliable and was rejected by the GNU project.
 
-  CVE-2019-1010022:
-    - timestamp: 2023-03-06T08:22:06.931107-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The CVE itself is disputed and should not be considered a security vulnerability.
+  - id: CVE-2019-1010022
+    events:
+      - timestamp: 2023-03-06T13:22:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The CVE itself is disputed and should not be considered a security vulnerability.
 
-  CVE-2019-1010023:
-    - timestamp: 2023-03-06T08:22:06.962374-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The CVE itself is disputed and should not be considered a security vulnerability.
+  - id: CVE-2019-1010023
+    events:
+      - timestamp: 2023-03-06T13:22:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The CVE itself is disputed and should not be considered a security vulnerability.
 
-  CVE-2019-1010024:
-    - timestamp: 2023-03-06T08:22:06.99195-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The CVE itself is disputed and should not be considered a security vulnerability.
+  - id: CVE-2019-1010024
+    events:
+      - timestamp: 2023-03-06T13:22:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The CVE itself is disputed and should not be considered a security vulnerability.
 
-  CVE-2019-1010025:
-    - timestamp: 2023-03-06T08:22:07.02221-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The CVE itself is disputed and should not be considered a security vulnerability.
+  - id: CVE-2019-1010025
+    events:
+      - timestamp: 2023-03-06T13:22:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The CVE itself is disputed and should not be considered a security vulnerability.
 
-  CVE-2022-39046:
-    - timestamp: 2022-10-11T20:29:19Z
-      status: fixed
-      fixed-version: 2.36-r1
+  - id: CVE-2022-39046
+    events:
+      - timestamp: 2022-10-11T20:29:19Z
+        type: fixed
+        data:
+          fixed-version: 2.36-r1
 
-  CVE-2023-0687:
-    - timestamp: 2023-08-01T16:33:30.855176-07:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The CVE itself is disputed and should not be considered a security vulnerability.
+  - id: CVE-2023-0687
+    events:
+      - timestamp: 2023-08-01T23:33:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The CVE itself is disputed and should not be considered a security vulnerability.
 
-  CVE-2023-25139:
-    - timestamp: 2023-02-23T07:02:55.128762-05:00
-      status: fixed
-      fixed-version: 2.37-r1
+  - id: CVE-2023-25139
+    events:
+      - timestamp: 2023-02-23T12:02:55Z
+        type: fixed
+        data:
+          fixed-version: 2.37-r1

--- a/gmp.advisories.yaml
+++ b/gmp.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: gmp
 
 advisories:
-  CVE-2021-43618:
-    - timestamp: 2022-10-11T19:40:48+00:00
-      status: fixed
-      fixed-version: 6.2.1-r4
+  - id: CVE-2021-43618
+    events:
+      - timestamp: 2022-10-11T19:40:48Z
+        type: fixed
+        data:
+          fixed-version: 6.2.1-r4

--- a/gnupg.advisories.yaml
+++ b/gnupg.advisories.yaml
@@ -1,29 +1,41 @@
+schema-version: "2"
+
 package:
   name: gnupg
 
 advisories:
-  CVE-2018-12020:
-    - timestamp: 2023-01-15T00:25:50.747956Z
-      status: fixed
-      fixed-version: 2.2.41-r0
+  - id: CVE-2018-12020
+    events:
+      - timestamp: 2023-01-15T00:25:50Z
+        type: fixed
+        data:
+          fixed-version: 2.2.41-r0
 
-  CVE-2019-14855:
-    - timestamp: 2023-01-15T00:25:50.74698Z
-      status: fixed
-      fixed-version: 2.2.41-r0
+  - id: CVE-2019-14855
+    events:
+      - timestamp: 2023-01-15T00:25:50Z
+        type: fixed
+        data:
+          fixed-version: 2.2.41-r0
 
-  CVE-2020-25125:
-    - timestamp: 2023-01-15T00:25:50.745731Z
-      status: fixed
-      fixed-version: 2.2.41-r0
+  - id: CVE-2020-25125
+    events:
+      - timestamp: 2023-01-15T00:25:50Z
+        type: fixed
+        data:
+          fixed-version: 2.2.41-r0
 
-  CVE-2022-3219:
-    - timestamp: 2023-06-05T06:34:22.527086-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The upstream maintainers deem this to be working as intended and not a security issue. See https://dev.gnupg.org/T5993
+  - id: CVE-2022-3219
+    events:
+      - timestamp: 2023-06-05T10:34:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The upstream maintainers deem this to be working as intended and not a security issue. See https://dev.gnupg.org/T5993
 
-  CVE-2022-34903:
-    - timestamp: 2023-01-15T00:25:50.744087Z
-      status: fixed
-      fixed-version: 2.2.41-r0
+  - id: CVE-2022-34903
+    events:
+      - timestamp: 2023-01-15T00:25:50Z
+        type: fixed
+        data:
+          fixed-version: 2.2.41-r0

--- a/gnupg.advisories.yaml
+++ b/gnupg.advisories.yaml
@@ -20,7 +20,7 @@ advisories:
   CVE-2022-3219:
     - timestamp: 2023-06-05T06:34:22.527086-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The upstream maintainers deem this to be working as intended and not a security issue. See https://dev.gnupg.org/T5993
 
   CVE-2022-34903:

--- a/gnutls.advisories.yaml
+++ b/gnutls.advisories.yaml
@@ -1,48 +1,68 @@
+schema-version: "2"
+
 package:
   name: gnutls
 
 advisories:
-  CVE-2017-7507:
-    - timestamp: 2023-01-15T00:22:41.810257Z
-      status: fixed
-      fixed-version: 3.7.8-r0
+  - id: CVE-2017-7507
+    events:
+      - timestamp: 2023-01-15T00:22:41Z
+        type: fixed
+        data:
+          fixed-version: 3.7.8-r0
 
-  CVE-2019-3829:
-    - timestamp: 2023-01-15T00:22:41.809619Z
-      status: fixed
-      fixed-version: 3.7.8-r0
+  - id: CVE-2019-3829
+    events:
+      - timestamp: 2023-01-15T00:22:41Z
+        type: fixed
+        data:
+          fixed-version: 3.7.8-r0
 
-  CVE-2019-3836:
-    - timestamp: 2023-01-15T00:22:41.808993Z
-      status: fixed
-      fixed-version: 3.7.8-r0
+  - id: CVE-2019-3836
+    events:
+      - timestamp: 2023-01-15T00:22:41Z
+        type: fixed
+        data:
+          fixed-version: 3.7.8-r0
 
-  CVE-2020-11501:
-    - timestamp: 2023-01-15T00:22:41.808363Z
-      status: fixed
-      fixed-version: 3.7.8-r0
+  - id: CVE-2020-11501
+    events:
+      - timestamp: 2023-01-15T00:22:41Z
+        type: fixed
+        data:
+          fixed-version: 3.7.8-r0
 
-  CVE-2020-13777:
-    - timestamp: 2023-01-15T00:22:41.807761Z
-      status: fixed
-      fixed-version: 3.7.8-r0
+  - id: CVE-2020-13777
+    events:
+      - timestamp: 2023-01-15T00:22:41Z
+        type: fixed
+        data:
+          fixed-version: 3.7.8-r0
 
-  CVE-2020-24659:
-    - timestamp: 2023-01-15T00:22:41.806274Z
-      status: fixed
-      fixed-version: 3.7.8-r0
+  - id: CVE-2020-24659
+    events:
+      - timestamp: 2023-01-15T00:22:41Z
+        type: fixed
+        data:
+          fixed-version: 3.7.8-r0
 
-  CVE-2021-20231:
-    - timestamp: 2023-01-15T00:22:41.805313Z
-      status: fixed
-      fixed-version: 3.7.8-r0
+  - id: CVE-2021-20231
+    events:
+      - timestamp: 2023-01-15T00:22:41Z
+        type: fixed
+        data:
+          fixed-version: 3.7.8-r0
 
-  CVE-2021-20232:
-    - timestamp: 2023-01-15T00:22:41.805772Z
-      status: fixed
-      fixed-version: 3.7.8-r0
+  - id: CVE-2021-20232
+    events:
+      - timestamp: 2023-01-15T00:22:41Z
+        type: fixed
+        data:
+          fixed-version: 3.7.8-r0
 
-  CVE-2022-2509:
-    - timestamp: 2023-01-15T00:22:41.804726Z
-      status: fixed
-      fixed-version: 3.7.8-r0
+  - id: CVE-2022-2509
+    events:
+      - timestamp: 2023-01-15T00:22:41Z
+        type: fixed
+        data:
+          fixed-version: 3.7.8-r0

--- a/go-1.19.advisories.yaml
+++ b/go-1.19.advisories.yaml
@@ -1,81 +1,114 @@
+schema-version: "2"
+
 package:
   name: go-1.19
 
 advisories:
-  CVE-2020-29509:
-    - timestamp: 2023-03-04T20:01:40.664098-05:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-    - timestamp: 2023-03-04T21:45:55.952053-05:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+  - id: CVE-2020-29509
+    events:
+      - timestamp: 2023-03-05T01:01:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+      - timestamp: 2023-03-05T02:45:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
 
-  CVE-2020-29511:
-    - timestamp: 2023-05-03T14:27:20.842639-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
+  - id: CVE-2020-29511
+    events:
+      - timestamp: 2023-05-03T18:27:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
 
-  CVE-2022-41716:
-    - timestamp: 2022-11-01T13:39:29-04:00
-      status: fixed
-      fixed-version: 1.19.3-r0
+  - id: CVE-2022-41716
+    events:
+      - timestamp: 2022-11-01T17:39:29Z
+        type: fixed
+        data:
+          fixed-version: 1.19.3-r0
 
-  CVE-2022-41717:
-    - timestamp: 2022-12-07T08:11:39Z
-      status: fixed
-      fixed-version: 1.19.4-r0
+  - id: CVE-2022-41717
+    events:
+      - timestamp: 2022-12-07T08:11:39Z
+        type: fixed
+        data:
+          fixed-version: 1.19.4-r0
 
-  CVE-2022-41720:
-    - timestamp: 2022-12-07T08:11:39Z
-      status: fixed
-      fixed-version: 1.19.4-r0
+  - id: CVE-2022-41720
+    events:
+      - timestamp: 2022-12-07T08:11:39Z
+        type: fixed
+        data:
+          fixed-version: 1.19.4-r0
 
-  CVE-2022-41723:
-    - timestamp: 2023-03-10T10:37:34.372665-05:00
-      status: fixed
-      fixed-version: 1.19.6-r1
+  - id: CVE-2022-41723
+    events:
+      - timestamp: 2023-03-10T15:37:34Z
+        type: fixed
+        data:
+          fixed-version: 1.19.6-r1
 
-  CVE-2023-24532:
-    - timestamp: 2023-03-10T10:43:49.770471-05:00
-      status: fixed
-      fixed-version: 1.19.7-r0
+  - id: CVE-2023-24532
+    events:
+      - timestamp: 2023-03-10T15:43:49Z
+        type: fixed
+        data:
+          fixed-version: 1.19.7-r0
 
-  CVE-2023-24534:
-    - timestamp: 2023-04-05T08:50:56.419825-04:00
-      status: fixed
-      fixed-version: 1.19.8-r0
+  - id: CVE-2023-24534
+    events:
+      - timestamp: 2023-04-05T12:50:56Z
+        type: fixed
+        data:
+          fixed-version: 1.19.8-r0
 
-  CVE-2023-24536:
-    - timestamp: 2023-04-05T08:50:56.421548-04:00
-      status: fixed
-      fixed-version: 1.19.8-r0
+  - id: CVE-2023-24536
+    events:
+      - timestamp: 2023-04-05T12:50:56Z
+        type: fixed
+        data:
+          fixed-version: 1.19.8-r0
 
-  CVE-2023-24537:
-    - timestamp: 2023-04-05T08:50:56.422508-04:00
-      status: fixed
-      fixed-version: 1.19.8-r0
+  - id: CVE-2023-24537
+    events:
+      - timestamp: 2023-04-05T12:50:56Z
+        type: fixed
+        data:
+          fixed-version: 1.19.8-r0
 
-  CVE-2023-24538:
-    - timestamp: 2023-04-05T08:50:56.423606-04:00
-      status: fixed
-      fixed-version: 1.19.8-r0
+  - id: CVE-2023-24538
+    events:
+      - timestamp: 2023-04-05T12:50:56Z
+        type: fixed
+        data:
+          fixed-version: 1.19.8-r0
 
-  CVE-2023-24539:
-    - timestamp: 2023-05-02T15:58:58.350831-04:00
-      status: fixed
-      fixed-version: 1.19.9-r0
+  - id: CVE-2023-24539
+    events:
+      - timestamp: 2023-05-02T19:58:58Z
+        type: fixed
+        data:
+          fixed-version: 1.19.9-r0
 
-  CVE-2023-24540:
-    - timestamp: 2023-05-02T15:59:11.158232-04:00
-      status: fixed
-      fixed-version: 1.19.9-r0
+  - id: CVE-2023-24540
+    events:
+      - timestamp: 2023-05-02T19:59:11Z
+        type: fixed
+        data:
+          fixed-version: 1.19.9-r0
 
-  CVE-2023-29400:
-    - timestamp: 2023-05-02T15:59:18.977361-04:00
-      status: fixed
-      fixed-version: 1.19.9-r0
+  - id: CVE-2023-29400
+    events:
+      - timestamp: 2023-05-02T19:59:18Z
+        type: fixed
+        data:
+          fixed-version: 1.19.9-r0
 
-  CVE-2023-29406:
-    - timestamp: 2023-07-14T09:10:15.807967-04:00
-      status: fixed
-      fixed-version: 1.19.11-r0
+  - id: CVE-2023-29406
+    events:
+      - timestamp: 2023-07-14T13:10:15Z
+        type: fixed
+        data:
+          fixed-version: 1.19.11-r0

--- a/go-1.19.advisories.yaml
+++ b/go-1.19.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2020-29509:
     - timestamp: 2023-03-04T20:01:40.664098-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
     - timestamp: 2023-03-04T21:45:55.952053-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
@@ -13,7 +13,7 @@ advisories:
   CVE-2020-29511:
     - timestamp: 2023-05-03T14:27:20.842639-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
 
   CVE-2022-41716:
     - timestamp: 2022-11-01T13:39:29-04:00

--- a/go-1.20.advisories.yaml
+++ b/go-1.20.advisories.yaml
@@ -1,74 +1,104 @@
+schema-version: "2"
+
 package:
   name: go-1.20
 
 advisories:
-  CVE-2020-29509:
-    - timestamp: 2023-03-04T20:01:01.646638-05:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-    - timestamp: 2023-03-04T20:01:14.615494-05:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+  - id: CVE-2020-29509
+    events:
+      - timestamp: 2023-03-05T01:01:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+      - timestamp: 2023-03-05T01:01:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
 
-  CVE-2020-29511:
-    - timestamp: 2023-03-04T20:01:14.61372-05:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-    - timestamp: 2023-03-04T21:45:58.722232-05:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+  - id: CVE-2020-29511
+    events:
+      - timestamp: 2023-03-05T01:01:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+      - timestamp: 2023-03-05T02:45:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
 
-  CVE-2022-41723:
-    - timestamp: 2023-03-10T10:38:17.029502-05:00
-      status: fixed
-      fixed-version: 1.20.1-r1
+  - id: CVE-2022-41723
+    events:
+      - timestamp: 2023-03-10T15:38:17Z
+        type: fixed
+        data:
+          fixed-version: 1.20.1-r1
 
-  CVE-2023-24532:
-    - timestamp: 2023-03-10T10:43:37.274724-05:00
-      status: fixed
-      fixed-version: 1.20.2-r0
+  - id: CVE-2023-24532
+    events:
+      - timestamp: 2023-03-10T15:43:37Z
+        type: fixed
+        data:
+          fixed-version: 1.20.2-r0
 
-  CVE-2023-24534:
-    - timestamp: 2023-04-05T08:50:58.534618-04:00
-      status: fixed
-      fixed-version: 1.20.3-r0
+  - id: CVE-2023-24534
+    events:
+      - timestamp: 2023-04-05T12:50:58Z
+        type: fixed
+        data:
+          fixed-version: 1.20.3-r0
 
-  CVE-2023-24536:
-    - timestamp: 2023-04-05T08:50:58.536094-04:00
-      status: fixed
-      fixed-version: 1.20.3-r0
+  - id: CVE-2023-24536
+    events:
+      - timestamp: 2023-04-05T12:50:58Z
+        type: fixed
+        data:
+          fixed-version: 1.20.3-r0
 
-  CVE-2023-24537:
-    - timestamp: 2023-04-05T08:50:58.536993-04:00
-      status: fixed
-      fixed-version: 1.20.3-r0
+  - id: CVE-2023-24537
+    events:
+      - timestamp: 2023-04-05T12:50:58Z
+        type: fixed
+        data:
+          fixed-version: 1.20.3-r0
 
-  CVE-2023-24538:
-    - timestamp: 2023-04-05T08:50:58.537967-04:00
-      status: fixed
-      fixed-version: 1.20.3-r0
+  - id: CVE-2023-24538
+    events:
+      - timestamp: 2023-04-05T12:50:58Z
+        type: fixed
+        data:
+          fixed-version: 1.20.3-r0
 
-  CVE-2023-24539:
-    - timestamp: 2023-05-02T16:01:15.588118-04:00
-      status: fixed
-      fixed-version: 1.20.4-r0
+  - id: CVE-2023-24539
+    events:
+      - timestamp: 2023-05-02T20:01:15Z
+        type: fixed
+        data:
+          fixed-version: 1.20.4-r0
 
-  CVE-2023-24540:
-    - timestamp: 2023-05-02T16:01:15.623186-04:00
-      status: fixed
-      fixed-version: 1.20.4-r0
+  - id: CVE-2023-24540
+    events:
+      - timestamp: 2023-05-02T20:01:15Z
+        type: fixed
+        data:
+          fixed-version: 1.20.4-r0
 
-  CVE-2023-29400:
-    - timestamp: 2023-05-02T16:01:15.651143-04:00
-      status: fixed
-      fixed-version: 1.20.4-r0
+  - id: CVE-2023-29400
+    events:
+      - timestamp: 2023-05-02T20:01:15Z
+        type: fixed
+        data:
+          fixed-version: 1.20.4-r0
 
-  CVE-2023-29406:
-    - timestamp: 2023-07-14T09:10:34.318524-04:00
-      status: fixed
-      fixed-version: 1.20.6-r0
+  - id: CVE-2023-29406
+    events:
+      - timestamp: 2023-07-14T13:10:34Z
+        type: fixed
+        data:
+          fixed-version: 1.20.6-r0
 
-  CVE-2023-29409:
-    - timestamp: 2023-08-14T16:20:14.203956-04:00
-      status: fixed
-      fixed-version: 1.20.7-r0
+  - id: CVE-2023-29409
+    events:
+      - timestamp: 2023-08-14T20:20:14Z
+        type: fixed
+        data:
+          fixed-version: 1.20.7-r0

--- a/go-1.20.advisories.yaml
+++ b/go-1.20.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2020-29509:
     - timestamp: 2023-03-04T20:01:01.646638-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
     - timestamp: 2023-03-04T20:01:14.615494-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
@@ -13,7 +13,7 @@ advisories:
   CVE-2020-29511:
     - timestamp: 2023-03-04T20:01:14.61372-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
     - timestamp: 2023-03-04T21:45:58.722232-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path

--- a/go-1.21.advisories.yaml
+++ b/go-1.21.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2020-29509:
     - timestamp: 2023-03-04T20:01:01.646638-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
     - timestamp: 2023-03-04T20:01:14.615494-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
@@ -13,7 +13,7 @@ advisories:
   CVE-2020-29511:
     - timestamp: 2023-03-04T20:01:14.61372-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
     - timestamp: 2023-03-04T21:45:58.722232-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
@@ -26,5 +26,5 @@ advisories:
   CVE-2023-29409:
     - timestamp: 2023-08-14T16:19:14.504643-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: This CVE was fixed in go 1.20.7, before 1.21 was branched.

--- a/go-1.21.advisories.yaml
+++ b/go-1.21.advisories.yaml
@@ -1,30 +1,42 @@
+schema-version: "2"
+
 package:
   name: go-1.21
 
 advisories:
-  CVE-2020-29509:
-    - timestamp: 2023-03-04T20:01:01.646638-05:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-    - timestamp: 2023-03-04T20:01:14.615494-05:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+  - id: CVE-2020-29509
+    events:
+      - timestamp: 2023-03-05T01:01:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+      - timestamp: 2023-03-05T01:01:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
 
-  CVE-2020-29511:
-    - timestamp: 2023-03-04T20:01:14.61372-05:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-    - timestamp: 2023-03-04T21:45:58.722232-05:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+  - id: CVE-2020-29511
+    events:
+      - timestamp: 2023-03-05T01:01:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+      - timestamp: 2023-03-05T02:45:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
 
-  CVE-2023-29406:
-    - timestamp: 2023-07-14T09:10:46.556709-04:00
-      status: affected
-      action: The Go team hasn't applied the patch yet since this is currently an rc release stream.
+  - id: CVE-2023-29406
+    events:
+      - timestamp: 2023-07-14T13:10:46Z
+        type: true-positive-determination
+        data:
+          note: The Go team hasn't applied the patch yet since this is currently an rc release stream.
 
-  CVE-2023-29409:
-    - timestamp: 2023-08-14T16:19:14.504643-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: This CVE was fixed in go 1.20.7, before 1.21 was branched.
+  - id: CVE-2023-29409
+    events:
+      - timestamp: 2023-08-14T20:19:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE was fixed in go 1.20.7, before 1.21 was branched.

--- a/go-fips-1.19.advisories.yaml
+++ b/go-fips-1.19.advisories.yaml
@@ -1,76 +1,107 @@
+schema-version: "2"
+
 package:
   name: go-fips-1.19
 
 advisories:
-  CVE-2020-29509:
-    - timestamp: 2023-03-04T20:01:40.664098-05:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-    - timestamp: 2023-03-04T21:45:55.952053-05:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+  - id: CVE-2020-29509
+    events:
+      - timestamp: 2023-03-05T01:01:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+      - timestamp: 2023-03-05T02:45:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
 
-  CVE-2020-29511:
-    - timestamp: 2023-05-03T14:27:38.169203-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
+  - id: CVE-2020-29511
+    events:
+      - timestamp: 2023-05-03T18:27:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
 
-  CVE-2022-41716:
-    - timestamp: 2022-11-01T13:39:29-04:00
-      status: fixed
-      fixed-version: 1.19.3-r0
+  - id: CVE-2022-41716
+    events:
+      - timestamp: 2022-11-01T17:39:29Z
+        type: fixed
+        data:
+          fixed-version: 1.19.3-r0
 
-  CVE-2022-41717:
-    - timestamp: 2022-12-07T08:11:39Z
-      status: fixed
-      fixed-version: 1.19.4-r0
+  - id: CVE-2022-41717
+    events:
+      - timestamp: 2022-12-07T08:11:39Z
+        type: fixed
+        data:
+          fixed-version: 1.19.4-r0
 
-  CVE-2022-41720:
-    - timestamp: 2022-12-07T08:11:39Z
-      status: fixed
-      fixed-version: 1.19.4-r0
+  - id: CVE-2022-41720
+    events:
+      - timestamp: 2022-12-07T08:11:39Z
+        type: fixed
+        data:
+          fixed-version: 1.19.4-r0
 
-  CVE-2022-41723:
-    - timestamp: 2023-03-10T10:37:34.372665-05:00
-      status: fixed
-      fixed-version: 1.19.6-r1
+  - id: CVE-2022-41723
+    events:
+      - timestamp: 2023-03-10T15:37:34Z
+        type: fixed
+        data:
+          fixed-version: 1.19.6-r1
 
-  CVE-2023-24532:
-    - timestamp: 2023-03-10T10:43:49.770471-05:00
-      status: fixed
-      fixed-version: 1.19.7-r0
+  - id: CVE-2023-24532
+    events:
+      - timestamp: 2023-03-10T15:43:49Z
+        type: fixed
+        data:
+          fixed-version: 1.19.7-r0
 
-  CVE-2023-24534:
-    - timestamp: 2023-04-05T08:55:40.60338-04:00
-      status: fixed
-      fixed-version: 1.19.8-r0
+  - id: CVE-2023-24534
+    events:
+      - timestamp: 2023-04-05T12:55:40Z
+        type: fixed
+        data:
+          fixed-version: 1.19.8-r0
 
-  CVE-2023-24536:
-    - timestamp: 2023-04-05T08:55:40.607432-04:00
-      status: fixed
-      fixed-version: 1.19.8-r0
+  - id: CVE-2023-24536
+    events:
+      - timestamp: 2023-04-05T12:55:40Z
+        type: fixed
+        data:
+          fixed-version: 1.19.8-r0
 
-  CVE-2023-24537:
-    - timestamp: 2023-04-05T08:55:40.6086-04:00
-      status: fixed
-      fixed-version: 1.19.8-r0
+  - id: CVE-2023-24537
+    events:
+      - timestamp: 2023-04-05T12:55:40Z
+        type: fixed
+        data:
+          fixed-version: 1.19.8-r0
 
-  CVE-2023-24538:
-    - timestamp: 2023-04-05T08:55:40.609989-04:00
-      status: fixed
-      fixed-version: 1.19.8-r0
+  - id: CVE-2023-24538
+    events:
+      - timestamp: 2023-04-05T12:55:40Z
+        type: fixed
+        data:
+          fixed-version: 1.19.8-r0
 
-  CVE-2023-24539:
-    - timestamp: 2023-05-02T15:59:47.675581-04:00
-      status: fixed
-      fixed-version: 1.19.9-r0
+  - id: CVE-2023-24539
+    events:
+      - timestamp: 2023-05-02T19:59:47Z
+        type: fixed
+        data:
+          fixed-version: 1.19.9-r0
 
-  CVE-2023-24540:
-    - timestamp: 2023-05-02T15:59:58.258052-04:00
-      status: fixed
-      fixed-version: 1.19.9-r0
+  - id: CVE-2023-24540
+    events:
+      - timestamp: 2023-05-02T19:59:58Z
+        type: fixed
+        data:
+          fixed-version: 1.19.9-r0
 
-  CVE-2023-29400:
-    - timestamp: 2023-05-02T16:00:05.929051-04:00
-      status: fixed
-      fixed-version: 1.19.9-r0
+  - id: CVE-2023-29400
+    events:
+      - timestamp: 2023-05-02T20:00:05Z
+        type: fixed
+        data:
+          fixed-version: 1.19.9-r0

--- a/go-fips-1.19.advisories.yaml
+++ b/go-fips-1.19.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2020-29509:
     - timestamp: 2023-03-04T20:01:40.664098-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
     - timestamp: 2023-03-04T21:45:55.952053-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
@@ -13,7 +13,7 @@ advisories:
   CVE-2020-29511:
     - timestamp: 2023-05-03T14:27:38.169203-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
 
   CVE-2022-41716:
     - timestamp: 2022-11-01T13:39:29-04:00

--- a/go-fips-1.20.advisories.yaml
+++ b/go-fips-1.20.advisories.yaml
@@ -1,64 +1,90 @@
+schema-version: "2"
+
 package:
   name: go-fips-1.20
 
 advisories:
-  CVE-2020-29509:
-    - timestamp: 2023-03-04T20:01:01.646638-05:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-    - timestamp: 2023-03-04T20:01:14.615494-05:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+  - id: CVE-2020-29509
+    events:
+      - timestamp: 2023-03-05T01:01:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+      - timestamp: 2023-03-05T01:01:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
 
-  CVE-2020-29511:
-    - timestamp: 2023-03-04T20:01:14.61372-05:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-    - timestamp: 2023-03-04T21:45:58.722232-05:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+  - id: CVE-2020-29511
+    events:
+      - timestamp: 2023-03-05T01:01:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+      - timestamp: 2023-03-05T02:45:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
 
-  CVE-2022-41723:
-    - timestamp: 2023-03-10T10:38:17.029502-05:00
-      status: fixed
-      fixed-version: 1.20.1-r1
+  - id: CVE-2022-41723
+    events:
+      - timestamp: 2023-03-10T15:38:17Z
+        type: fixed
+        data:
+          fixed-version: 1.20.1-r1
 
-  CVE-2023-24532:
-    - timestamp: 2023-03-10T10:43:37.274724-05:00
-      status: fixed
-      fixed-version: 1.20.2-r0
+  - id: CVE-2023-24532
+    events:
+      - timestamp: 2023-03-10T15:43:37Z
+        type: fixed
+        data:
+          fixed-version: 1.20.2-r0
 
-  CVE-2023-24534:
-    - timestamp: 2023-04-05T08:55:05.219737-04:00
-      status: fixed
-      fixed-version: 1.20.3-r0
+  - id: CVE-2023-24534
+    events:
+      - timestamp: 2023-04-05T12:55:05Z
+        type: fixed
+        data:
+          fixed-version: 1.20.3-r0
 
-  CVE-2023-24536:
-    - timestamp: 2023-04-05T08:55:05.224221-04:00
-      status: fixed
-      fixed-version: 1.20.3-r0
+  - id: CVE-2023-24536
+    events:
+      - timestamp: 2023-04-05T12:55:05Z
+        type: fixed
+        data:
+          fixed-version: 1.20.3-r0
 
-  CVE-2023-24537:
-    - timestamp: 2023-04-05T08:55:05.225081-04:00
-      status: fixed
-      fixed-version: 1.20.3-r0
+  - id: CVE-2023-24537
+    events:
+      - timestamp: 2023-04-05T12:55:05Z
+        type: fixed
+        data:
+          fixed-version: 1.20.3-r0
 
-  CVE-2023-24538:
-    - timestamp: 2023-04-05T08:55:05.226339-04:00
-      status: fixed
-      fixed-version: 1.20.3-r0
+  - id: CVE-2023-24538
+    events:
+      - timestamp: 2023-04-05T12:55:05Z
+        type: fixed
+        data:
+          fixed-version: 1.20.3-r0
 
-  CVE-2023-24539:
-    - timestamp: 2023-05-02T16:02:29.236055-04:00
-      status: fixed
-      fixed-version: 1.20.4-r0
+  - id: CVE-2023-24539
+    events:
+      - timestamp: 2023-05-02T20:02:29Z
+        type: fixed
+        data:
+          fixed-version: 1.20.4-r0
 
-  CVE-2023-24540:
-    - timestamp: 2023-05-02T16:02:29.279148-04:00
-      status: fixed
-      fixed-version: 1.20.4-r0
+  - id: CVE-2023-24540
+    events:
+      - timestamp: 2023-05-02T20:02:29Z
+        type: fixed
+        data:
+          fixed-version: 1.20.4-r0
 
-  CVE-2023-29400:
-    - timestamp: 2023-05-02T16:02:29.308339-04:00
-      status: fixed
-      fixed-version: 1.20.4-r0
+  - id: CVE-2023-29400
+    events:
+      - timestamp: 2023-05-02T20:02:29Z
+        type: fixed
+        data:
+          fixed-version: 1.20.4-r0

--- a/go-fips-1.20.advisories.yaml
+++ b/go-fips-1.20.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2020-29509:
     - timestamp: 2023-03-04T20:01:01.646638-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
     - timestamp: 2023-03-04T20:01:14.615494-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
@@ -13,7 +13,7 @@ advisories:
   CVE-2020-29511:
     - timestamp: 2023-03-04T20:01:14.61372-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
     - timestamp: 2023-03-04T21:45:58.722232-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path

--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -1,40 +1,58 @@
+schema-version: "2"
+
 package:
   name: gradle-8
 
 advisories:
-  CVE-2020-8908:
-    - timestamp: 2023-08-10T18:12:46.040472-04:00
-      status: fixed
-      fixed-version: 8.2.1-r1
+  - id: CVE-2020-8908
+    events:
+      - timestamp: 2023-08-10T22:12:46Z
+        type: fixed
+        data:
+          fixed-version: 8.2.1-r1
 
-  CVE-2022-37866:
-    - timestamp: 2023-08-11T10:59:21.033003-04:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: 'Gradle is not vulnerable because it does not leverage the Apache Ivy dependency cache: https://github.com/gradle/gradle/issues/24795#issuecomment-1623594418'
+  - id: CVE-2022-37866
+    events:
+      - timestamp: 2023-08-11T14:59:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: 'Gradle is not vulnerable because it does not leverage the Apache Ivy dependency cache: https://github.com/gradle/gradle/issues/24795#issuecomment-1623594418'
 
-  CVE-2022-45868:
-    - timestamp: 2023-08-11T10:07:24.992685-04:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: 'CVE is disputed. It relates to exposed passwords when using h2 via command-line. h2 is in use by Gradle as a library, and there is no reference of the CVE-related CLI argument being used in the codebase. Project maintainer''s position: https://github.com/gradle/gradle/issues/24708#issuecomment-1508321833'
+  - id: CVE-2022-45868
+    events:
+      - timestamp: 2023-08-11T14:07:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: 'CVE is disputed. It relates to exposed passwords when using h2 via command-line. h2 is in use by Gradle as a library, and there is no reference of the CVE-related CLI argument being used in the codebase. Project maintainer''s position: https://github.com/gradle/gradle/issues/24708#issuecomment-1508321833'
 
-  CVE-2022-46751:
-    - timestamp: 2023-08-25T14:31:33.045497-07:00
-      status: under_investigation
-    - timestamp: 2023-08-29T11:10:21.039797-04:00
-      status: affected
-      action: The fix for this vulnerability is in version 2.5.2 of the Apache Ivy dependency. A fix for Gradle was asked via https://github.com/gradle/gradle/issues/24795#issuecomment-1695916608 and is awaiting for a response.
+  - id: CVE-2022-46751
+    events:
+      - timestamp: 2023-08-25T21:31:33Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-29T15:10:21Z
+        type: true-positive-determination
+        data:
+          note: The fix for this vulnerability is in version 2.5.2 of the Apache Ivy dependency. A fix for Gradle was asked via https://github.com/gradle/gradle/issues/24795#issuecomment-1695916608 and is awaiting for a response.
 
-  CVE-2023-2976:
-    - timestamp: 2023-08-08T17:07:36.957515-04:00
-      status: under_investigation
-    - timestamp: 2023-08-10T18:11:57.628638-04:00
-      status: fixed
-      fixed-version: 8.2.1-r1
+  - id: CVE-2023-2976
+    events:
+      - timestamp: 2023-08-08T21:07:36Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-10T22:11:57Z
+        type: fixed
+        data:
+          fixed-version: 8.2.1-r1
 
-  CVE-2023-35116:
-    - timestamp: 2023-08-11T11:36:11.286307-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386
+  - id: CVE-2023-35116
+    events:
+      - timestamp: 2023-08-11T15:36:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386

--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -36,5 +36,5 @@ advisories:
   CVE-2023-35116:
     - timestamp: 2023-08-11T11:36:11.286307-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386

--- a/grpcurl.advisories.yaml
+++ b/grpcurl.advisories.yaml
@@ -1,33 +1,47 @@
+schema-version: "2"
+
 package:
   name: grpcurl
 
 advisories:
-  CVE-2021-31525:
-    - timestamp: 2023-08-11T14:20:17.843561-07:00
-      status: fixed
-      fixed-version: 1.8.7-r7
+  - id: CVE-2021-31525
+    events:
+      - timestamp: 2023-08-11T21:20:17Z
+        type: fixed
+        data:
+          fixed-version: 1.8.7-r7
 
-  CVE-2021-33194:
-    - timestamp: 2023-08-11T14:19:46.312532-07:00
-      status: fixed
-      fixed-version: 1.8.7-r7
+  - id: CVE-2021-33194
+    events:
+      - timestamp: 2023-08-11T21:19:46Z
+        type: fixed
+        data:
+          fixed-version: 1.8.7-r7
 
-  CVE-2022-27664:
-    - timestamp: 2023-08-11T14:18:47.729099-07:00
-      status: fixed
-      fixed-version: 1.8.7-r7
+  - id: CVE-2022-27664
+    events:
+      - timestamp: 2023-08-11T21:18:47Z
+        type: fixed
+        data:
+          fixed-version: 1.8.7-r7
 
-  CVE-2022-29526:
-    - timestamp: 2023-08-11T14:21:21.255018-07:00
-      status: fixed
-      fixed-version: 1.8.7-r7
+  - id: CVE-2022-29526
+    events:
+      - timestamp: 2023-08-11T21:21:21Z
+        type: fixed
+        data:
+          fixed-version: 1.8.7-r7
 
-  CVE-2022-32149:
-    - timestamp: 2023-08-11T14:21:48.171142-07:00
-      status: fixed
-      fixed-version: 1.8.7-r7
+  - id: CVE-2022-32149
+    events:
+      - timestamp: 2023-08-11T21:21:48Z
+        type: fixed
+        data:
+          fixed-version: 1.8.7-r7
 
-  CVE-2022-41723:
-    - timestamp: 2023-08-11T14:20:57.929088-07:00
-      status: fixed
-      fixed-version: 1.8.7-r7
+  - id: CVE-2022-41723
+    events:
+      - timestamp: 2023-08-11T21:20:57Z
+        type: fixed
+        data:
+          fixed-version: 1.8.7-r7

--- a/guacamole-server.advisories.yaml
+++ b/guacamole-server.advisories.yaml
@@ -5,11 +5,11 @@ advisories:
   CVE-2023-30575:
     - timestamp: 2023-06-21T18:40:20.441374-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: This was fixed upstream prior to Wolfi packaging.
 
   CVE-2023-30576:
     - timestamp: 2023-06-21T18:40:20.441374-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: This was fixed upstream prior to Wolfi packaging.

--- a/guacamole-server.advisories.yaml
+++ b/guacamole-server.advisories.yaml
@@ -1,15 +1,21 @@
+schema-version: "2"
+
 package:
   name: guacamole-server
 
 advisories:
-  CVE-2023-30575:
-    - timestamp: 2023-06-21T18:40:20.441374-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: This was fixed upstream prior to Wolfi packaging.
+  - id: CVE-2023-30575
+    events:
+      - timestamp: 2023-06-21T22:40:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This was fixed upstream prior to Wolfi packaging.
 
-  CVE-2023-30576:
-    - timestamp: 2023-06-21T18:40:20.441374-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: This was fixed upstream prior to Wolfi packaging.
+  - id: CVE-2023-30576
+    events:
+      - timestamp: 2023-06-21T22:40:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This was fixed upstream prior to Wolfi packaging.

--- a/haproxy.advisories.yaml
+++ b/haproxy.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2016-2102:
     - timestamp: 2023-02-20T14:35:07.391236-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
     - timestamp: 2023-02-20T15:12:46.092387-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path

--- a/haproxy.advisories.yaml
+++ b/haproxy.advisories.yaml
@@ -1,26 +1,37 @@
+schema-version: "2"
+
 package:
   name: haproxy
 
 advisories:
-  CVE-2016-2102:
-    - timestamp: 2023-02-20T14:35:07.391236-05:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-    - timestamp: 2023-02-20T15:12:46.092387-05:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+  - id: CVE-2016-2102
+    events:
+      - timestamp: 2023-02-20T19:35:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+      - timestamp: 2023-02-20T20:12:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
 
-  CVE-2023-0056:
-    - timestamp: 2023-05-04T10:59:24.549732-04:00
-      status: fixed
-      fixed-version: 2.6.8-r0
+  - id: CVE-2023-0056
+    events:
+      - timestamp: 2023-05-04T14:59:24Z
+        type: fixed
+        data:
+          fixed-version: 2.6.8-r0
 
-  CVE-2023-25725:
-    - timestamp: 2023-02-15T16:12:20.024784027+07:00
-      status: fixed
-      fixed-version: 2.6.9-r0
+  - id: CVE-2023-25725
+    events:
+      - timestamp: 2023-02-15T09:12:20Z
+        type: fixed
+        data:
+          fixed-version: 2.6.9-r0
 
-  CVE-2023-40225:
-    - timestamp: 2023-08-22T09:38:16.806572-07:00
-      status: fixed
-      fixed-version: 2.8.2-r0
+  - id: CVE-2023-40225
+    events:
+      - timestamp: 2023-08-22T16:38:16Z
+        type: fixed
+        data:
+          fixed-version: 2.8.2-r0

--- a/heimdal.advisories.yaml
+++ b/heimdal.advisories.yaml
@@ -1,10 +1,16 @@
+schema-version: "2"
+
 package:
   name: heimdal
 
 advisories:
-  CVE-2022-45142:
-    - timestamp: 2023-03-15T11:31:20.584188-04:00
-      status: under_investigation
-    - timestamp: 2023-03-15T12:06:34.898053-04:00
-      status: fixed
-      fixed-version: 7.8.0-r1
+  - id: CVE-2022-45142
+    events:
+      - timestamp: 2023-03-15T15:31:20Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-03-15T16:06:34Z
+        type: fixed
+        data:
+          fixed-version: 7.8.0-r1

--- a/helm.advisories.yaml
+++ b/helm.advisories.yaml
@@ -1,29 +1,45 @@
+schema-version: "2"
+
 package:
   name: helm
 
 advisories:
-  CVE-2023-25165:
-    - timestamp: 2023-02-18T07:29:34.59207-05:00
-      status: fixed
-      fixed-version: 3.11.1-r0
+  - id: CVE-2023-25165
+    events:
+      - timestamp: 2023-02-18T12:29:34Z
+        type: fixed
+        data:
+          fixed-version: 3.11.1-r0
 
-  CVE-2023-28840:
-    - timestamp: 2023-08-02T10:08:42.242587-07:00
-      status: under_investigation
-    - timestamp: 2023-08-02T10:09:23.125263-07:00
-      status: fixed
-      fixed-version: 3.12.2-r1
+  - id: CVE-2023-28840
+    events:
+      - timestamp: 2023-08-02T17:08:42Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-02T17:09:23Z
+        type: fixed
+        data:
+          fixed-version: 3.12.2-r1
 
-  CVE-2023-28841:
-    - timestamp: 2023-08-02T10:08:56.305252-07:00
-      status: under_investigation
-    - timestamp: 2023-08-02T10:09:59.888443-07:00
-      status: fixed
-      fixed-version: 3.12.2-r1
+  - id: CVE-2023-28841
+    events:
+      - timestamp: 2023-08-02T17:08:56Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-02T17:09:59Z
+        type: fixed
+        data:
+          fixed-version: 3.12.2-r1
 
-  CVE-2023-28842:
-    - timestamp: 2023-08-02T10:09:12.079369-07:00
-      status: under_investigation
-    - timestamp: 2023-08-02T10:10:19.539437-07:00
-      status: fixed
-      fixed-version: 3.12.2-r1
+  - id: CVE-2023-28842
+    events:
+      - timestamp: 2023-08-02T17:09:12Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-02T17:10:19Z
+        type: fixed
+        data:
+          fixed-version: 3.12.2-r1

--- a/hey.advisories.yaml
+++ b/hey.advisories.yaml
@@ -1,53 +1,75 @@
+schema-version: "2"
+
 package:
   name: hey
 
 advisories:
-  CVE-2018-17847:
-    - timestamp: 2023-08-11T13:04:56.98804-04:00
-      status: fixed
-      fixed-version: 0.1.4-r3
+  - id: CVE-2018-17847
+    events:
+      - timestamp: 2023-08-11T17:04:56Z
+        type: fixed
+        data:
+          fixed-version: 0.1.4-r3
 
-  CVE-2018-17848:
-    - timestamp: 2023-08-11T13:05:49.119992-04:00
-      status: fixed
-      fixed-version: 0.1.4-r3
+  - id: CVE-2018-17848
+    events:
+      - timestamp: 2023-08-11T17:05:49Z
+        type: fixed
+        data:
+          fixed-version: 0.1.4-r3
 
-  CVE-2019-9512:
-    - timestamp: 2023-08-11T13:05:40.915483-04:00
-      status: fixed
-      fixed-version: 0.1.4-r3
+  - id: CVE-2019-9512
+    events:
+      - timestamp: 2023-08-11T17:05:40Z
+        type: fixed
+        data:
+          fixed-version: 0.1.4-r3
 
-  CVE-2019-9514:
-    - timestamp: 2023-08-11T13:03:13.931719-04:00
-      status: fixed
-      fixed-version: 0.1.4-r3
+  - id: CVE-2019-9514
+    events:
+      - timestamp: 2023-08-11T17:03:13Z
+        type: fixed
+        data:
+          fixed-version: 0.1.4-r3
 
-  CVE-2021-31525:
-    - timestamp: 2023-08-11T13:05:29.955246-04:00
-      status: fixed
-      fixed-version: 0.1.4-r3
+  - id: CVE-2021-31525
+    events:
+      - timestamp: 2023-08-11T17:05:29Z
+        type: fixed
+        data:
+          fixed-version: 0.1.4-r3
 
-  CVE-2021-33194:
-    - timestamp: 2023-08-11T13:05:21.493807-04:00
-      status: fixed
-      fixed-version: 0.1.4-r3
+  - id: CVE-2021-33194
+    events:
+      - timestamp: 2023-08-11T17:05:21Z
+        type: fixed
+        data:
+          fixed-version: 0.1.4-r3
 
-  CVE-2021-38561:
-    - timestamp: 2023-08-11T13:06:18.136257-04:00
-      status: fixed
-      fixed-version: 0.1.4-r3
+  - id: CVE-2021-38561
+    events:
+      - timestamp: 2023-08-11T17:06:18Z
+        type: fixed
+        data:
+          fixed-version: 0.1.4-r3
 
-  CVE-2022-27664:
-    - timestamp: 2023-08-11T13:05:11.683946-04:00
-      status: fixed
-      fixed-version: 0.1.4-r3
+  - id: CVE-2022-27664
+    events:
+      - timestamp: 2023-08-11T17:05:11Z
+        type: fixed
+        data:
+          fixed-version: 0.1.4-r3
 
-  CVE-2022-32149:
-    - timestamp: 2023-08-11T13:06:08.647486-04:00
-      status: fixed
-      fixed-version: 0.1.4-r3
+  - id: CVE-2022-32149
+    events:
+      - timestamp: 2023-08-11T17:06:08Z
+        type: fixed
+        data:
+          fixed-version: 0.1.4-r3
 
-  CVE-2022-41723:
-    - timestamp: 2023-08-11T13:05:58.672358-04:00
-      status: fixed
-      fixed-version: 0.1.4-r3
+  - id: CVE-2022-41723
+    events:
+      - timestamp: 2023-08-11T17:05:58Z
+        type: fixed
+        data:
+          fixed-version: 0.1.4-r3

--- a/httpie.advisories.yaml
+++ b/httpie.advisories.yaml
@@ -5,4 +5,4 @@ advisories:
   CVE-2019-10751:
     - timestamp: 2023-06-15T19:25:11.63471+03:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used

--- a/httpie.advisories.yaml
+++ b/httpie.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: httpie
 
 advisories:
-  CVE-2019-10751:
-    - timestamp: 2023-06-15T19:25:11.63471+03:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
+  - id: CVE-2019-10751
+    events:
+      - timestamp: 2023-06-15T16:25:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used

--- a/jenkins.advisories.yaml
+++ b/jenkins.advisories.yaml
@@ -49,11 +49,11 @@ advisories:
   GHSA-58qw-p7qm-5rvh:
     - timestamp: 2023-08-14T08:56:28.871454-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This was deemed to not be a vulnerability in the code itself. Applications can use it incorrectly, but there's no evidence of that here.
 
   GHSA-mjmj-j48q-9wg2:
     - timestamp: 2023-07-24T11:14:08.315835-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The vulnerable code is not present in the Jenkins snakeyaml plugin, see https://github.com/jenkinsci/snakeyaml-api-plugin/pull/75#issuecomment-1482964755.

--- a/jenkins.advisories.yaml
+++ b/jenkins.advisories.yaml
@@ -1,59 +1,83 @@
+schema-version: "2"
+
 package:
   name: jenkins
 
 advisories:
-  CVE-2016-1000027:
-    - timestamp: 2023-07-21T14:56:46.359543-04:00
-      status: under_investigation
-    - timestamp: 2023-07-21T15:11:25.939734-04:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: Data serialization is performed by the Jenkins framework, nothing specific to this application.
+  - id: CVE-2016-1000027
+    events:
+      - timestamp: 2023-07-21T18:56:46Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-07-21T19:11:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Data serialization is performed by the Jenkins framework, nothing specific to this application.
 
-  CVE-2023-24998:
-    - timestamp: 2023-03-25T21:19:30.185258-04:00
-      status: fixed
-      fixed-version: 2.394-r0
+  - id: CVE-2023-24998
+    events:
+      - timestamp: 2023-03-26T01:19:30Z
+        type: fixed
+        data:
+          fixed-version: 2.394-r0
 
-  CVE-2023-27898:
-    - timestamp: 2023-03-11T18:35:43.356601-05:00
-      status: fixed
-      fixed-version: 2.394-r0
+  - id: CVE-2023-27898
+    events:
+      - timestamp: 2023-03-11T23:35:43Z
+        type: fixed
+        data:
+          fixed-version: 2.394-r0
 
-  CVE-2023-27899:
-    - timestamp: 2023-03-25T21:19:10.610669-04:00
-      status: fixed
-      fixed-version: 2.394-r0
+  - id: CVE-2023-27899
+    events:
+      - timestamp: 2023-03-26T01:19:10Z
+        type: fixed
+        data:
+          fixed-version: 2.394-r0
 
-  CVE-2023-27902:
-    - timestamp: 2023-03-25T21:19:39.717473-04:00
-      status: fixed
-      fixed-version: 2.394-r0
+  - id: CVE-2023-27902
+    events:
+      - timestamp: 2023-03-26T01:19:39Z
+        type: fixed
+        data:
+          fixed-version: 2.394-r0
 
-  CVE-2023-27903:
-    - timestamp: 2023-03-25T21:19:51.085573-04:00
-      status: fixed
-      fixed-version: 2.394-r0
+  - id: CVE-2023-27903
+    events:
+      - timestamp: 2023-03-26T01:19:51Z
+        type: fixed
+        data:
+          fixed-version: 2.394-r0
 
-  CVE-2023-27904:
-    - timestamp: 2023-03-25T21:19:59.68093-04:00
-      status: fixed
-      fixed-version: 2.394-r0
+  - id: CVE-2023-27904
+    events:
+      - timestamp: 2023-03-26T01:19:59Z
+        type: fixed
+        data:
+          fixed-version: 2.394-r0
 
-  CVE-2023-35116:
-    - timestamp: 2023-07-24T09:36:57.297152-07:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: CVE disputed by upstream developers, nothing specific to this application.
+  - id: CVE-2023-35116
+    events:
+      - timestamp: 2023-07-24T16:36:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: CVE disputed by upstream developers, nothing specific to this application.
 
-  GHSA-58qw-p7qm-5rvh:
-    - timestamp: 2023-08-14T08:56:28.871454-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This was deemed to not be a vulnerability in the code itself. Applications can use it incorrectly, but there's no evidence of that here.
+  - id: GHSA-58qw-p7qm-5rvh
+    events:
+      - timestamp: 2023-08-14T12:56:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This was deemed to not be a vulnerability in the code itself. Applications can use it incorrectly, but there's no evidence of that here.
 
-  GHSA-mjmj-j48q-9wg2:
-    - timestamp: 2023-07-24T11:14:08.315835-07:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The vulnerable code is not present in the Jenkins snakeyaml plugin, see https://github.com/jenkinsci/snakeyaml-api-plugin/pull/75#issuecomment-1482964755.
+  - id: GHSA-mjmj-j48q-9wg2
+    events:
+      - timestamp: 2023-07-24T18:14:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The vulnerable code is not present in the Jenkins snakeyaml plugin, see https://github.com/jenkinsci/snakeyaml-api-plugin/pull/75#issuecomment-1482964755.

--- a/kafka.advisories.yaml
+++ b/kafka.advisories.yaml
@@ -1,19 +1,27 @@
+schema-version: "2"
+
 package:
   name: kafka
 
 advisories:
-  CVE-2023-26048:
-    - timestamp: 2023-05-02T08:42:50.301866-04:00
-      status: fixed
-      fixed-version: 3.4.0-r2
+  - id: CVE-2023-26048
+    events:
+      - timestamp: 2023-05-02T12:42:50Z
+        type: fixed
+        data:
+          fixed-version: 3.4.0-r2
 
-  CVE-2023-26049:
-    - timestamp: 2023-05-02T08:43:01.711354-04:00
-      status: fixed
-      fixed-version: 3.4.0-r2
+  - id: CVE-2023-26049
+    events:
+      - timestamp: 2023-05-02T12:43:01Z
+        type: fixed
+        data:
+          fixed-version: 3.4.0-r2
 
-  CVE-2023-35116:
-    - timestamp: 2023-08-11T16:30:36.883091-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: CVE disputed by upstream developers, nothing specific to this application.
+  - id: CVE-2023-35116
+    events:
+      - timestamp: 2023-08-11T20:30:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE disputed by upstream developers, nothing specific to this application.

--- a/kafka.advisories.yaml
+++ b/kafka.advisories.yaml
@@ -15,5 +15,5 @@ advisories:
   CVE-2023-35116:
     - timestamp: 2023-08-11T16:30:36.883091-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: CVE disputed by upstream developers, nothing specific to this application.

--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -1,21 +1,29 @@
+schema-version: "2"
+
 package:
   name: keycloak
 
 advisories:
-  CVE-2017-12158:
-    - timestamp: 2023-04-09T09:54:02.778547-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: The CVE was fixed in a version of keycloak prior to our packaging
+  - id: CVE-2017-12158
+    events:
+      - timestamp: 2023-04-09T13:54:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The CVE was fixed in a version of keycloak prior to our packaging
 
-  CVE-2017-12159:
-    - timestamp: 2023-04-09T09:53:42.563254-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: The CVE was fixed in a version of keycloak prior to our packaging
+  - id: CVE-2017-12159
+    events:
+      - timestamp: 2023-04-09T13:53:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The CVE was fixed in a version of keycloak prior to our packaging
 
-  CVE-2023-0264:
-    - timestamp: 2023-04-30T07:15:20.601606-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: The CVE was fixed in a version of keycloak prior to our packaging
+  - id: CVE-2023-0264
+    events:
+      - timestamp: 2023-04-30T11:15:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The CVE was fixed in a version of keycloak prior to our packaging

--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -5,17 +5,17 @@ advisories:
   CVE-2017-12158:
     - timestamp: 2023-04-09T09:54:02.778547-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: The CVE was fixed in a version of keycloak prior to our packaging
 
   CVE-2017-12159:
     - timestamp: 2023-04-09T09:53:42.563254-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: The CVE was fixed in a version of keycloak prior to our packaging
 
   CVE-2023-0264:
     - timestamp: 2023-04-30T07:15:20.601606-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: The CVE was fixed in a version of keycloak prior to our packaging

--- a/ko.advisories.yaml
+++ b/ko.advisories.yaml
@@ -1,28 +1,40 @@
+schema-version: "2"
+
 package:
   name: ko
 
 advisories:
-  GHSA-2h5h-59f5-c5x9:
-    - timestamp: 2023-05-04T10:34:34.169879-04:00
-      status: fixed
-      fixed-version: 0.13.0-r3
+  - id: GHSA-232p-vwff-86mp
+    events:
+      - timestamp: 2023-05-04T14:34:34Z
+        type: fixed
+        data:
+          fixed-version: 0.13.0-r3
 
-  GHSA-6wrf-mxfj-pf5p:
-    - timestamp: 2023-05-04T10:34:34.141361-04:00
-      status: fixed
-      fixed-version: 0.13.0-r3
+  - id: GHSA-2h5h-59f5-c5x9
+    events:
+      - timestamp: 2023-05-04T14:34:34Z
+        type: fixed
+        data:
+          fixed-version: 0.13.0-r3
 
-  GHSA-33pg-m6jh-5237:
-    - timestamp: 2023-05-04T10:34:34.117098-04:00
-      status: fixed
-      fixed-version: 0.13.0-r3
+  - id: GHSA-33pg-m6jh-5237
+    events:
+      - timestamp: 2023-05-04T14:34:34Z
+        type: fixed
+        data:
+          fixed-version: 0.13.0-r3
 
-  GHSA-232p-vwff-86mp:
-    - timestamp: 2023-05-04T10:34:34.07704-04:00
-      status: fixed
-      fixed-version: 0.13.0-r3
+  - id: GHSA-6wrf-mxfj-pf5p
+    events:
+      - timestamp: 2023-05-04T14:34:34Z
+        type: fixed
+        data:
+          fixed-version: 0.13.0-r3
 
-  GHSA-hw7c-3rfg-p46j:
-    - timestamp: 2023-05-04T10:34:34.199688-04:00
-      status: fixed
-      fixed-version: 0.13.0-r3
+  - id: GHSA-hw7c-3rfg-p46j
+    events:
+      - timestamp: 2023-05-04T14:34:34Z
+        type: fixed
+        data:
+          fixed-version: 0.13.0-r3

--- a/kots.advisories.yaml
+++ b/kots.advisories.yaml
@@ -7,7 +7,7 @@ advisories:
       status: under_investigation
     - timestamp: 2023-08-10T20:35:31.121444-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).
 
   CVE-2020-26290:
@@ -15,7 +15,7 @@ advisories:
       status: under_investigation
     - timestamp: 2023-08-10T20:35:31.121444-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).
 
   CVE-2022-39222:
@@ -23,5 +23,5 @@ advisories:
       status: under_investigation
     - timestamp: 2023-08-10T20:35:31.121444-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).

--- a/kots.advisories.yaml
+++ b/kots.advisories.yaml
@@ -1,27 +1,41 @@
+schema-version: "2"
+
 package:
   name: kots
 
 advisories:
-  CVE-2020-27847:
-    - timestamp: 2023-08-10T20:35:13.673631-04:00
-      status: under_investigation
-    - timestamp: 2023-08-10T20:35:31.121444-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).
+  - id: CVE-2020-26290
+    events:
+      - timestamp: 2023-08-11T00:35:13Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-11T00:35:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).
 
-  CVE-2020-26290:
-    - timestamp: 2023-08-10T20:35:13.673631-04:00
-      status: under_investigation
-    - timestamp: 2023-08-10T20:35:31.121444-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).
+  - id: CVE-2020-27847
+    events:
+      - timestamp: 2023-08-11T00:35:13Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-11T00:35:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).
 
-  CVE-2022-39222:
-    - timestamp: 2023-08-10T20:35:13.673631-04:00
-      status: under_investigation
-    - timestamp: 2023-08-10T20:35:31.121444-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).
+  - id: CVE-2022-39222
+    events:
+      - timestamp: 2023-08-11T00:35:13Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-11T00:35:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).

--- a/kpt.advisories.yaml
+++ b/kpt.advisories.yaml
@@ -1,10 +1,16 @@
+schema-version: "2"
+
 package:
   name: kpt
 
 advisories:
-  CVE-2023-2253:
-    - timestamp: 2023-08-02T10:06:36.09552-07:00
-      status: under_investigation
-    - timestamp: 2023-08-02T10:06:56.297593-07:00
-      status: fixed
-      fixed-version: 1.0.0_beta31-r5
+  - id: CVE-2023-2253
+    events:
+      - timestamp: 2023-08-02T17:06:36Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-02T17:06:56Z
+        type: fixed
+        data:
+          fixed-version: 1.0.0_beta31-r5

--- a/kube-downscaler.advisories.yaml
+++ b/kube-downscaler.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: kube-downscaler
 
 advisories:
-  CVE-2023-37920:
-    - timestamp: 2023-08-25T16:23:14.82416-07:00
-      status: fixed
-      fixed-version: 23.2.0-r3
+  - id: CVE-2023-37920
+    events:
+      - timestamp: 2023-08-25T23:23:14Z
+        type: fixed
+        data:
+          fixed-version: 23.2.0-r3

--- a/kube-fluentd-operator.advisories.yaml
+++ b/kube-fluentd-operator.advisories.yaml
@@ -1,19 +1,27 @@
+schema-version: "2"
+
 package:
   name: kube-fluentd-operator
 
 advisories:
-  CVE-2008-1145:
-    - timestamp: 2023-07-10T15:15:14.819759+01:00
-      status: not_affected
-      justification: component_not_present
-      impact: The CVE was against an older version of ruby itself which included this in the stdlib.
+  - id: CVE-2008-1145
+    events:
+      - timestamp: 2023-07-10T14:15:14Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The CVE was against an older version of ruby itself which included this in the stdlib.
 
-  CVE-2023-36617:
-    - timestamp: 2023-07-25T17:20:01.132149+02:00
-      status: affected
-      action: This has been fixed upstream (commit dd73fe077cae077808e820f4765a12b1f4660521) and we're waiting for a release.
+  - id: CVE-2023-36617
+    events:
+      - timestamp: 2023-07-25T15:20:01Z
+        type: true-positive-determination
+        data:
+          note: This has been fixed upstream (commit dd73fe077cae077808e820f4765a12b1f4660521) and we're waiting for a release.
 
-  CVE-2023-38037:
-    - timestamp: 2023-08-29T09:45:48.823065-07:00
-      status: fixed
-      fixed-version: 1.17.6-r2
+  - id: CVE-2023-38037
+    events:
+      - timestamp: 2023-08-29T16:45:48Z
+        type: fixed
+        data:
+          fixed-version: 1.17.6-r2

--- a/kubectl.advisories.yaml
+++ b/kubectl.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: kubectl
 
 advisories:
-  CVE-2019-11255:
-    - timestamp: 2023-08-07T15:07:36.090523-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vuln only present in Kubernets CSI sidecars external-provisioner, external-snapshotter, external-resizer
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-07T19:07:36Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vuln only present in Kubernets CSI sidecars external-provisioner, external-snapshotter, external-resizer

--- a/kubernetes-1.24.advisories.yaml
+++ b/kubernetes-1.24.advisories.yaml
@@ -1,39 +1,53 @@
+schema-version: "2"
+
 package:
   name: kubernetes-1.24
 
 advisories:
-  CVE-2015-7561:
-    - timestamp: 2023-08-18T13:06:31.615082-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2015-7561
+    events:
+      - timestamp: 2023-08-18T17:06:31Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2016-1905:
-    - timestamp: 2023-08-18T13:06:32.489667-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.2
+  - id: CVE-2016-1905
+    events:
+      - timestamp: 2023-08-18T17:06:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.2
 
-  CVE-2016-1906:
-    - timestamp: 2023-08-18T13:06:33.321482-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2016-1906
+    events:
+      - timestamp: 2023-08-18T17:06:33Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2016-7075:
-    - timestamp: 2023-08-18T13:06:34.808915-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2016-7075
+    events:
+      - timestamp: 2023-08-18T17:06:34Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2019-11255:
-    - timestamp: 2023-08-18T13:06:34.080427-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 2.1
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-18T17:06:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 2.1
 
-  CVE-2020-8554:
-    - timestamp: 2023-08-18T13:06:35.552499-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.21
+  - id: CVE-2020-8554
+    events:
+      - timestamp: 2023-08-18T17:06:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.21

--- a/kubernetes-1.24.advisories.yaml
+++ b/kubernetes-1.24.advisories.yaml
@@ -11,7 +11,7 @@ advisories:
   CVE-2016-1905:
     - timestamp: 2023-08-18T13:06:32.489667-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.2
 
   CVE-2016-1906:
@@ -29,11 +29,11 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-18T13:06:34.080427-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 2.1
 
   CVE-2020-8554:
     - timestamp: 2023-08-18T13:06:35.552499-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.21

--- a/kubernetes-1.25.advisories.yaml
+++ b/kubernetes-1.25.advisories.yaml
@@ -1,39 +1,53 @@
+schema-version: "2"
+
 package:
   name: kubernetes-1.25
 
 advisories:
-  CVE-2015-7561:
-    - timestamp: 2023-08-18T13:06:36.359478-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2015-7561
+    events:
+      - timestamp: 2023-08-18T17:06:36Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2016-1905:
-    - timestamp: 2023-08-18T13:06:37.107079-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.2
+  - id: CVE-2016-1905
+    events:
+      - timestamp: 2023-08-18T17:06:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.2
 
-  CVE-2016-1906:
-    - timestamp: 2023-08-18T13:06:37.861431-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2016-1906
+    events:
+      - timestamp: 2023-08-18T17:06:37Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2016-7075:
-    - timestamp: 2023-08-18T13:06:39.587546-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2016-7075
+    events:
+      - timestamp: 2023-08-18T17:06:39Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2019-11255:
-    - timestamp: 2023-08-18T13:06:38.903818-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.2
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-18T17:06:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.2
 
-  CVE-2020-8554:
-    - timestamp: 2023-08-18T13:06:40.324611-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.21
+  - id: CVE-2020-8554
+    events:
+      - timestamp: 2023-08-18T17:06:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.21

--- a/kubernetes-1.25.advisories.yaml
+++ b/kubernetes-1.25.advisories.yaml
@@ -11,7 +11,7 @@ advisories:
   CVE-2016-1905:
     - timestamp: 2023-08-18T13:06:37.107079-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.2
 
   CVE-2016-1906:
@@ -29,11 +29,11 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-18T13:06:38.903818-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.2
 
   CVE-2020-8554:
     - timestamp: 2023-08-18T13:06:40.324611-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.21

--- a/kubernetes-1.26.advisories.yaml
+++ b/kubernetes-1.26.advisories.yaml
@@ -11,7 +11,7 @@ advisories:
   CVE-2016-1905:
     - timestamp: 2023-08-18T13:06:41.736236-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.2
 
   CVE-2016-1906:
@@ -29,11 +29,11 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-18T13:06:43.209483-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.2
 
   CVE-2020-8554:
     - timestamp: 2023-08-18T13:06:44.646688-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.21

--- a/kubernetes-1.26.advisories.yaml
+++ b/kubernetes-1.26.advisories.yaml
@@ -1,39 +1,53 @@
+schema-version: "2"
+
 package:
   name: kubernetes-1.26
 
 advisories:
-  CVE-2015-7561:
-    - timestamp: 2023-08-18T13:06:41.050418-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2015-7561
+    events:
+      - timestamp: 2023-08-18T17:06:41Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2016-1905:
-    - timestamp: 2023-08-18T13:06:41.736236-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.2
+  - id: CVE-2016-1905
+    events:
+      - timestamp: 2023-08-18T17:06:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.2
 
-  CVE-2016-1906:
-    - timestamp: 2023-08-18T13:06:42.428268-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2016-1906
+    events:
+      - timestamp: 2023-08-18T17:06:42Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2016-7075:
-    - timestamp: 2023-08-18T13:06:43.918169-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2016-7075
+    events:
+      - timestamp: 2023-08-18T17:06:43Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2019-11255:
-    - timestamp: 2023-08-18T13:06:43.209483-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.2
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-18T17:06:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.2
 
-  CVE-2020-8554:
-    - timestamp: 2023-08-18T13:06:44.646688-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.21
+  - id: CVE-2020-8554
+    events:
+      - timestamp: 2023-08-18T17:06:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.21

--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -1,39 +1,53 @@
+schema-version: "2"
+
 package:
   name: kubernetes-1.27
 
 advisories:
-  CVE-2015-7561:
-    - timestamp: 2023-08-18T13:06:45.386198-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2015-7561
+    events:
+      - timestamp: 2023-08-18T17:06:45Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2016-1905:
-    - timestamp: 2023-08-18T13:06:46.069097-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.2
+  - id: CVE-2016-1905
+    events:
+      - timestamp: 2023-08-18T17:06:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.2
 
-  CVE-2016-1906:
-    - timestamp: 2023-08-18T13:06:46.746774-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2016-1906
+    events:
+      - timestamp: 2023-08-18T17:06:46Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2016-7075:
-    - timestamp: 2023-08-18T13:06:48.133846-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2016-7075
+    events:
+      - timestamp: 2023-08-18T17:06:48Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2019-11255:
-    - timestamp: 2023-08-18T13:06:47.442579-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.2
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-18T17:06:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.2
 
-  CVE-2020-8554:
-    - timestamp: 2023-08-18T13:06:48.872972-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.21
+  - id: CVE-2020-8554
+    events:
+      - timestamp: 2023-08-18T17:06:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.21

--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -11,7 +11,7 @@ advisories:
   CVE-2016-1905:
     - timestamp: 2023-08-18T13:06:46.069097-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.2
 
   CVE-2016-1906:
@@ -29,11 +29,11 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-18T13:06:47.442579-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.2
 
   CVE-2020-8554:
     - timestamp: 2023-08-18T13:06:48.872972-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.21

--- a/kubernetes-1.28.advisories.yaml
+++ b/kubernetes-1.28.advisories.yaml
@@ -11,7 +11,7 @@ advisories:
   CVE-2016-1905:
     - timestamp: 2023-08-18T13:06:50.313089-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.2
 
   CVE-2016-1906:
@@ -29,11 +29,11 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-18T13:06:51.852614-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.2
 
   CVE-2020-8554:
     - timestamp: 2023-08-18T13:06:53.245254-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Fixed in Kubernetes 1.21

--- a/kubernetes-1.28.advisories.yaml
+++ b/kubernetes-1.28.advisories.yaml
@@ -1,39 +1,53 @@
+schema-version: "2"
+
 package:
   name: kubernetes-1.28
 
 advisories:
-  CVE-2015-7561:
-    - timestamp: 2023-08-18T13:06:49.629816-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2015-7561
+    events:
+      - timestamp: 2023-08-18T17:06:49Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2016-1905:
-    - timestamp: 2023-08-18T13:06:50.313089-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.2
+  - id: CVE-2016-1905
+    events:
+      - timestamp: 2023-08-18T17:06:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.2
 
-  CVE-2016-1906:
-    - timestamp: 2023-08-18T13:06:51.026787-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2016-1906
+    events:
+      - timestamp: 2023-08-18T17:06:51Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2016-7075:
-    - timestamp: 2023-08-18T13:06:52.558931-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vulnerability only impacts OpenShift
+  - id: CVE-2016-7075
+    events:
+      - timestamp: 2023-08-18T17:06:52Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vulnerability only impacts OpenShift
 
-  CVE-2019-11255:
-    - timestamp: 2023-08-18T13:06:51.852614-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.2
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-18T17:06:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.2
 
-  CVE-2020-8554:
-    - timestamp: 2023-08-18T13:06:53.245254-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Fixed in Kubernetes 1.21
+  - id: CVE-2020-8554
+    events:
+      - timestamp: 2023-08-18T17:06:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Fixed in Kubernetes 1.21

--- a/kubernetes-dashboard.advisories.yaml
+++ b/kubernetes-dashboard.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: kubernetes-dashboard
 
 advisories:
-  CVE-2023-2253:
-    - timestamp: 2023-05-26T13:58:25.44826-04:00
-      status: fixed
-      fixed-version: 2.7.0-r2
+  - id: CVE-2023-2253
+    events:
+      - timestamp: 2023-05-26T17:58:25Z
+        type: fixed
+        data:
+          fixed-version: 2.7.0-r2

--- a/kubernetes-dns-node-cache.advisories.yaml
+++ b/kubernetes-dns-node-cache.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: kubernetes-dns-node-cache
 
 advisories:
-  CVE-2019-11255:
-    - timestamp: 2023-08-21T09:27:12.008255-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of external-csi-driver and not included in kubernetes-dns-node-cache
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-21T16:27:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of external-csi-driver and not included in kubernetes-dns-node-cache

--- a/kubernetes-dns-node-cache.advisories.yaml
+++ b/kubernetes-dns-node-cache.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2019-11255:
     - timestamp: 2023-08-21T09:27:12.008255-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of external-csi-driver and not included in kubernetes-dns-node-cache

--- a/kubevela.advisories.yaml
+++ b/kubevela.advisories.yaml
@@ -1,15 +1,21 @@
+schema-version: "2"
+
 package:
   name: kubevela
 
 advisories:
-  CVE-2022-39383:
-    - timestamp: 2023-08-11T15:59:56.494207-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Vulnerable code was fixed in KubeVela 1.5.9/1.6.2.  Earliest Wolfi package is 1.7.0.
+  - id: CVE-2022-39383
+    events:
+      - timestamp: 2023-08-11T22:59:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Vulnerable code was fixed in KubeVela 1.5.9/1.6.2.  Earliest Wolfi package is 1.7.0.
 
-  GHSA-m5xf-x7q6-3rm7:
-    - timestamp: 2023-08-11T15:58:40.185465-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Vulnerable code was fixed in KubeVela 1.5.9/1.6.2.  Earliest Wolfi package is 1.7.0.
+  - id: GHSA-m5xf-x7q6-3rm7
+    events:
+      - timestamp: 2023-08-11T22:58:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Vulnerable code was fixed in KubeVela 1.5.9/1.6.2.  Earliest Wolfi package is 1.7.0.

--- a/kubevela.advisories.yaml
+++ b/kubevela.advisories.yaml
@@ -5,11 +5,11 @@ advisories:
   CVE-2022-39383:
     - timestamp: 2023-08-11T15:59:56.494207-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Vulnerable code was fixed in KubeVela 1.5.9/1.6.2.  Earliest Wolfi package is 1.7.0.
 
   GHSA-m5xf-x7q6-3rm7:
     - timestamp: 2023-08-11T15:58:40.185465-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Vulnerable code was fixed in KubeVela 1.5.9/1.6.2.  Earliest Wolfi package is 1.7.0.

--- a/kyverno.advisories.yaml
+++ b/kyverno.advisories.yaml
@@ -1,15 +1,21 @@
+schema-version: "2"
+
 package:
   name: kyverno
 
 advisories:
-  CVE-2023-30551:
-    - timestamp: 2023-08-08T16:51:19.398968-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: The vulnerable code in Rekor cannot be imported.
+  - id: CVE-2023-30551
+    events:
+      - timestamp: 2023-08-08T23:51:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The vulnerable code in Rekor cannot be imported.
 
-  CVE-2023-33199:
-    - timestamp: 2023-08-08T16:51:19.398968-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: The vulnerable code is effectively private. The vulnerable code is unlikely to ever be imported.
+  - id: CVE-2023-33199
+    events:
+      - timestamp: 2023-08-08T23:51:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The vulnerable code is effectively private. The vulnerable code is unlikely to ever be imported.

--- a/kyverno.advisories.yaml
+++ b/kyverno.advisories.yaml
@@ -5,11 +5,11 @@ advisories:
   CVE-2023-30551:
     - timestamp: 2023-08-08T16:51:19.398968-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: The vulnerable code in Rekor cannot be imported.
 
   CVE-2023-33199:
     - timestamp: 2023-08-08T16:51:19.398968-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: The vulnerable code is effectively private. The vulnerable code is unlikely to ever be imported.

--- a/libarchive.advisories.yaml
+++ b/libarchive.advisories.yaml
@@ -1,12 +1,19 @@
+schema-version: "2"
+
 package:
   name: libarchive
 
 advisories:
-  CVE-2022-36227:
-    - timestamp: 2022-12-06T16:23:01Z
-      status: fixed
-      fixed-version: 3.6.1-r2
+  - id: CVE-2022-36227
+    events:
+      - timestamp: 2022-12-06T16:23:01Z
+        type: fixed
+        data:
+          fixed-version: 3.6.1-r2
 
-  CVE-2023-30571:
-    - timestamp: 2023-06-11T09:10:50.395655-04:00
-      status: under_investigation
+  - id: CVE-2023-30571
+    events:
+      - timestamp: 2023-06-11T13:10:50Z
+        type: detection
+        data:
+          type: manual

--- a/libidn2.advisories.yaml
+++ b/libidn2.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: libidn2
 
 advisories:
-  CVE-2019-12290:
-    - timestamp: 2023-01-15T00:15:49.178501Z
-      status: fixed
-      fixed-version: 2.3.4-r0
+  - id: CVE-2019-12290
+    events:
+      - timestamp: 2023-01-15T00:15:49Z
+        type: fixed
+        data:
+          fixed-version: 2.3.4-r0
 
-  CVE-2019-18224:
-    - timestamp: 2023-01-15T00:15:49.179474Z
-      status: fixed
-      fixed-version: 2.3.4-r0
+  - id: CVE-2019-18224
+    events:
+      - timestamp: 2023-01-15T00:15:49Z
+        type: fixed
+        data:
+          fixed-version: 2.3.4-r0

--- a/libjpeg-turbo.advisories.yaml
+++ b/libjpeg-turbo.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: libjpeg-turbo
 
 advisories:
-  CVE-2023-2804:
-    - timestamp: 2023-06-07T13:56:43.199195-04:00
-      status: fixed
-      fixed-version: 2.1.91-r3
+  - id: CVE-2023-2804
+    events:
+      - timestamp: 2023-06-07T17:56:43Z
+        type: fixed
+        data:
+          fixed-version: 2.1.91-r3

--- a/libksba.advisories.yaml
+++ b/libksba.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: libksba
 
 advisories:
-  CVE-2022-3515:
-    - timestamp: 2023-01-15T00:17:15.589537Z
-      status: fixed
-      fixed-version: 1.6.3-r0
+  - id: CVE-2022-3515
+    events:
+      - timestamp: 2023-01-15T00:17:15Z
+        type: fixed
+        data:
+          fixed-version: 1.6.3-r0
 
-  CVE-2022-47629:
-    - timestamp: 2023-01-15T00:17:15.588976Z
-      status: fixed
-      fixed-version: 1.6.3-r0
+  - id: CVE-2022-47629
+    events:
+      - timestamp: 2023-01-15T00:17:15Z
+        type: fixed
+        data:
+          fixed-version: 1.6.3-r0

--- a/libssh.advisories.yaml
+++ b/libssh.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2023-3603:
     - timestamp: 2023-08-11T15:37:30.618212-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This CVE pertains to a defect in an example program and is unrelated to the library.

--- a/libssh.advisories.yaml
+++ b/libssh.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: libssh
 
 advisories:
-  CVE-2023-3603:
-    - timestamp: 2023-08-11T15:37:30.618212-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This CVE pertains to a defect in an example program and is unrelated to the library.
+  - id: CVE-2023-3603
+    events:
+      - timestamp: 2023-08-11T22:37:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This CVE pertains to a defect in an example program and is unrelated to the library.

--- a/libssh2.advisories.yaml
+++ b/libssh2.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: libssh2
 
 advisories:
-  CVE-2023-3603:
-    - timestamp: 2023-08-11T15:39:49.474346-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This CVE pertains to a defect in an example program in libssh, not libssh2.
+  - id: CVE-2023-3603
+    events:
+      - timestamp: 2023-08-11T22:39:49Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This CVE pertains to a defect in an example program in libssh, not libssh2.

--- a/libtasn1.advisories.yaml
+++ b/libtasn1.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: libtasn1
 
 advisories:
-  CVE-2021-46848:
-    - timestamp: 2023-01-11T23:36:05.441484Z
-      status: fixed
-      fixed-version: 4.19.0-r0
+  - id: CVE-2021-46848
+    events:
+      - timestamp: 2023-01-11T23:36:05Z
+        type: fixed
+        data:
+          fixed-version: 4.19.0-r0

--- a/libxml2.advisories.yaml
+++ b/libxml2.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: libxml2
 
 advisories:
-  CVE-2022-40303:
-    - timestamp: 2022-10-20T22:07:42+01:00
-      status: fixed
-      fixed-version: 2.10.3-r0
+  - id: CVE-2022-40303
+    events:
+      - timestamp: 2022-10-20T21:07:42Z
+        type: fixed
+        data:
+          fixed-version: 2.10.3-r0
 
-  CVE-2022-40304:
-    - timestamp: 2022-10-20T22:07:42+01:00
-      status: fixed
-      fixed-version: 2.10.3-r0
+  - id: CVE-2022-40304
+    events:
+      - timestamp: 2022-10-20T21:07:42Z
+        type: fixed
+        data:
+          fixed-version: 2.10.3-r0

--- a/libxpm.advisories.yaml
+++ b/libxpm.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: libxpm
 
 advisories:
-  CVE-2022-44617:
-    - timestamp: 2023-02-18T07:34:06.261739-05:00
-      status: fixed
-      fixed-version: 3.5.15-r0
+  - id: CVE-2022-44617
+    events:
+      - timestamp: 2023-02-18T12:34:06Z
+        type: fixed
+        data:
+          fixed-version: 3.5.15-r0

--- a/loki.advisories.yaml
+++ b/loki.advisories.yaml
@@ -1,14 +1,20 @@
+schema-version: "2"
+
 package:
   name: loki
 
 advisories:
-  CVE-2023-40577:
-    - timestamp: 2023-09-01T21:06:18.358891-04:00
-      status: fixed
-      fixed-version: 2.8.4-r5
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-09-02T01:06:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This CVE affects the Prometheus UI (Javascript) and not the Go code
 
-  CVE-2019-3826:
-    - timestamp: 2023-09-01T21:06:18.358891-04:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: This CVE affects the Prometheus UI (Javascript) and not the Go code
+  - id: CVE-2023-40577
+    events:
+      - timestamp: 2023-09-02T01:06:18Z
+        type: fixed
+        data:
+          fixed-version: 2.8.4-r5

--- a/lua5.4.advisories.yaml
+++ b/lua5.4.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: lua5.4
 
 advisories:
-  CVE-2019-6706:
-    - timestamp: 2023-01-12T09:51:37.85609Z
-      status: fixed
-      fixed-version: 5.4.4-r0
+  - id: CVE-2019-6706
+    events:
+      - timestamp: 2023-01-12T09:51:37Z
+        type: fixed
+        data:
+          fixed-version: 5.4.4-r0
 
-  CVE-2022-28805:
-    - timestamp: 2023-01-12T09:51:37.855026Z
-      status: fixed
-      fixed-version: 5.4.4-r0
+  - id: CVE-2022-28805
+    events:
+      - timestamp: 2023-01-12T09:51:37Z
+        type: fixed
+        data:
+          fixed-version: 5.4.4-r0

--- a/mariadb-10.11.advisories.yaml
+++ b/mariadb-10.11.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: mariadb-10.11
 
 advisories:
-  CVE-2022-47015:
-    - timestamp: 2023-02-12T07:33:40.136467-05:00
-      status: fixed
-      fixed-version: 10.6.12-r1
+  - id: CVE-2022-47015
+    events:
+      - timestamp: 2023-02-12T12:33:40Z
+        type: fixed
+        data:
+          fixed-version: 10.6.12-r1

--- a/mariadb-10.6.advisories.yaml
+++ b/mariadb-10.6.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: mariadb-10.6
 
 advisories:
-  CVE-2022-47015:
-    - timestamp: 2023-02-12T07:33:40.136467-05:00
-      status: fixed
-      fixed-version: 10.6.12-r1
+  - id: CVE-2022-47015
+    events:
+      - timestamp: 2023-02-12T12:33:40Z
+        type: fixed
+        data:
+          fixed-version: 10.6.12-r1

--- a/maven.advisories.yaml
+++ b/maven.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: maven
 
 advisories:
-  CVE-2020-8908:
-    - timestamp: 2023-08-18T14:06:28.607474-07:00
-      status: fixed
-      fixed-version: 3.9.3-r1
+  - id: CVE-2020-8908
+    events:
+      - timestamp: 2023-08-18T21:06:28Z
+        type: fixed
+        data:
+          fixed-version: 3.9.3-r1
 
-  CVE-2023-2976:
-    - timestamp: 2023-08-18T14:06:59.102688-07:00
-      status: fixed
-      fixed-version: 3.9.3-r1
+  - id: CVE-2023-2976
+    events:
+      - timestamp: 2023-08-18T21:06:59Z
+        type: fixed
+        data:
+          fixed-version: 3.9.3-r1

--- a/melange.advisories.yaml
+++ b/melange.advisories.yaml
@@ -1,18 +1,26 @@
+schema-version: "2"
+
 package:
   name: melange
 
 advisories:
-  CVE-2023-28840:
-    - timestamp: 2023-04-05T10:22:34.321059-04:00
-      status: fixed
-      fixed-version: 0.3.2-r1
+  - id: CVE-2023-28840
+    events:
+      - timestamp: 2023-04-05T14:22:34Z
+        type: fixed
+        data:
+          fixed-version: 0.3.2-r1
 
-  CVE-2023-28841:
-    - timestamp: 2023-04-05T10:22:34.321895-04:00
-      status: fixed
-      fixed-version: 0.3.2-r1
+  - id: CVE-2023-28841
+    events:
+      - timestamp: 2023-04-05T14:22:34Z
+        type: fixed
+        data:
+          fixed-version: 0.3.2-r1
 
-  CVE-2023-28842:
-    - timestamp: 2023-04-05T10:22:34.32252-04:00
-      status: fixed
-      fixed-version: 0.3.2-r1
+  - id: CVE-2023-28842
+    events:
+      - timestamp: 2023-04-05T14:22:34Z
+        type: fixed
+        data:
+          fixed-version: 0.3.2-r1

--- a/metrics-server.advisories.yaml
+++ b/metrics-server.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: metrics-server
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-13T15:49:44.468793-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This CVE affects the Prometheus UI (Javascript) and not the Go code. See prometheus/prometheus#12403 and prometheus/prometheus#5163
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-13T22:49:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This CVE affects the Prometheus UI (Javascript) and not the Go code. See prometheus/prometheus#12403 and prometheus/prometheus#5163

--- a/metrics-server.advisories.yaml
+++ b/metrics-server.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2019-3826:
     - timestamp: 2023-08-13T15:49:44.468793-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This CVE affects the Prometheus UI (Javascript) and not the Go code. See prometheus/prometheus#12403 and prometheus/prometheus#5163

--- a/minio.advisories.yaml
+++ b/minio.advisories.yaml
@@ -5,37 +5,37 @@ advisories:
   CVE-2018-1000538:
     - timestamp: 2023-03-25T17:04:18.613256-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
 
   CVE-2020-11012:
     - timestamp: 2023-03-25T17:04:39.916688-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
 
   CVE-2021-21287:
     - timestamp: 2023-03-25T17:04:51.061715-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
 
   CVE-2021-21362:
     - timestamp: 2023-03-25T17:04:58.58436-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
 
   CVE-2021-21390:
     - timestamp: 2023-03-25T17:05:03.086934-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
 
   CVE-2021-43858:
     - timestamp: 2023-03-25T17:05:08.097081-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
 
   CVE-2022-35919:
     - timestamp: 2023-03-25T17:05:12.402326-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
 
   CVE-2023-28433:
     - timestamp: 2023-04-13T17:44:39.707701-04:00

--- a/minio.advisories.yaml
+++ b/minio.advisories.yaml
@@ -1,48 +1,68 @@
+schema-version: "2"
+
 package:
   name: minio
 
 advisories:
-  CVE-2018-1000538:
-    - timestamp: 2023-03-25T17:04:18.613256-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
+  - id: CVE-2018-1000538
+    events:
+      - timestamp: 2023-03-25T21:04:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
 
-  CVE-2020-11012:
-    - timestamp: 2023-03-25T17:04:39.916688-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
+  - id: CVE-2020-11012
+    events:
+      - timestamp: 2023-03-25T21:04:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
 
-  CVE-2021-21287:
-    - timestamp: 2023-03-25T17:04:51.061715-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
+  - id: CVE-2021-21287
+    events:
+      - timestamp: 2023-03-25T21:04:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
 
-  CVE-2021-21362:
-    - timestamp: 2023-03-25T17:04:58.58436-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
+  - id: CVE-2021-21362
+    events:
+      - timestamp: 2023-03-25T21:04:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
 
-  CVE-2021-21390:
-    - timestamp: 2023-03-25T17:05:03.086934-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
+  - id: CVE-2021-21390
+    events:
+      - timestamp: 2023-03-25T21:05:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
 
-  CVE-2021-43858:
-    - timestamp: 2023-03-25T17:05:08.097081-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
+  - id: CVE-2021-43858
+    events:
+      - timestamp: 2023-03-25T21:05:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
 
-  CVE-2022-35919:
-    - timestamp: 2023-03-25T17:05:12.402326-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
+  - id: CVE-2022-35919
+    events:
+      - timestamp: 2023-03-25T21:05:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
 
-  CVE-2023-28433:
-    - timestamp: 2023-04-13T17:44:39.707701-04:00
-      status: fixed
-      fixed-version: 0.20230413.030807
+  - id: CVE-2023-28433
+    events:
+      - timestamp: 2023-04-13T21:44:39Z
+        type: fixed
+        data:
+          fixed-version: 0.20230413.030807
 
-  CVE-2023-28434:
-    - timestamp: 2023-04-13T17:44:43.780465-04:00
-      status: fixed
-      fixed-version: 0.20230413.030807
+  - id: CVE-2023-28434
+    events:
+      - timestamp: 2023-04-13T21:44:43Z
+        type: fixed
+        data:
+          fixed-version: 0.20230413.030807

--- a/modsecurity.advisories.yaml
+++ b/modsecurity.advisories.yaml
@@ -1,17 +1,27 @@
+schema-version: "2"
+
 package:
   name: modsecurity
 
 advisories:
-  CVE-2023-28882:
-    - timestamp: 2023-06-11T09:10:50.44874-04:00
-      status: under_investigation
-    - timestamp: 2023-06-11T12:07:02.998852-04:00
-      status: fixed
-      fixed-version: 3.0.9-r0
+  - id: CVE-2023-28882
+    events:
+      - timestamp: 2023-06-11T13:10:50Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-06-11T16:07:02Z
+        type: fixed
+        data:
+          fixed-version: 3.0.9-r0
 
-  CVE-2023-38285:
-    - timestamp: 2023-08-03T14:54:35.115332-04:00
-      status: under_investigation
-    - timestamp: 2023-08-03T19:00:01.335372-04:00
-      status: fixed
-      fixed-version: 3.0.10-r0
+  - id: CVE-2023-38285
+    events:
+      - timestamp: 2023-08-03T18:54:35Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-03T23:00:01Z
+        type: fixed
+        data:
+          fixed-version: 3.0.10-r0

--- a/ncurses.advisories.yaml
+++ b/ncurses.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: ncurses
 
 advisories:
-  CVE-2022-29458:
-    - timestamp: 2022-10-11T19:49:30+00:00
-      status: fixed
-      fixed-version: 6.3-r0
+  - id: CVE-2022-29458
+    events:
+      - timestamp: 2022-10-11T19:49:30Z
+        type: fixed
+        data:
+          fixed-version: 6.3-r0

--- a/nettle.advisories.yaml
+++ b/nettle.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: nettle
 
 advisories:
-  CVE-2021-3580:
-    - timestamp: 2023-01-15T00:21:09.333693Z
-      status: fixed
-      fixed-version: 3.8.1-r0
+  - id: CVE-2021-20305
+    events:
+      - timestamp: 2023-01-15T00:21:09Z
+        type: fixed
+        data:
+          fixed-version: 3.8.1-r0
 
-  CVE-2021-20305:
-    - timestamp: 2023-01-15T00:21:09.334893Z
-      status: fixed
-      fixed-version: 3.8.1-r0
+  - id: CVE-2021-3580
+    events:
+      - timestamp: 2023-01-15T00:21:09Z
+        type: fixed
+        data:
+          fixed-version: 3.8.1-r0

--- a/node-problem-detector.advisories.yaml
+++ b/node-problem-detector.advisories.yaml
@@ -1,95 +1,129 @@
+schema-version: "2"
+
 package:
   name: node-problem-detector
 
 advisories:
-  CVE-2019-11250:
-    - timestamp: 2023-08-11T12:35:15.52539-07:00
-      status: affected
-      action: Waiting for upstream release, fixed with PR https://github.com/kubernetes/node-problem-detector/pull/760.
-    - timestamp: 2023-08-27T16:22:34.909365-07:00
-      status: fixed
-      fixed-version: 0.8.14-r0
+  - id: CVE-2019-11250
+    events:
+      - timestamp: 2023-08-11T19:35:15Z
+        type: true-positive-determination
+        data:
+          note: Waiting for upstream release, fixed with PR https://github.com/kubernetes/node-problem-detector/pull/760.
+      - timestamp: 2023-08-27T23:22:34Z
+        type: fixed
+        data:
+          fixed-version: 0.8.14-r0
 
-  CVE-2020-8554:
-    - timestamp: 2023-08-11T11:24:18.698345-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+  - id: CVE-2020-8554
+    events:
+      - timestamp: 2023-08-11T18:24:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
-  CVE-2020-8558:
-    - timestamp: 2023-08-11T10:55:42.282825-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included k8s.io/kube-proxy library
+  - id: CVE-2020-8558
+    events:
+      - timestamp: 2023-08-11T17:55:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included k8s.io/kube-proxy library
 
-  CVE-2020-8561:
-    - timestamp: 2023-08-11T11:22:58.011256-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+  - id: CVE-2020-8561
+    events:
+      - timestamp: 2023-08-11T18:22:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
-  CVE-2020-8562:
-    - timestamp: 2023-08-11T10:57:54.984096-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+  - id: CVE-2020-8562
+    events:
+      - timestamp: 2023-08-11T17:57:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
-  CVE-2020-8564:
-    - timestamp: 2023-08-11T12:46:01.969823-07:00
-      status: affected
-      action: Pending upstream project to pick up one of k8s.io/kubernetes 0.17.13+, 0.18.10+, 0.19.3+.
-    - timestamp: 2023-08-27T16:22:08.390785-07:00
-      status: fixed
-      fixed-version: 0.8.14-r0
+  - id: CVE-2020-8564
+    events:
+      - timestamp: 2023-08-11T19:46:01Z
+        type: true-positive-determination
+        data:
+          note: Pending upstream project to pick up one of k8s.io/kubernetes 0.17.13+, 0.18.10+, 0.19.3+.
+      - timestamp: 2023-08-27T23:22:08Z
+        type: fixed
+        data:
+          fixed-version: 0.8.14-r0
 
-  CVE-2020-8565:
-    - timestamp: 2023-08-11T12:45:22.307105-07:00
-      status: affected
-      action: Pending upstream project to pick up k8s.io/kubernetes 0.19.4+.
-    - timestamp: 2023-08-27T16:51:15.477346-07:00
-      status: fixed
-      fixed-version: 0.8.14-r0
+  - id: CVE-2020-8565
+    events:
+      - timestamp: 2023-08-11T19:45:22Z
+        type: true-positive-determination
+        data:
+          note: Pending upstream project to pick up k8s.io/kubernetes 0.19.4+.
+      - timestamp: 2023-08-27T23:51:15Z
+        type: fixed
+        data:
+          fixed-version: 0.8.14-r0
 
-  CVE-2021-25735:
-    - timestamp: 2023-08-11T11:21:29.54486-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+  - id: CVE-2021-25735
+    events:
+      - timestamp: 2023-08-11T18:21:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
-  CVE-2021-25740:
-    - timestamp: 2023-08-11T11:26:56.323061-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+  - id: CVE-2021-25740
+    events:
+      - timestamp: 2023-08-11T18:26:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
-  CVE-2021-25741:
-    - timestamp: 2023-08-11T11:11:46.059396-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+  - id: CVE-2021-25741
+    events:
+      - timestamp: 2023-08-11T18:11:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
-  CVE-2023-2431:
-    - timestamp: 2023-08-11T11:14:34.193773-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+  - id: CVE-2023-2431
+    events:
+      - timestamp: 2023-08-11T18:14:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
-  CVE-2023-2727:
-    - timestamp: 2023-08-11T10:42:39.976381-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+  - id: CVE-2023-2727
+    events:
+      - timestamp: 2023-08-11T17:42:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
-  CVE-2023-2728:
-    - timestamp: 2023-08-11T10:50:53.380736-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
+  - id: CVE-2023-2728
+    events:
+      - timestamp: 2023-08-11T17:50:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
-  GHSA-74fp-r6jw-h4mp:
-    - timestamp: 2023-08-11T12:27:05.856378-07:00
-      status: affected
-      action: Waiting for upstream release, fixed with PR https://github.com/kubernetes/node-problem-detector/pull/760.
-    - timestamp: 2023-08-27T16:21:24.431686-07:00
-      status: fixed
-      fixed-version: 0.8.14-r0
+  - id: GHSA-74fp-r6jw-h4mp
+    events:
+      - timestamp: 2023-08-11T19:27:05Z
+        type: true-positive-determination
+        data:
+          note: Waiting for upstream release, fixed with PR https://github.com/kubernetes/node-problem-detector/pull/760.
+      - timestamp: 2023-08-27T23:21:24Z
+        type: fixed
+        data:
+          fixed-version: 0.8.14-r0

--- a/node-problem-detector.advisories.yaml
+++ b/node-problem-detector.advisories.yaml
@@ -13,25 +13,25 @@ advisories:
   CVE-2020-8554:
     - timestamp: 2023-08-11T11:24:18.698345-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   CVE-2020-8558:
     - timestamp: 2023-08-11T10:55:42.282825-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included k8s.io/kube-proxy library
 
   CVE-2020-8561:
     - timestamp: 2023-08-11T11:22:58.011256-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   CVE-2020-8562:
     - timestamp: 2023-08-11T10:57:54.984096-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   CVE-2020-8564:
@@ -53,37 +53,37 @@ advisories:
   CVE-2021-25735:
     - timestamp: 2023-08-11T11:21:29.54486-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   CVE-2021-25740:
     - timestamp: 2023-08-11T11:26:56.323061-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   CVE-2021-25741:
     - timestamp: 2023-08-11T11:11:46.059396-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   CVE-2023-2431:
     - timestamp: 2023-08-11T11:14:34.193773-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   CVE-2023-2727:
     - timestamp: 2023-08-11T10:42:39.976381-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   CVE-2023-2728:
     - timestamp: 2023-08-11T10:50:53.380736-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   GHSA-74fp-r6jw-h4mp:

--- a/nodejs-16.advisories.yaml
+++ b/nodejs-16.advisories.yaml
@@ -35,13 +35,13 @@ advisories:
   CVE-2023-32003:
     - timestamp: 2023-08-23T08:15:50.072854-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 16. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
   CVE-2023-32004:
     - timestamp: 2023-08-23T08:17:36.057113-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 16. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
   CVE-2023-32006:

--- a/nodejs-16.advisories.yaml
+++ b/nodejs-16.advisories.yaml
@@ -1,55 +1,77 @@
+schema-version: "2"
+
 package:
   name: nodejs-16
 
 advisories:
-  CVE-2023-30581:
-    - timestamp: 2023-06-20T13:11:00-04:00
-      status: fixed
-      fixed-version: 16.20.1-r0
+  - id: CVE-2023-30581
+    events:
+      - timestamp: 2023-06-20T17:11:00Z
+        type: fixed
+        data:
+          fixed-version: 16.20.1-r0
 
-  CVE-2023-30585:
-    - timestamp: 2023-06-20T13:11:00-04:00
-      status: fixed
-      fixed-version: 16.20.1-r0
+  - id: CVE-2023-30585
+    events:
+      - timestamp: 2023-06-20T17:11:00Z
+        type: fixed
+        data:
+          fixed-version: 16.20.1-r0
 
-  CVE-2023-30588:
-    - timestamp: 2023-06-20T13:11:00-04:00
-      status: fixed
-      fixed-version: 16.20.1-r0
+  - id: CVE-2023-30588
+    events:
+      - timestamp: 2023-06-20T17:11:00Z
+        type: fixed
+        data:
+          fixed-version: 16.20.1-r0
 
-  CVE-2023-30589:
-    - timestamp: 2023-06-20T13:11:00-04:00
-      status: fixed
-      fixed-version: 16.20.1-r0
+  - id: CVE-2023-30589
+    events:
+      - timestamp: 2023-06-20T17:11:00Z
+        type: fixed
+        data:
+          fixed-version: 16.20.1-r0
 
-  CVE-2023-30590:
-    - timestamp: 2023-06-20T13:11:00-04:00
-      status: fixed
-      fixed-version: 16.20.1-r0
+  - id: CVE-2023-30590
+    events:
+      - timestamp: 2023-06-20T17:11:00Z
+        type: fixed
+        data:
+          fixed-version: 16.20.1-r0
 
-  CVE-2023-32002:
-    - timestamp: 2023-08-10T08:00:44.454427-04:00
-      status: fixed
-      fixed-version: 16.20.2-r0
+  - id: CVE-2023-32002
+    events:
+      - timestamp: 2023-08-10T12:00:44Z
+        type: fixed
+        data:
+          fixed-version: 16.20.2-r0
 
-  CVE-2023-32003:
-    - timestamp: 2023-08-23T08:15:50.072854-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 16. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
+  - id: CVE-2023-32003
+    events:
+      - timestamp: 2023-08-23T15:15:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 16. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
-  CVE-2023-32004:
-    - timestamp: 2023-08-23T08:17:36.057113-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 16. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
+  - id: CVE-2023-32004
+    events:
+      - timestamp: 2023-08-23T15:17:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 16. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
-  CVE-2023-32006:
-    - timestamp: 2023-08-10T08:00:44.454427-04:00
-      status: fixed
-      fixed-version: 16.20.2-r0
+  - id: CVE-2023-32006
+    events:
+      - timestamp: 2023-08-10T12:00:44Z
+        type: fixed
+        data:
+          fixed-version: 16.20.2-r0
 
-  CVE-2023-32559:
-    - timestamp: 2023-08-10T08:00:44.454427-04:00
-      status: fixed
-      fixed-version: 16.20.2-r0
+  - id: CVE-2023-32559
+    events:
+      - timestamp: 2023-08-10T12:00:44Z
+        type: fixed
+        data:
+          fixed-version: 16.20.2-r0

--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -35,13 +35,13 @@ advisories:
   CVE-2023-32003:
     - timestamp: 2023-08-23T08:18:24.79314-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 18. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
   CVE-2023-32004:
     - timestamp: 2023-08-23T08:18:42.902151-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 18. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
   CVE-2023-32006:

--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -1,55 +1,77 @@
+schema-version: "2"
+
 package:
   name: nodejs-18
 
 advisories:
-  CVE-2023-30581:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 18.16.1-r0
+  - id: CVE-2023-30581
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 18.16.1-r0
 
-  CVE-2023-30585:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 18.16.1-r0
+  - id: CVE-2023-30585
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 18.16.1-r0
 
-  CVE-2023-30588:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 18.16.1-r0
+  - id: CVE-2023-30588
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 18.16.1-r0
 
-  CVE-2023-30589:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 18.16.1-r0
+  - id: CVE-2023-30589
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 18.16.1-r0
 
-  CVE-2023-30590:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 18.16.1-r0
+  - id: CVE-2023-30590
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 18.16.1-r0
 
-  CVE-2023-32002:
-    - timestamp: 2023-08-10T08:00:44.454427-04:00
-      status: fixed
-      fixed-version: 18.17.1-r0
+  - id: CVE-2023-32002
+    events:
+      - timestamp: 2023-08-10T12:00:44Z
+        type: fixed
+        data:
+          fixed-version: 18.17.1-r0
 
-  CVE-2023-32003:
-    - timestamp: 2023-08-23T08:18:24.79314-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 18. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
+  - id: CVE-2023-32003
+    events:
+      - timestamp: 2023-08-23T15:18:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 18. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
-  CVE-2023-32004:
-    - timestamp: 2023-08-23T08:18:42.902151-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 18. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
+  - id: CVE-2023-32004
+    events:
+      - timestamp: 2023-08-23T15:18:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 18. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
-  CVE-2023-32006:
-    - timestamp: 2023-08-10T08:00:44.454427-04:00
-      status: fixed
-      fixed-version: 18.17.1-r0
+  - id: CVE-2023-32006
+    events:
+      - timestamp: 2023-08-10T12:00:44Z
+        type: fixed
+        data:
+          fixed-version: 18.17.1-r0
 
-  CVE-2023-32559:
-    - timestamp: 2023-08-10T08:00:44.454427-04:00
-      status: fixed
-      fixed-version: 18.17.1-r0
+  - id: CVE-2023-32559
+    events:
+      - timestamp: 2023-08-10T12:00:44Z
+        type: fixed
+        data:
+          fixed-version: 18.17.1-r0

--- a/nodejs-19.advisories.yaml
+++ b/nodejs-19.advisories.yaml
@@ -5,11 +5,11 @@ advisories:
   CVE-2023-32003:
     - timestamp: 2023-08-23T08:22:45.087919-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 19. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
   CVE-2023-32004:
     - timestamp: 2023-08-23T08:23:06.841405-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 19. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'

--- a/nodejs-19.advisories.yaml
+++ b/nodejs-19.advisories.yaml
@@ -1,15 +1,21 @@
+schema-version: "2"
+
 package:
   name: nodejs-19
 
 advisories:
-  CVE-2023-32003:
-    - timestamp: 2023-08-23T08:22:45.087919-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 19. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
+  - id: CVE-2023-32003
+    events:
+      - timestamp: 2023-08-23T15:22:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 19. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
-  CVE-2023-32004:
-    - timestamp: 2023-08-23T08:23:06.841405-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 19. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
+  - id: CVE-2023-32004
+    events:
+      - timestamp: 2023-08-23T15:23:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 19. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'

--- a/nodejs-20.advisories.yaml
+++ b/nodejs-20.advisories.yaml
@@ -1,78 +1,110 @@
+schema-version: "2"
+
 package:
   name: nodejs-20
 
 advisories:
-  CVE-2023-30581:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 20.3.1-r0
+  - id: CVE-2023-30581
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 20.3.1-r0
 
-  CVE-2023-30582:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 20.3.1-r0
+  - id: CVE-2023-30582
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 20.3.1-r0
 
-  CVE-2023-30583:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 20.3.1-r0
+  - id: CVE-2023-30583
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 20.3.1-r0
 
-  CVE-2023-30584:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 20.3.1-r0
+  - id: CVE-2023-30584
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 20.3.1-r0
 
-  CVE-2023-30585:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 20.3.1-r0
+  - id: CVE-2023-30585
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 20.3.1-r0
 
-  CVE-2023-30586:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 20.3.1-r0
+  - id: CVE-2023-30586
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 20.3.1-r0
 
-  CVE-2023-30587:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 20.3.1-r0
+  - id: CVE-2023-30587
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 20.3.1-r0
 
-  CVE-2023-30588:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 20.3.1-r0
+  - id: CVE-2023-30588
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 20.3.1-r0
 
-  CVE-2023-30589:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 20.3.1-r0
+  - id: CVE-2023-30589
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 20.3.1-r0
 
-  CVE-2023-30590:
-    - timestamp: 2023-06-20T15:07:00-04:00
-      status: fixed
-      fixed-version: 20.3.1-r0
+  - id: CVE-2023-30590
+    events:
+      - timestamp: 2023-06-20T19:07:00Z
+        type: fixed
+        data:
+          fixed-version: 20.3.1-r0
 
-  CVE-2023-32002:
-    - timestamp: 2023-08-10T08:00:44.454427-04:00
-      status: fixed
-      fixed-version: 20.5.1-r0
+  - id: CVE-2023-32002
+    events:
+      - timestamp: 2023-08-10T12:00:44Z
+        type: fixed
+        data:
+          fixed-version: 20.5.1-r0
 
-  CVE-2023-32003:
-    - timestamp: 2023-08-23T08:33:03.425649-07:00
-      status: fixed
-      fixed-version: 20.5.1-r0
+  - id: CVE-2023-32003
+    events:
+      - timestamp: 2023-08-23T15:33:03Z
+        type: fixed
+        data:
+          fixed-version: 20.5.1-r0
 
-  CVE-2023-32004:
-    - timestamp: 2023-08-23T08:33:23.722095-07:00
-      status: fixed
-      fixed-version: 20.5.1-r0
+  - id: CVE-2023-32004
+    events:
+      - timestamp: 2023-08-23T15:33:23Z
+        type: fixed
+        data:
+          fixed-version: 20.5.1-r0
 
-  CVE-2023-32006:
-    - timestamp: 2023-08-10T08:00:44.454427-04:00
-      status: fixed
-      fixed-version: 20.5.1-r0
+  - id: CVE-2023-32006
+    events:
+      - timestamp: 2023-08-10T12:00:44Z
+        type: fixed
+        data:
+          fixed-version: 20.5.1-r0
 
-  CVE-2023-32559:
-    - timestamp: 2023-08-10T08:00:44.454427-04:00
-      status: fixed
-      fixed-version: 20.5.1-r0
+  - id: CVE-2023-32559
+    events:
+      - timestamp: 2023-08-10T12:00:44Z
+        type: fixed
+        data:
+          fixed-version: 20.5.1-r0

--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -1,57 +1,77 @@
+schema-version: "2"
+
 package:
   name: nodetaint
 
 advisories:
-  CVE-2019-11255:
-    - timestamp: 2023-08-11T10:53:13.239852-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: Vuln only present in Kubernets CSI sidecars external-provisioner, external-snapshotter, external-resizer
+  - id: CVE-2019-11255
+    events:
+      - timestamp: 2023-08-11T17:53:13Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Vuln only present in Kubernets CSI sidecars external-provisioner, external-snapshotter, external-resizer
 
-  CVE-2020-8554:
-    - timestamp: 2023-08-11T11:25:13.728152-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This is a Kubernetes API flaw, but we don't include an API server in this package.
+  - id: CVE-2020-8554
+    events:
+      - timestamp: 2023-08-11T18:25:13Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This is a Kubernetes API flaw, but we don't include an API server in this package.
 
-  CVE-2020-8561:
-    - timestamp: 2023-08-11T12:02:42.993043-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This only affects kube-apiserver logs, and code was marked NOT_IMPORTABLE in Golang vulndb
+  - id: CVE-2020-8561
+    events:
+      - timestamp: 2023-08-11T19:02:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This only affects kube-apiserver logs, and code was marked NOT_IMPORTABLE in Golang vulndb
 
-  CVE-2020-8564:
-    - timestamp: 2023-08-11T12:22:26.031395-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: This does not affect k8s.io/client-go@v0.20.0-alpha.2
+  - id: CVE-2020-8564
+    events:
+      - timestamp: 2023-08-11T19:22:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This does not affect k8s.io/client-go@v0.20.0-alpha.2
 
-  CVE-2020-8565:
-    - timestamp: 2023-08-11T12:17:00.292793-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: This does not affect k8s.io/client-go@v0.20.0-alpha.2
+  - id: CVE-2020-8565
+    events:
+      - timestamp: 2023-08-11T19:17:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This does not affect k8s.io/client-go@v0.20.0-alpha.2
 
-  CVE-2021-25740:
-    - timestamp: 2023-08-11T11:11:11.384955-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This only affects Kubernetes itself, and code was marked not importable in Golang vulndb
+  - id: CVE-2021-25740
+    events:
+      - timestamp: 2023-08-11T18:11:11Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This only affects Kubernetes itself, and code was marked not importable in Golang vulndb
 
-  CVE-2023-2431:
-    - timestamp: 2023-08-11T11:16:32.997948-07:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: This bug affects Kubelet, which isn't in nodetaint -- also Golang vulndb marked as EFFECTIVELY_PRIVATE
+  - id: CVE-2023-2431
+    events:
+      - timestamp: 2023-08-11T18:16:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This bug affects Kubelet, which isn't in nodetaint -- also Golang vulndb marked as EFFECTIVELY_PRIVATE
 
-  CVE-2023-2727:
-    - timestamp: 2023-08-11T11:58:45.324372-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This is only affecting Kubernetes, and was also mark NOT_IMPORTABLE in Golang vulndb
+  - id: CVE-2023-2727
+    events:
+      - timestamp: 2023-08-11T18:58:45Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This is only affecting Kubernetes, and was also mark NOT_IMPORTABLE in Golang vulndb
 
-  CVE-2023-2728:
-    - timestamp: 2023-08-11T12:05:59.729557-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This only impacts Kubernetes itself, and was also marked NOT_IMPORTABLE by Golang vulndb
+  - id: CVE-2023-2728
+    events:
+      - timestamp: 2023-08-11T19:05:59Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This only impacts Kubernetes itself, and was also marked NOT_IMPORTABLE by Golang vulndb

--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -17,19 +17,19 @@ advisories:
   CVE-2020-8561:
     - timestamp: 2023-08-11T12:02:42.993043-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This only affects kube-apiserver logs, and code was marked NOT_IMPORTABLE in Golang vulndb
 
   CVE-2020-8564:
     - timestamp: 2023-08-11T12:22:26.031395-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: This does not affect k8s.io/client-go@v0.20.0-alpha.2
 
   CVE-2020-8565:
     - timestamp: 2023-08-11T12:17:00.292793-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: This does not affect k8s.io/client-go@v0.20.0-alpha.2
 
   CVE-2021-25740:

--- a/oauth2-proxy.advisories.yaml
+++ b/oauth2-proxy.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: oauth2-proxy
 
 advisories:
-  GHSA-vvpx-j8f3-3w6h:
-    - timestamp: 2023-04-17T15:30:27.323339903-06:00
-      status: fixed
-      fixed-version: 7.4.0-r0
+  - id: GHSA-vvpx-j8f3-3w6h
+    events:
+      - timestamp: 2023-04-17T21:30:27Z
+        type: fixed
+        data:
+          fixed-version: 7.4.0-r0

--- a/openai.advisories.yaml
+++ b/openai.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: openai
 
 advisories:
-  CVE-2023-37276:
-    - timestamp: 2023-08-10T14:58:35.706092-04:00
-      status: fixed
-      fixed-version: 0.27.8-r1
+  - id: CVE-2023-37276
+    events:
+      - timestamp: 2023-08-10T18:58:35Z
+        type: fixed
+        data:
+          fixed-version: 0.27.8-r1
 
-  CVE-2023-37920:
-    - timestamp: 2023-08-10T14:58:59.293747-04:00
-      status: fixed
-      fixed-version: 0.27.8-r1
+  - id: CVE-2023-37920
+    events:
+      - timestamp: 2023-08-10T18:58:59Z
+        type: fixed
+        data:
+          fixed-version: 0.27.8-r1

--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2023-21968:
     - timestamp: 2023-08-11T16:23:47.720726-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: The vulnerability was patched upstream in 362, prior to Wolfi packaging.

--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: openjdk-8
 
 advisories:
-  CVE-2023-21968:
-    - timestamp: 2023-08-11T16:23:47.720726-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: The vulnerability was patched upstream in 362, prior to Wolfi packaging.
+  - id: CVE-2023-21968
+    events:
+      - timestamp: 2023-08-11T20:23:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability was patched upstream in 362, prior to Wolfi packaging.

--- a/opensearch-2.advisories.yaml
+++ b/opensearch-2.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: opensearch-2
 
 advisories:
-  CVE-2023-35116:
-    - timestamp: 2023-08-11T16:28:34.348667-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: CVE disputed by upstream developers, nothing specific to this application.
+  - id: CVE-2023-35116
+    events:
+      - timestamp: 2023-08-11T20:28:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE disputed by upstream developers, nothing specific to this application.

--- a/opensearch-2.advisories.yaml
+++ b/opensearch-2.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2023-35116:
     - timestamp: 2023-08-11T16:28:34.348667-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: CVE disputed by upstream developers, nothing specific to this application.

--- a/openssh.advisories.yaml
+++ b/openssh.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: openssh
 
 advisories:
-  CVE-2023-25136:
-    - timestamp: 2023-02-06T13:39:35.322093-05:00
-      status: fixed
-      fixed-version: 9.2_p1-r0
+  - id: CVE-2023-25136
+    events:
+      - timestamp: 2023-02-06T18:39:35Z
+        type: fixed
+        data:
+          fixed-version: 9.2_p1-r0
 
-  CVE-2023-38408:
-    - timestamp: 2023-07-19T11:06:22.022093-05:00
-      status: fixed
-      fixed-version: 9.3_p2-r0
+  - id: CVE-2023-38408
+    events:
+      - timestamp: 2023-07-19T16:06:22Z
+        type: fixed
+        data:
+          fixed-version: 9.3_p2-r0

--- a/openssl.advisories.yaml
+++ b/openssl.advisories.yaml
@@ -1,104 +1,146 @@
+schema-version: "2"
+
 package:
   name: openssl
 
 advisories:
-  CVE-2022-3358:
-    - timestamp: 2022-11-01T16:49:56Z
-      status: fixed
-      fixed-version: 3.0.7-r0
+  - id: CVE-2022-3358
+    events:
+      - timestamp: 2022-11-01T16:49:56Z
+        type: fixed
+        data:
+          fixed-version: 3.0.7-r0
 
-  CVE-2022-3602:
-    - timestamp: 2022-11-01T16:49:56Z
-      status: fixed
-      fixed-version: 3.0.7-r0
+  - id: CVE-2022-3602
+    events:
+      - timestamp: 2022-11-01T16:49:56Z
+        type: fixed
+        data:
+          fixed-version: 3.0.7-r0
 
-  CVE-2022-3786:
-    - timestamp: 2022-11-01T16:49:56Z
-      status: fixed
-      fixed-version: 3.0.7-r0
+  - id: CVE-2022-3786
+    events:
+      - timestamp: 2022-11-01T16:49:56Z
+        type: fixed
+        data:
+          fixed-version: 3.0.7-r0
 
-  CVE-2022-3996:
-    - timestamp: 2022-12-22T17:26:45Z
-      status: fixed
-      fixed-version: 3.0.7-r1
+  - id: CVE-2022-3996
+    events:
+      - timestamp: 2022-12-22T17:26:45Z
+        type: fixed
+        data:
+          fixed-version: 3.0.7-r1
 
-  CVE-2022-4203:
-    - timestamp: 2023-02-07T11:50:00.020081-05:00
-      status: fixed
-      fixed-version: 3.0.8-r0
+  - id: CVE-2022-4203
+    events:
+      - timestamp: 2023-02-07T16:50:00Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
 
-  CVE-2022-4304:
-    - timestamp: 2023-02-07T11:49:50.211721-05:00
-      status: fixed
-      fixed-version: 3.0.8-r0
+  - id: CVE-2022-4304
+    events:
+      - timestamp: 2023-02-07T16:49:50Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
 
-  CVE-2022-4450:
-    - timestamp: 2023-02-07T11:50:17.798241-05:00
-      status: fixed
-      fixed-version: 3.0.8-r0
+  - id: CVE-2022-4450
+    events:
+      - timestamp: 2023-02-07T16:50:17Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
 
-  CVE-2023-0215:
-    - timestamp: 2023-02-07T11:50:08.401769-05:00
-      status: fixed
-      fixed-version: 3.0.8-r0
+  - id: CVE-2023-0215
+    events:
+      - timestamp: 2023-02-07T16:50:08Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
 
-  CVE-2023-0216:
-    - timestamp: 2023-02-07T11:50:29.806824-05:00
-      status: fixed
-      fixed-version: 3.0.8-r0
+  - id: CVE-2023-0216
+    events:
+      - timestamp: 2023-02-07T16:50:29Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
 
-  CVE-2023-0217:
-    - timestamp: 2023-02-07T11:50:39.207629-05:00
-      status: fixed
-      fixed-version: 3.0.8-r0
+  - id: CVE-2023-0217
+    events:
+      - timestamp: 2023-02-07T16:50:39Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
 
-  CVE-2023-0286:
-    - timestamp: 2023-02-07T11:49:30.049397-05:00
-      status: fixed
-      fixed-version: 3.0.8-r0
+  - id: CVE-2023-0286
+    events:
+      - timestamp: 2023-02-07T16:49:30Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
 
-  CVE-2023-0401:
-    - timestamp: 2023-02-07T11:50:53.191261-05:00
-      status: fixed
-      fixed-version: 3.0.8-r0
+  - id: CVE-2023-0401
+    events:
+      - timestamp: 2023-02-07T16:50:53Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
 
-  CVE-2023-0464:
-    - timestamp: 2023-03-23T02:31:00.664255-07:00
-      status: fixed
-      fixed-version: 3.1.0-r1
+  - id: CVE-2023-0464
+    events:
+      - timestamp: 2023-03-23T09:31:00Z
+        type: fixed
+        data:
+          fixed-version: 3.1.0-r1
 
-  CVE-2023-0465:
-    - timestamp: 2023-03-28T07:54:27.093515-07:00
-      status: fixed
-      fixed-version: 3.1.0-r2
+  - id: CVE-2023-0465
+    events:
+      - timestamp: 2023-03-28T14:54:27Z
+        type: fixed
+        data:
+          fixed-version: 3.1.0-r2
 
-  CVE-2023-0466:
-    - timestamp: 2023-04-08T12:32:54.797413-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This was a case of documentation not matching function behavior. The upstream maintainers decided to update the documentation rather than change the behavior. See https://www.openssl.org/news/secadv/20230328.txt
+  - id: CVE-2023-0466
+    events:
+      - timestamp: 2023-04-08T16:32:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This was a case of documentation not matching function behavior. The upstream maintainers decided to update the documentation rather than change the behavior. See https://www.openssl.org/news/secadv/20230328.txt
 
-  CVE-2023-1255:
-    - timestamp: 2023-04-20T09:29:24.558074-07:00
-      status: fixed
-      fixed-version: 3.1.0-r5
+  - id: CVE-2023-1255
+    events:
+      - timestamp: 2023-04-20T16:29:24Z
+        type: fixed
+        data:
+          fixed-version: 3.1.0-r5
 
-  CVE-2023-2650:
-    - timestamp: 2023-05-30T11:31:01.558074-05:00
-      status: fixed
-      fixed-version: 3.1.1-r0
+  - id: CVE-2023-2650
+    events:
+      - timestamp: 2023-05-30T16:31:01Z
+        type: fixed
+        data:
+          fixed-version: 3.1.1-r0
 
-  CVE-2023-2975:
-    - timestamp: 2023-07-17T14:45:05.099165-07:00
-      status: fixed
-      fixed-version: 3.1.1-r2
+  - id: CVE-2023-2975
+    events:
+      - timestamp: 2023-07-17T21:45:05Z
+        type: fixed
+        data:
+          fixed-version: 3.1.1-r2
 
-  CVE-2023-3446:
-    - timestamp: 2023-07-19T10:06:50.88984-07:00
-      status: fixed
-      fixed-version: 3.1.1-r3
+  - id: CVE-2023-3446
+    events:
+      - timestamp: 2023-07-19T17:06:50Z
+        type: fixed
+        data:
+          fixed-version: 3.1.1-r3
 
-  CVE-2023-3817:
-    - timestamp: 2023-07-31T14:46:13.337282-07:00
-      status: fixed
-      fixed-version: 3.1.1-r4
+  - id: CVE-2023-3817
+    events:
+      - timestamp: 2023-07-31T21:46:13Z
+        type: fixed
+        data:
+          fixed-version: 3.1.1-r4

--- a/openssl.advisories.yaml
+++ b/openssl.advisories.yaml
@@ -75,7 +75,7 @@ advisories:
   CVE-2023-0466:
     - timestamp: 2023-04-08T12:32:54.797413-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This was a case of documentation not matching function behavior. The upstream maintainers decided to update the documentation rather than change the behavior. See https://www.openssl.org/news/secadv/20230328.txt
 
   CVE-2023-1255:

--- a/orc.advisories.yaml
+++ b/orc.advisories.yaml
@@ -1,11 +1,17 @@
+schema-version: "2"
+
 package:
   name: orc
 
 advisories:
-  CVE-2018-8015:
-    - timestamp: 2023-07-01T06:54:08.255397-04:00
-      status: under_investigation
-    - timestamp: 2023-07-01T06:57:44.168849-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: The vulnerability applies to Apache ORC, not the ORC compiler. These are different projects.
+  - id: CVE-2018-8015
+    events:
+      - timestamp: 2023-07-01T10:54:08Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-07-01T10:57:44Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The vulnerability applies to Apache ORC, not the ORC compiler. These are different projects.

--- a/patch.advisories.yaml
+++ b/patch.advisories.yaml
@@ -1,38 +1,54 @@
+schema-version: "2"
+
 package:
   name: patch
 
 advisories:
-  CVE-2018-6951:
-    - timestamp: 2022-09-28T12:06:03+01:00
-      status: fixed
-      fixed-version: 2.7.6-r3
+  - id: CVE-2018-1000156
+    events:
+      - timestamp: 2022-09-28T11:06:03Z
+        type: fixed
+        data:
+          fixed-version: 2.7.6-r3
 
-  CVE-2018-6952:
-    - timestamp: 2022-09-28T12:06:03+01:00
-      status: fixed
-      fixed-version: 2.7.6-r3
+  - id: CVE-2018-20969
+    events:
+      - timestamp: 2022-09-28T11:06:03Z
+        type: fixed
+        data:
+          fixed-version: 2.7.6-r3
 
-  CVE-2018-20969:
-    - timestamp: 2022-09-28T12:06:03+01:00
-      status: fixed
-      fixed-version: 2.7.6-r3
+  - id: CVE-2018-6951
+    events:
+      - timestamp: 2022-09-28T11:06:03Z
+        type: fixed
+        data:
+          fixed-version: 2.7.6-r3
 
-  CVE-2018-1000156:
-    - timestamp: 2022-09-28T12:06:03+01:00
-      status: fixed
-      fixed-version: 2.7.6-r3
+  - id: CVE-2018-6952
+    events:
+      - timestamp: 2022-09-28T11:06:03Z
+        type: fixed
+        data:
+          fixed-version: 2.7.6-r3
 
-  CVE-2019-13636:
-    - timestamp: 2022-09-28T12:06:03+01:00
-      status: fixed
-      fixed-version: 2.7.6-r3
+  - id: CVE-2019-13636
+    events:
+      - timestamp: 2022-09-28T11:06:03Z
+        type: fixed
+        data:
+          fixed-version: 2.7.6-r3
 
-  CVE-2019-13638:
-    - timestamp: 2022-09-28T12:06:03+01:00
-      status: fixed
-      fixed-version: 2.7.6-r3
+  - id: CVE-2019-13638
+    events:
+      - timestamp: 2022-09-28T11:06:03Z
+        type: fixed
+        data:
+          fixed-version: 2.7.6-r3
 
-  CVE-2019-20633:
-    - timestamp: 2022-09-28T12:06:03+01:00
-      status: fixed
-      fixed-version: 2.7.6-r3
+  - id: CVE-2019-20633
+    events:
+      - timestamp: 2022-09-28T11:06:03Z
+        type: fixed
+        data:
+          fixed-version: 2.7.6-r3

--- a/pcre2.advisories.yaml
+++ b/pcre2.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: pcre2
 
 advisories:
-  CVE-2022-1586:
-    - timestamp: 2022-09-20T11:15:38+00:00
-      status: fixed
-      fixed-version: 10.40-r0
+  - id: CVE-2022-1586
+    events:
+      - timestamp: 2022-09-20T11:15:38Z
+        type: fixed
+        data:
+          fixed-version: 10.40-r0
 
-  CVE-2022-1587:
-    - timestamp: 2022-09-20T11:15:38+00:00
-      status: fixed
-      fixed-version: 10.40-r0
+  - id: CVE-2022-1587
+    events:
+      - timestamp: 2022-09-20T11:15:38Z
+        type: fixed
+        data:
+          fixed-version: 10.40-r0

--- a/php.advisories.yaml
+++ b/php.advisories.yaml
@@ -5,17 +5,17 @@ advisories:
   CVE-2007-2728:
     - timestamp: 2023-02-16T11:01:48.943749-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
 
   CVE-2007-3205:
     - timestamp: 2023-02-16T11:01:59.241092-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
 
   CVE-2007-4596:
     - timestamp: 2023-02-16T11:02:05.863326-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
 
   CVE-2015-3211:
     - timestamp: 2023-08-11T15:45:28.979618-07:00

--- a/php.advisories.yaml
+++ b/php.advisories.yaml
@@ -1,41 +1,57 @@
+schema-version: "2"
+
 package:
   name: php
 
 advisories:
-  CVE-2007-2728:
-    - timestamp: 2023-02-16T11:01:48.943749-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
+  - id: CVE-2007-2728
+    events:
+      - timestamp: 2023-02-16T16:01:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
 
-  CVE-2007-3205:
-    - timestamp: 2023-02-16T11:01:59.241092-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
+  - id: CVE-2007-3205
+    events:
+      - timestamp: 2023-02-16T16:01:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
 
-  CVE-2007-4596:
-    - timestamp: 2023-02-16T11:02:05.863326-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
+  - id: CVE-2007-4596
+    events:
+      - timestamp: 2023-02-16T16:02:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
 
-  CVE-2015-3211:
-    - timestamp: 2023-08-11T15:45:28.979618-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This is a packaging defect specific to the php-fpm package included in RHEL.  The Wolfi php-fpm package does not include this defect.
+  - id: CVE-2015-3211
+    events:
+      - timestamp: 2023-08-11T22:45:28Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This is a packaging defect specific to the php-fpm package included in RHEL.  The Wolfi php-fpm package does not include this defect.
 
-  CVE-2017-6485:
-    - timestamp: 2023-08-11T15:49:50.193085-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This CVE targets a PHP-based web application called "PHP Calendar," and is unrelated to the PHP calendar extension.
+  - id: CVE-2017-6485
+    events:
+      - timestamp: 2023-08-11T22:49:50Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This CVE targets a PHP-based web application called "PHP Calendar," and is unrelated to the PHP calendar extension.
 
-  CVE-2022-4455:
-    - timestamp: 2023-08-11T15:50:45.763846-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This CVE targets a PHP-based web application called "PHP Calendar," and is unrelated to the PHP calendar extension.
+  - id: CVE-2022-31630
+    events:
+      - timestamp: 2023-02-12T01:12:25Z
+        type: fixed
+        data:
+          fixed-version: 8.1.13-r0
 
-  CVE-2022-31630:
-    - timestamp: 2023-02-11T20:12:25.988296-05:00
-      status: fixed
-      fixed-version: 8.1.13-r0
+  - id: CVE-2022-4455
+    events:
+      - timestamp: 2023-08-11T22:50:45Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This CVE targets a PHP-based web application called "PHP Calendar," and is unrelated to the PHP calendar extension.

--- a/pixman.advisories.yaml
+++ b/pixman.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: pixman
 
 advisories:
-  CVE-2023-37769:
-    - timestamp: 2023-08-11T15:29:36.629482-07:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: This CVE was reported against a test program which is explicitly designed to fail.  Upstream plans to dispute it.  https://gitlab.freedesktop.org/pixman/pixman/-/issues/76#note_2016420
+  - id: CVE-2023-37769
+    events:
+      - timestamp: 2023-08-11T22:29:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This CVE was reported against a test program which is explicitly designed to fail.  Upstream plans to dispute it.  https://gitlab.freedesktop.org/pixman/pixman/-/issues/76#note_2016420

--- a/pkgconf.advisories.yaml
+++ b/pkgconf.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: pkgconf
 
 advisories:
-  CVE-2023-24056:
-    - timestamp: 2023-01-22T05:08:29.956723119Z
-      status: fixed
-      fixed-version: 1.9.4-r0
+  - id: CVE-2023-24056
+    events:
+      - timestamp: 2023-01-22T05:08:29Z
+        type: fixed
+        data:
+          fixed-version: 1.9.4-r0

--- a/postgresql-11.advisories.yaml
+++ b/postgresql-11.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2017-8806:
     - timestamp: 2023-05-03T13:58:34.261264-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: This CVE appears to impact only Debian/Ubuntu.

--- a/postgresql-11.advisories.yaml
+++ b/postgresql-11.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: postgresql-11
 
 advisories:
-  CVE-2017-8806:
-    - timestamp: 2023-05-03T13:58:34.261264-04:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: This CVE appears to impact only Debian/Ubuntu.
+  - id: CVE-2017-8806
+    events:
+      - timestamp: 2023-05-03T17:58:34Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This CVE appears to impact only Debian/Ubuntu.

--- a/postgresql-12.advisories.yaml
+++ b/postgresql-12.advisories.yaml
@@ -1,15 +1,21 @@
+schema-version: "2"
+
 package:
   name: postgresql-12
 
 advisories:
-  CVE-2017-8806:
-    - timestamp: 2023-05-03T13:58:26.329535-04:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: This CVE appears to impact only Debian/Ubuntu.
+  - id: CVE-2017-8806
+    events:
+      - timestamp: 2023-05-03T17:58:26Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This CVE appears to impact only Debian/Ubuntu.
 
-  CVE-2020-21469:
-    - timestamp: 2023-08-29T18:47:14.7929-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: Sanity dictates (and the maintainers agree) that this is neither a vulnerability nor a bug. https://www.postgresql.org/about/news/cve-2020-21469-is-not-a-security-vulnerability-2701/
+  - id: CVE-2020-21469
+    events:
+      - timestamp: 2023-08-29T22:47:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: Sanity dictates (and the maintainers agree) that this is neither a vulnerability nor a bug. https://www.postgresql.org/about/news/cve-2020-21469-is-not-a-security-vulnerability-2701/

--- a/postgresql-12.advisories.yaml
+++ b/postgresql-12.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2017-8806:
     - timestamp: 2023-05-03T13:58:26.329535-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: This CVE appears to impact only Debian/Ubuntu.
 
   CVE-2020-21469:

--- a/postgresql-12.advisories.yaml
+++ b/postgresql-12.advisories.yaml
@@ -11,5 +11,5 @@ advisories:
   CVE-2020-21469:
     - timestamp: 2023-08-29T18:47:14.7929-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: Sanity dictates (and the maintainers agree) that this is neither a vulnerability nor a bug. https://www.postgresql.org/about/news/cve-2020-21469-is-not-a-security-vulnerability-2701/

--- a/postgresql-13.advisories.yaml
+++ b/postgresql-13.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2017-8806:
     - timestamp: 2023-05-03T13:58:22.118734-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: This CVE appears to impact only Debian/Ubuntu.

--- a/postgresql-13.advisories.yaml
+++ b/postgresql-13.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: postgresql-13
 
 advisories:
-  CVE-2017-8806:
-    - timestamp: 2023-05-03T13:58:22.118734-04:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: This CVE appears to impact only Debian/Ubuntu.
+  - id: CVE-2017-8806
+    events:
+      - timestamp: 2023-05-03T17:58:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This CVE appears to impact only Debian/Ubuntu.

--- a/postgresql-14.advisories.yaml
+++ b/postgresql-14.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2017-8806:
     - timestamp: 2023-05-03T13:58:17.082446-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: This CVE appears to impact only Debian/Ubuntu.

--- a/postgresql-14.advisories.yaml
+++ b/postgresql-14.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: postgresql-14
 
 advisories:
-  CVE-2017-8806:
-    - timestamp: 2023-05-03T13:58:17.082446-04:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: This CVE appears to impact only Debian/Ubuntu.
+  - id: CVE-2017-8806
+    events:
+      - timestamp: 2023-05-03T17:58:17Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This CVE appears to impact only Debian/Ubuntu.

--- a/postgresql-15.advisories.yaml
+++ b/postgresql-15.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2017-8806:
     - timestamp: 2022-11-03T12:41:55Z
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: This CVE appears to impact only Debian/Ubuntu.
 
   CVE-2022-41862:

--- a/postgresql-15.advisories.yaml
+++ b/postgresql-15.advisories.yaml
@@ -1,14 +1,20 @@
+schema-version: "2"
+
 package:
   name: postgresql-15
 
 advisories:
-  CVE-2017-8806:
-    - timestamp: 2022-11-03T12:41:55Z
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: This CVE appears to impact only Debian/Ubuntu.
+  - id: CVE-2017-8806
+    events:
+      - timestamp: 2022-11-03T12:41:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This CVE appears to impact only Debian/Ubuntu.
 
-  CVE-2022-41862:
-    - timestamp: 2023-03-19T17:21:53.344464-04:00
-      status: fixed
-      fixed-version: 15.2-r0
+  - id: CVE-2022-41862
+    events:
+      - timestamp: 2023-03-19T21:21:53Z
+        type: fixed
+        data:
+          fixed-version: 15.2-r0

--- a/prometheus-alertmanager.advisories.yaml
+++ b/prometheus-alertmanager.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: prometheus-alertmanager
 
 advisories:
-  CVE-2023-40577:
-    - timestamp: 2023-08-25T13:39:59.197573-07:00
-      status: fixed
-      fixed-version: 0.26.0-r0
+  - id: CVE-2023-40577
+    events:
+      - timestamp: 2023-08-25T20:39:59Z
+        type: fixed
+        data:
+          fixed-version: 0.26.0-r0

--- a/prometheus-config-reloader.advisories.yaml
+++ b/prometheus-config-reloader.advisories.yaml
@@ -11,5 +11,5 @@ advisories:
   CVE-2023-40577:
     - timestamp: 2023-08-25T13:47:31.328914-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.

--- a/prometheus-config-reloader.advisories.yaml
+++ b/prometheus-config-reloader.advisories.yaml
@@ -1,15 +1,21 @@
+schema-version: "2"
+
 package:
   name: prometheus-config-reloader
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-11T14:17:56.238481-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: This CVE only impacts prometheus 2.7 but our prometheus-config-reloader is using v0.46.0 Go library which is in fact prometheus 2.46
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-11T21:17:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE only impacts prometheus 2.7 but our prometheus-config-reloader is using v0.46.0 Go library which is in fact prometheus 2.46
 
-  CVE-2023-40577:
-    - timestamp: 2023-08-25T13:47:31.328914-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.
+  - id: CVE-2023-40577
+    events:
+      - timestamp: 2023-08-25T20:47:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.

--- a/prometheus-config-reloader.advisories.yaml
+++ b/prometheus-config-reloader.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2019-3826:
     - timestamp: 2023-08-11T14:17:56.238481-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: This CVE only impacts prometheus 2.7 but our prometheus-config-reloader is using v0.46.0 Go library which is in fact prometheus 2.46
 
   CVE-2023-40577:

--- a/prometheus-operator.advisories.yaml
+++ b/prometheus-operator.advisories.yaml
@@ -11,5 +11,5 @@ advisories:
   CVE-2023-40577:
     - timestamp: 2023-08-25T13:47:54.188231-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.

--- a/prometheus-operator.advisories.yaml
+++ b/prometheus-operator.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2019-3826:
     - timestamp: 2023-08-11T14:13:07.826089-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: This CVE only impacts prometheus 2.7 but our prometheus-operator is using v0.46.0 Go library which is in fact prothemeus 2.46
 
   CVE-2023-40577:

--- a/prometheus-operator.advisories.yaml
+++ b/prometheus-operator.advisories.yaml
@@ -1,15 +1,21 @@
+schema-version: "2"
+
 package:
   name: prometheus-operator
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-11T14:13:07.826089-07:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: This CVE only impacts prometheus 2.7 but our prometheus-operator is using v0.46.0 Go library which is in fact prothemeus 2.46
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-11T21:13:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE only impacts prometheus 2.7 but our prometheus-operator is using v0.46.0 Go library which is in fact prothemeus 2.46
 
-  CVE-2023-40577:
-    - timestamp: 2023-08-25T13:47:54.188231-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.
+  - id: CVE-2023-40577
+    events:
+      - timestamp: 2023-08-25T20:47:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.

--- a/prometheus-stackdriver-exporter.advisories.yaml
+++ b/prometheus-stackdriver-exporter.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: prometheus-stackdriver-exporter
 
 advisories:
-  CVE-2022-41723:
-    - timestamp: 2023-05-02T22:52:07.740978573Z
-      status: fixed
-      fixed-version: 0.13.0-r0
+  - id: CVE-2022-41723
+    events:
+      - timestamp: 2023-05-02T22:52:07Z
+        type: fixed
+        data:
+          fixed-version: 0.13.0-r0

--- a/prometheus.advisories.yaml
+++ b/prometheus.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2023-40577:
     - timestamp: 2023-08-25T13:46:25.775137-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This vulnerability is an XSS flaw affecting alertmanager as a server not the library.

--- a/prometheus.advisories.yaml
+++ b/prometheus.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: prometheus
 
 advisories:
-  CVE-2023-40577:
-    - timestamp: 2023-08-25T13:46:25.775137-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This vulnerability is an XSS flaw affecting alertmanager as a server not the library.
+  - id: CVE-2023-40577
+    events:
+      - timestamp: 2023-08-25T20:46:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is an XSS flaw affecting alertmanager as a server not the library.

--- a/protobuf-c.advisories.yaml
+++ b/protobuf-c.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: protobuf-c
 
 advisories:
-  CVE-2021-3121:
-    - timestamp: 2023-01-15T00:53:43.019884Z
-      status: fixed
-      fixed-version: 1.4.1-r0
+  - id: CVE-2021-3121
+    events:
+      - timestamp: 2023-01-15T00:53:43Z
+        type: fixed
+        data:
+          fixed-version: 1.4.1-r0
 
-  CVE-2022-33070:
-    - timestamp: 2023-01-15T00:53:43.01836Z
-      status: fixed
-      fixed-version: 1.4.1-r0
+  - id: CVE-2022-33070
+    events:
+      - timestamp: 2023-01-15T00:53:43Z
+        type: fixed
+        data:
+          fixed-version: 1.4.1-r0

--- a/pulumi-language-java.advisories.yaml
+++ b/pulumi-language-java.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: pulumi-language-java
 
 advisories:
-  CVE-2023-1732:
-    - timestamp: 2023-06-04T12:04:33.465827-04:00
-      status: fixed
-      fixed-version: 0.9.3-r2
+  - id: CVE-2023-1732
+    events:
+      - timestamp: 2023-06-04T16:04:33Z
+        type: fixed
+        data:
+          fixed-version: 0.9.3-r2

--- a/pulumi.advisories.yaml
+++ b/pulumi.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: pulumi
 
 advisories:
-  CVE-2018-20225:
-    - timestamp: 2023-07-27T16:10:39.129113-07:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
+  - id: CVE-2018-20225
+    events:
+      - timestamp: 2023-07-27T23:10:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.

--- a/pulumi.advisories.yaml
+++ b/pulumi.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2018-20225:
     - timestamp: 2023-07-27T16:10:39.129113-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.

--- a/py3-click.advisories.yaml
+++ b/py3-click.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: py3-click
 
 advisories:
-  CVE-2015-8768:
-    - timestamp: 2023-07-21T08:38:52.925024-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: The vulnerability affects an Ubuntu installer named click (https://launchpad.net/click), not the python click package.
+  - id: CVE-2015-8768
+    events:
+      - timestamp: 2023-07-21T12:38:52Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The vulnerability affects an Ubuntu installer named click (https://launchpad.net/click), not the python click package.

--- a/py3-configobj.advisories.yaml
+++ b/py3-configobj.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: py3-configobj
 
 advisories:
-  CVE-2023-26112:
-    - timestamp: 2023-07-21T08:41:52.106634-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The maintainers correctly deemed this to not be a vulnerability given it requires the system operator to enter the incorrect value.
+  - id: CVE-2023-26112
+    events:
+      - timestamp: 2023-07-21T12:41:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The maintainers correctly deemed this to not be a vulnerability given it requires the system operator to enter the incorrect value.

--- a/py3-configobj.advisories.yaml
+++ b/py3-configobj.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2023-26112:
     - timestamp: 2023-07-21T08:41:52.106634-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The maintainers correctly deemed this to not be a vulnerability given it requires the system operator to enter the incorrect value.

--- a/py3-jmespath.advisories.yaml
+++ b/py3-jmespath.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: py3-jmespath
 
 advisories:
-  CVE-2022-32511:
-    - timestamp: 2023-06-05T06:37:49.935863-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: The vulnerability is in a ruby library, this refers to a python one with the same name
+  - id: CVE-2022-32511
+    events:
+      - timestamp: 2023-06-05T10:37:49Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The vulnerability is in a ruby library, this refers to a python one with the same name

--- a/py3.10-pip.advisories.yaml
+++ b/py3.10-pip.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: py3.10-pip
 
 advisories:
-  CVE-2018-20225:
-    - timestamp: 2023-03-28T09:38:33.819695-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
+  - id: CVE-2018-20225
+    events:
+      - timestamp: 2023-03-28T13:38:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.

--- a/py3.10-pip.advisories.yaml
+++ b/py3.10-pip.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2018-20225:
     - timestamp: 2023-03-28T09:38:33.819695-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.

--- a/py3.11-pip.advisories.yaml
+++ b/py3.11-pip.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: py3.11-pip
 
 advisories:
-  CVE-2018-20225:
-    - timestamp: 2023-03-28T09:38:38.961464-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
+  - id: CVE-2018-20225
+    events:
+      - timestamp: 2023-03-28T13:38:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.

--- a/py3.11-pip.advisories.yaml
+++ b/py3.11-pip.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2018-20225:
     - timestamp: 2023-03-28T09:38:38.961464-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.

--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -5,14 +5,14 @@ advisories:
   CVE-2007-4559:
     - timestamp: 2023-03-11T17:20:54.537869-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
     - timestamp: 2023-06-28T08:14:30.533746-04:00
       status: affected
       action: Users should upgrade to version 3.10.12-r0 or later and set the filter parameter to 'data' when calling TarFile.extract and TarFile.extractall methods. For more information, see https://peps.python.org/pep-0706/.
     - timestamp: 2023-07-11T14:09:29.265761-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
   CVE-2020-10735:
@@ -29,7 +29,7 @@ advisories:
   CVE-2023-36632:
     - timestamp: 2023-07-07T12:34:41.0519+01:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The vendor's perspective is that this is neither a vulnerability nor a bug.
 
   CVE-2023-27043:

--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -1,38 +1,52 @@
+schema-version: "2"
+
 package:
   name: python-3.10
 
 advisories:
-  CVE-2007-4559:
-    - timestamp: 2023-03-11T17:20:54.537869-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
-    - timestamp: 2023-06-28T08:14:30.533746-04:00
-      status: affected
-      action: Users should upgrade to version 3.10.12-r0 or later and set the filter parameter to 'data' when calling TarFile.extract and TarFile.extractall methods. For more information, see https://peps.python.org/pep-0706/.
-    - timestamp: 2023-07-11T14:09:29.265761-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
+  - id: CVE-2007-4559
+    events:
+      - timestamp: 2023-03-11T22:20:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
+      - timestamp: 2023-06-28T12:14:30Z
+        type: true-positive-determination
+        data:
+          note: Users should upgrade to version 3.10.12-r0 or later and set the filter parameter to 'data' when calling TarFile.extract and TarFile.extractall methods. For more information, see https://peps.python.org/pep-0706/.
+      - timestamp: 2023-07-11T18:09:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
-  CVE-2020-10735:
-    - timestamp: 2023-02-07T08:34:29.611707Z
-      status: fixed
-      fixed-version: 3.10.9-r0
+  - id: CVE-2020-10735
+    events:
+      - timestamp: 2023-02-07T08:34:29Z
+        type: fixed
+        data:
+          fixed-version: 3.10.9-r0
 
-  CVE-2023-24329:
-    - timestamp: 2023-03-31T18:57:02.344902-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: The upstream issue has been deemed expected behavior, not a security issue. See https://github.com/python/cpython/issues/102153.
+  - id: CVE-2023-24329
+    events:
+      - timestamp: 2023-03-31T22:57:02Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The upstream issue has been deemed expected behavior, not a security issue. See https://github.com/python/cpython/issues/102153.
 
-  CVE-2023-36632:
-    - timestamp: 2023-07-07T12:34:41.0519+01:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The vendor's perspective is that this is neither a vulnerability nor a bug.
+  - id: CVE-2023-27043
+    events:
+      - timestamp: 2023-08-14T21:08:51Z
+        type: true-positive-determination
+        data:
+          note: A fix for this has not yet been released upstream.
 
-  CVE-2023-27043:
-    - timestamp: 2023-08-14T17:08:51.900138-04:00
-      status: affected
-      action: A fix for this has not yet been released upstream.
+  - id: CVE-2023-36632
+    events:
+      - timestamp: 2023-07-07T11:34:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The vendor's perspective is that this is neither a vulnerability nor a bug.

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -1,38 +1,52 @@
+schema-version: "2"
+
 package:
   name: python-3.11
 
 advisories:
-  CVE-2007-4559:
-    - timestamp: 2023-03-11T17:20:54.562759-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
-    - timestamp: 2023-06-28T08:14:24.080074-04:00
-      status: affected
-      action: Users should upgrade to version 3.11.4-r0 or later and set the filter parameter to 'data' when calling TarFile.extract and TarFile.extractall methods. For more information, see https://peps.python.org/pep-0706/.
-    - timestamp: 2023-07-11T14:09:29.265761-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
+  - id: CVE-2007-4559
+    events:
+      - timestamp: 2023-03-11T22:20:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
+      - timestamp: 2023-06-28T12:14:24Z
+        type: true-positive-determination
+        data:
+          note: Users should upgrade to version 3.11.4-r0 or later and set the filter parameter to 'data' when calling TarFile.extract and TarFile.extractall methods. For more information, see https://peps.python.org/pep-0706/.
+      - timestamp: 2023-07-11T18:09:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
-  CVE-2020-10735:
-    - timestamp: 2022-09-12T21:06:30Z
-      status: fixed
-      fixed-version: 3.0.7-r0
+  - id: CVE-2020-10735
+    events:
+      - timestamp: 2022-09-12T21:06:30Z
+        type: fixed
+        data:
+          fixed-version: 3.0.7-r0
 
-  CVE-2023-24329:
-    - timestamp: 2023-07-21T08:31:48.003474-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: The upstream issue has been deemed expected behavior, not a security issue. See https://github.com/python/cpython/issues/102153.
+  - id: CVE-2023-24329
+    events:
+      - timestamp: 2023-07-21T12:31:48Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The upstream issue has been deemed expected behavior, not a security issue. See https://github.com/python/cpython/issues/102153.
 
-  CVE-2023-36632:
-    - timestamp: 2023-07-07T12:34:41.0519+01:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The vendor's perspective is that this is neither a vulnerability nor a bug.
+  - id: CVE-2023-27043
+    events:
+      - timestamp: 2023-08-14T21:08:51Z
+        type: true-positive-determination
+        data:
+          note: A fix for this has not yet been released upstream.
 
-  CVE-2023-27043:
-    - timestamp: 2023-08-14T17:08:51.900138-04:00
-      status: affected
-      action: A fix for this has not yet been released upstream.
+  - id: CVE-2023-36632
+    events:
+      - timestamp: 2023-07-07T11:34:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The vendor's perspective is that this is neither a vulnerability nor a bug.

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -5,14 +5,14 @@ advisories:
   CVE-2007-4559:
     - timestamp: 2023-03-11T17:20:54.562759-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
     - timestamp: 2023-06-28T08:14:24.080074-04:00
       status: affected
       action: Users should upgrade to version 3.11.4-r0 or later and set the filter parameter to 'data' when calling TarFile.extract and TarFile.extractall methods. For more information, see https://peps.python.org/pep-0706/.
     - timestamp: 2023-07-11T14:09:29.265761-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
   CVE-2020-10735:
@@ -29,7 +29,7 @@ advisories:
   CVE-2023-36632:
     - timestamp: 2023-07-07T12:34:41.0519+01:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The vendor's perspective is that this is neither a vulnerability nor a bug.
 
   CVE-2023-27043:

--- a/python-3.12.advisories.yaml
+++ b/python-3.12.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2007-4559:
     - timestamp: 2023-03-11T17:20:54.584305-05:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
     - timestamp: 2023-06-28T08:12:51.372694-04:00
       status: affected
@@ -13,7 +13,7 @@ advisories:
         Users should upgrade to version 3.12.0_beta1-r0 or later and set the filter parameter to 'data' when calling TarFile.extract and TarFile.extractall methods. For more information, see https://peps.python.org/pep-0706/.
     - timestamp: 2023-07-11T14:09:29.265761-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
   CVE-2020-10735:
@@ -30,5 +30,5 @@ advisories:
   CVE-2023-36632:
     - timestamp: 2023-07-07T12:34:41.0519+01:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The vendor's perspective is that this is neither a vulnerability nor a bug.

--- a/python-3.12.advisories.yaml
+++ b/python-3.12.advisories.yaml
@@ -1,34 +1,46 @@
+schema-version: "2"
+
 package:
   name: python-3.12
 
 advisories:
-  CVE-2007-4559:
-    - timestamp: 2023-03-11T17:20:54.584305-05:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
-    - timestamp: 2023-06-28T08:12:51.372694-04:00
-      status: affected
-      action: |
-        Users should upgrade to version 3.12.0_beta1-r0 or later and set the filter parameter to 'data' when calling TarFile.extract and TarFile.extractall methods. For more information, see https://peps.python.org/pep-0706/.
-    - timestamp: 2023-07-11T14:09:29.265761-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
+  - id: CVE-2007-4559
+    events:
+      - timestamp: 2023-03-11T22:20:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
+      - timestamp: 2023-06-28T12:12:51Z
+        type: true-positive-determination
+        data:
+          note: |
+            Users should upgrade to version 3.12.0_beta1-r0 or later and set the filter parameter to 'data' when calling TarFile.extract and TarFile.extractall methods. For more information, see https://peps.python.org/pep-0706/.
+      - timestamp: 2023-07-11T18:09:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
-  CVE-2020-10735:
-    - timestamp: 2022-09-12T21:06:30Z
-      status: fixed
-      fixed-version: 3.0.7-r0
+  - id: CVE-2020-10735
+    events:
+      - timestamp: 2022-09-12T21:06:30Z
+        type: fixed
+        data:
+          fixed-version: 3.0.7-r0
 
-  CVE-2023-24329:
-    - timestamp: 2023-07-21T08:31:48.003474-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: The upstream issue has been deemed expected behavior, not a security issue. See https://github.com/python/cpython/issues/102153.
+  - id: CVE-2023-24329
+    events:
+      - timestamp: 2023-07-21T12:31:48Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The upstream issue has been deemed expected behavior, not a security issue. See https://github.com/python/cpython/issues/102153.
 
-  CVE-2023-36632:
-    - timestamp: 2023-07-07T12:34:41.0519+01:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The vendor's perspective is that this is neither a vulnerability nor a bug.
+  - id: CVE-2023-36632
+    events:
+      - timestamp: 2023-07-07T11:34:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The vendor's perspective is that this is neither a vulnerability nor a bug.

--- a/redis-6.2.advisories.yaml
+++ b/redis-6.2.advisories.yaml
@@ -1,21 +1,29 @@
+schema-version: "2"
+
 package:
   name: redis-6.2
 
 advisories:
-  CVE-2022-0543:
-    - timestamp: 2023-07-12T12:05:46.282906-04:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: This is a Debian-specific issue and does not affect Wolfi.
+  - id: CVE-2022-0543
+    events:
+      - timestamp: 2023-07-12T16:05:46Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This is a Debian-specific issue and does not affect Wolfi.
 
-  CVE-2022-3647:
-    - timestamp: 2023-05-22T06:35:07.758435-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The vulnerability is disputed upstream, indicating that this is expected behavior.
+  - id: CVE-2022-3647
+    events:
+      - timestamp: 2023-05-22T10:35:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The vulnerability is disputed upstream, indicating that this is expected behavior.
 
-  CVE-2022-3734:
-    - timestamp: 2023-07-12T12:07:06.829221-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This is a disputed CVE entry that does not actually affect Redis.
+  - id: CVE-2022-3734
+    events:
+      - timestamp: 2023-07-12T16:07:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This is a disputed CVE entry that does not actually affect Redis.

--- a/redis-6.2.advisories.yaml
+++ b/redis-6.2.advisories.yaml
@@ -5,17 +5,17 @@ advisories:
   CVE-2022-0543:
     - timestamp: 2023-07-12T12:05:46.282906-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: This is a Debian-specific issue and does not affect Wolfi.
 
   CVE-2022-3647:
     - timestamp: 2023-05-22T06:35:07.758435-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The vulnerability is disputed upstream, indicating that this is expected behavior.
 
   CVE-2022-3734:
     - timestamp: 2023-07-12T12:07:06.829221-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This is a disputed CVE entry that does not actually affect Redis.

--- a/redis-7.0.advisories.yaml
+++ b/redis-7.0.advisories.yaml
@@ -5,17 +5,17 @@ advisories:
   CVE-2022-0543:
     - timestamp: 2023-08-31T10:52:09.786739-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: This is a Debian-specific issue and does not affect Wolfi.
 
   CVE-2022-3647:
     - timestamp: 2023-08-31T10:52:09.786739-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: The vulnerability is disputed upstream, indicating that this is expected behavior.
 
   CVE-2022-3734:
     - timestamp: 2023-08-31T10:52:09.786739-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This is a disputed CVE entry that does not actually affect Redis.

--- a/redis-7.0.advisories.yaml
+++ b/redis-7.0.advisories.yaml
@@ -1,21 +1,29 @@
+schema-version: "2"
+
 package:
   name: redis-7.0
 
 advisories:
-  CVE-2022-0543:
-    - timestamp: 2023-08-31T10:52:09.786739-07:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: This is a Debian-specific issue and does not affect Wolfi.
+  - id: CVE-2022-0543
+    events:
+      - timestamp: 2023-08-31T17:52:09Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This is a Debian-specific issue and does not affect Wolfi.
 
-  CVE-2022-3647:
-    - timestamp: 2023-08-31T10:52:09.786739-07:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: The vulnerability is disputed upstream, indicating that this is expected behavior.
+  - id: CVE-2022-3647
+    events:
+      - timestamp: 2023-08-31T17:52:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The vulnerability is disputed upstream, indicating that this is expected behavior.
 
-  CVE-2022-3734:
-    - timestamp: 2023-08-31T10:52:09.786739-07:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This is a disputed CVE entry that does not actually affect Redis.
+  - id: CVE-2022-3734
+    events:
+      - timestamp: 2023-08-31T17:52:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This is a disputed CVE entry that does not actually affect Redis.

--- a/redis.advisories.yaml
+++ b/redis.advisories.yaml
@@ -1,58 +1,82 @@
+schema-version: "2"
+
 package:
   name: redis
 
 advisories:
-  CVE-2022-0543:
-    - timestamp: 2022-12-24T13:35:15-05:00
-      status: fixed
-      fixed-version: 7.0.7-r0
-    - timestamp: 2023-07-12T12:05:46.282906-04:00
-      status: not_affected
-      justification: component-vulnerability-mismatch
-      impact: This is a Debian-specific issue and does not affect Wolfi.
+  - id: CVE-2022-0543
+    events:
+      - timestamp: 2022-12-24T18:35:15Z
+        type: fixed
+        data:
+          fixed-version: 7.0.7-r0
+      - timestamp: 2023-07-12T16:05:46Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This is a Debian-specific issue and does not affect Wolfi.
 
-  CVE-2022-3647:
-    - timestamp: 2022-12-24T13:35:15-05:00
-      status: fixed
-      fixed-version: 7.0.7-r0
+  - id: CVE-2022-35977
+    events:
+      - timestamp: 2023-02-20T19:37:55Z
+        type: fixed
+        data:
+          fixed-version: 7.0.8-r0
 
-  CVE-2022-3734:
-    - timestamp: 2022-12-24T13:35:15-05:00
-      status: fixed
-      fixed-version: 7.0.7-r0
-    - timestamp: 2023-07-12T12:07:06.829221-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This is a disputed CVE entry that does not actually affect Redis.
+  - id: CVE-2022-36021
+    events:
+      - timestamp: 2023-03-10T00:16:28Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-03-10T00:32:02Z
+        type: fixed
+        data:
+          fixed-version: 7.0.9-r0
 
-  CVE-2022-35977:
-    - timestamp: 2023-02-20T14:37:55.058122-05:00
-      status: fixed
-      fixed-version: 7.0.8-r0
+  - id: CVE-2022-3647
+    events:
+      - timestamp: 2022-12-24T18:35:15Z
+        type: fixed
+        data:
+          fixed-version: 7.0.7-r0
 
-  CVE-2022-36021:
-    - timestamp: 2023-03-09T19:16:28.313696-05:00
-      status: under_investigation
-    - timestamp: 2023-03-09T19:32:02.236148-05:00
-      status: fixed
-      fixed-version: 7.0.9-r0
+  - id: CVE-2022-3734
+    events:
+      - timestamp: 2022-12-24T18:35:15Z
+        type: fixed
+        data:
+          fixed-version: 7.0.7-r0
+      - timestamp: 2023-07-12T16:07:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This is a disputed CVE entry that does not actually affect Redis.
 
-  CVE-2023-22458:
-    - timestamp: 2023-02-25T06:54:30.972765-05:00
-      status: fixed
-      fixed-version: 7.0.8-r0
+  - id: CVE-2023-22458
+    events:
+      - timestamp: 2023-02-25T11:54:30Z
+        type: fixed
+        data:
+          fixed-version: 7.0.8-r0
 
-  CVE-2023-25155:
-    - timestamp: 2023-03-19T17:23:43.585248-04:00
-      status: fixed
-      fixed-version: 7.0.9-r0
+  - id: CVE-2023-25155
+    events:
+      - timestamp: 2023-03-19T21:23:43Z
+        type: fixed
+        data:
+          fixed-version: 7.0.9-r0
 
-  CVE-2023-28425:
-    - timestamp: 2023-03-25T07:00:34.041442-04:00
-      status: fixed
-      fixed-version: 7.0.10-r0
+  - id: CVE-2023-28425
+    events:
+      - timestamp: 2023-03-25T11:00:34Z
+        type: fixed
+        data:
+          fixed-version: 7.0.10-r0
 
-  CVE-2023-28856:
-    - timestamp: 2023-04-17T09:33:39.2182-04:00
-      status: fixed
-      fixed-version: 7.0.11-r0
+  - id: CVE-2023-28856
+    events:
+      - timestamp: 2023-04-17T13:33:39Z
+        type: fixed
+        data:
+          fixed-version: 7.0.11-r0

--- a/redis.advisories.yaml
+++ b/redis.advisories.yaml
@@ -8,7 +8,7 @@ advisories:
       fixed-version: 7.0.7-r0
     - timestamp: 2023-07-12T12:05:46.282906-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: component-vulnerability-mismatch
       impact: This is a Debian-specific issue and does not affect Wolfi.
 
   CVE-2022-3647:
@@ -22,7 +22,7 @@ advisories:
       fixed-version: 7.0.7-r0
     - timestamp: 2023-07-12T12:07:06.829221-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This is a disputed CVE entry that does not actually affect Redis.
 
   CVE-2022-35977:

--- a/restic.advisories.yaml
+++ b/restic.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: restic
 
 advisories:
-  CVE-2022-41723:
-    - timestamp: 2023-03-31T09:11:12.275409-04:00
-      status: fixed
-      fixed-version: 0.15.1-r1
+  - id: CVE-2022-41723
+    events:
+      - timestamp: 2023-03-31T13:11:12Z
+        type: fixed
+        data:
+          fixed-version: 0.15.1-r1

--- a/ruby-3.0.advisories.yaml
+++ b/ruby-3.0.advisories.yaml
@@ -10,7 +10,7 @@ advisories:
   CVE-2021-41816:
     - timestamp: 2023-06-23T07:48:12.506426-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: Wolfi has never shipped an affected version of cgi. This NVD record's CPE configuration 1 looks incorrect based on the description and Ruby's advisory.
 
   CVE-2023-0464:

--- a/ruby-3.0.advisories.yaml
+++ b/ruby-3.0.advisories.yaml
@@ -1,54 +1,76 @@
+schema-version: "2"
+
 package:
   name: ruby-3.0
 
 advisories:
-  CVE-2021-33621:
-    - timestamp: 2023-03-10T10:57:16.957642-05:00
-      status: fixed
-      fixed-version: 3.0.5-r0
+  - id: CVE-2021-33621
+    events:
+      - timestamp: 2023-03-10T15:57:16Z
+        type: fixed
+        data:
+          fixed-version: 3.0.5-r0
 
-  CVE-2021-41816:
-    - timestamp: 2023-06-23T07:48:12.506426-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: Wolfi has never shipped an affected version of cgi. This NVD record's CPE configuration 1 looks incorrect based on the description and Ruby's advisory.
+  - id: CVE-2021-41816
+    events:
+      - timestamp: 2023-06-23T11:48:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Wolfi has never shipped an affected version of cgi. This NVD record's CPE configuration 1 looks incorrect based on the description and Ruby's advisory.
 
-  CVE-2023-0464:
-    - timestamp: 2023-06-15T13:11:53.746588-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0464
+    events:
+      - timestamp: 2023-06-15T20:11:53Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0465:
-    - timestamp: 2023-06-15T13:12:12.459975-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0465
+    events:
+      - timestamp: 2023-06-15T20:12:12Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0466:
-    - timestamp: 2023-06-15T13:12:30.380561-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0466
+    events:
+      - timestamp: 2023-06-15T20:12:30Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-1255:
-    - timestamp: 2023-06-15T13:12:38.06302-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-1255
+    events:
+      - timestamp: 2023-06-15T20:12:38Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-2650:
-    - timestamp: 2023-06-15T13:12:44.477214-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-2650
+    events:
+      - timestamp: 2023-06-15T20:12:44Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-28755:
-    - timestamp: 2023-04-14T07:20:45.246887-04:00
-      status: fixed
-      fixed-version: 3.0.6-r0
+  - id: CVE-2023-28755
+    events:
+      - timestamp: 2023-04-14T11:20:45Z
+        type: fixed
+        data:
+          fixed-version: 3.0.6-r0
 
-  CVE-2023-28756:
-    - timestamp: 2023-04-14T07:20:49.582382-04:00
-      status: fixed
-      fixed-version: 3.0.6-r0
+  - id: CVE-2023-28756
+    events:
+      - timestamp: 2023-04-14T11:20:49Z
+        type: fixed
+        data:
+          fixed-version: 3.0.6-r0
 
-  CVE-2023-36617:
-    - timestamp: 2023-07-07T12:17:56.069893-04:00
-      status: affected
-      action: This has been fixed upstream (commit 616926b55e306a0704254a7ddfd6e9834d06c7f2) and we're waiting for a release.
+  - id: CVE-2023-36617
+    events:
+      - timestamp: 2023-07-07T16:17:56Z
+        type: true-positive-determination
+        data:
+          note: This has been fixed upstream (commit 616926b55e306a0704254a7ddfd6e9834d06c7f2) and we're waiting for a release.

--- a/ruby-3.1.advisories.yaml
+++ b/ruby-3.1.advisories.yaml
@@ -1,141 +1,198 @@
+schema-version: "2"
+
 package:
   name: ruby-3.1
 
 advisories:
-  CVE-2022-0778:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-0778
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-1292:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-1292
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-1343:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-1343
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-1434:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-1434
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-1473:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-1473
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-2068:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-2068
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-2097:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-2097
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-3358:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-3358
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-3602:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-3602
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-3786:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-3786
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-3996:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-3996
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-4203:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-4203
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-4304:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-4304
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2022-4450:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2022-4450
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0215:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0215
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0216:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0216
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0217:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0217
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0286:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0286
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0401:
-    - timestamp: 2023-06-23T03:04:27Z
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0401
+    events:
+      - timestamp: 2023-06-23T03:04:27Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0464:
-    - timestamp: 2023-06-15T13:10:44.002604-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0464
+    events:
+      - timestamp: 2023-06-15T20:10:44Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0465:
-    - timestamp: 2023-06-15T13:10:55.064181-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0465
+    events:
+      - timestamp: 2023-06-15T20:10:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0466:
-    - timestamp: 2023-06-15T13:11:03.368875-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0466
+    events:
+      - timestamp: 2023-06-15T20:11:03Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-1255:
-    - timestamp: 2023-06-15T13:11:32.564922-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-1255
+    events:
+      - timestamp: 2023-06-15T20:11:32Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-2650:
-    - timestamp: 2023-06-15T13:11:41.039748-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-2650
+    events:
+      - timestamp: 2023-06-15T20:11:41Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-28755:
-    - timestamp: 2023-04-14T07:20:17.118678-04:00
-      status: fixed
-      fixed-version: 3.1.4-r0
+  - id: CVE-2023-28755
+    events:
+      - timestamp: 2023-04-14T11:20:17Z
+        type: fixed
+        data:
+          fixed-version: 3.1.4-r0
 
-  CVE-2023-28756:
-    - timestamp: 2023-04-14T07:20:13.369198-04:00
-      status: fixed
-      fixed-version: 3.1.4-r0
+  - id: CVE-2023-28756
+    events:
+      - timestamp: 2023-04-14T11:20:13Z
+        type: fixed
+        data:
+          fixed-version: 3.1.4-r0
 
-  CVE-2023-36617:
-    - timestamp: 2023-07-07T12:18:57.18399-04:00
-      status: affected
-      action: This has been fixed upstream (commit 5fbc1d45f17e4bff7cc61a78a7d788aa32ff390a) and we're waiting for a release.
-    - timestamp: 2023-08-27T19:08:23.774449-04:00
-      status: fixed
-      fixed-version: 3.1.4-r2
+  - id: CVE-2023-36617
+    events:
+      - timestamp: 2023-07-07T16:18:57Z
+        type: true-positive-determination
+        data:
+          note: This has been fixed upstream (commit 5fbc1d45f17e4bff7cc61a78a7d788aa32ff390a) and we're waiting for a release.
+      - timestamp: 2023-08-27T23:08:23Z
+        type: fixed
+        data:
+          fixed-version: 3.1.4-r2

--- a/ruby-3.2.advisories.yaml
+++ b/ruby-3.2.advisories.yaml
@@ -1,46 +1,65 @@
+schema-version: "2"
+
 package:
   name: ruby-3.2
 
 advisories:
-  CVE-2023-0464:
-    - timestamp: 2023-06-13T15:47:44.510868-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0464
+    events:
+      - timestamp: 2023-06-13T22:47:44Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0465:
-    - timestamp: 2023-06-13T15:51:00.551447-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0465
+    events:
+      - timestamp: 2023-06-13T22:51:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-0466:
-    - timestamp: 2023-06-13T15:51:18.547878-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-0466
+    events:
+      - timestamp: 2023-06-13T22:51:18Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-1255:
-    - timestamp: 2023-06-13T15:51:41.898861-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-1255
+    events:
+      - timestamp: 2023-06-13T22:51:41Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-2650:
-    - timestamp: 2023-06-13T15:51:52.313268-07:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-2650
+    events:
+      - timestamp: 2023-06-13T22:51:52Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
 
-  CVE-2023-28755:
-    - timestamp: 2023-04-14T07:19:28.944696-04:00
-      status: fixed
-      fixed-version: 3.2.2-r0
+  - id: CVE-2023-28755
+    events:
+      - timestamp: 2023-04-14T11:19:28Z
+        type: fixed
+        data:
+          fixed-version: 3.2.2-r0
 
-  CVE-2023-28756:
-    - timestamp: 2023-04-14T07:19:41.245348-04:00
-      status: fixed
-      fixed-version: 3.2.2-r0
+  - id: CVE-2023-28756
+    events:
+      - timestamp: 2023-04-14T11:19:41Z
+        type: fixed
+        data:
+          fixed-version: 3.2.2-r0
 
-  CVE-2023-36617:
-    - timestamp: 2023-07-07T12:19:11.120734-04:00
-      status: affected
-      action: This has been fixed upstream (commit dd73fe077cae077808e820f4765a12b1f4660521) and we're waiting for a release.
-    - timestamp: 2023-08-27T19:07:00.161946-04:00
-      status: fixed
-      fixed-version: 3.2.2-r2
+  - id: CVE-2023-36617
+    events:
+      - timestamp: 2023-07-07T16:19:11Z
+        type: true-positive-determination
+        data:
+          note: This has been fixed upstream (commit dd73fe077cae077808e820f4765a12b1f4660521) and we're waiting for a release.
+      - timestamp: 2023-08-27T23:07:00Z
+        type: fixed
+        data:
+          fixed-version: 3.2.2-r2

--- a/ruby3.2-fluentd14.advisories.yaml
+++ b/ruby3.2-fluentd14.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: ruby3.2-fluentd14
 
 advisories:
-  CVE-2022-39379:
-    - timestamp: 2023-03-22T17:39:59.867848079-06:00
-      status: fixed
-      fixed-version: 1.14.6-r3
+  - id: CVE-2022-39379
+    events:
+      - timestamp: 2023-03-22T23:39:59Z
+        type: fixed
+        data:
+          fixed-version: 1.14.6-r3

--- a/ruby3.2-webrick.advisories.yaml
+++ b/ruby3.2-webrick.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: ruby3.2-webrick
 
 advisories:
-  CVE-2008-1145:
-    - timestamp: 2023-06-05T09:58:31.22184-04:00
-      status: not_affected
-      justification: component_not_present
-      impact: The CVE was against an older version of ruby itself which included this in the stdlib.
+  - id: CVE-2008-1145
+    events:
+      - timestamp: 2023-06-05T13:58:31Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The CVE was against an older version of ruby itself which included this in the stdlib.

--- a/samurai.advisories.yaml
+++ b/samurai.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: samurai
 
 advisories:
-  CVE-2021-30218:
-    - timestamp: 2022-09-19T06:57:25+00:00
-      status: fixed
-      fixed-version: 1.2-r0
+  - id: CVE-2021-30218
+    events:
+      - timestamp: 2022-09-19T06:57:25Z
+        type: fixed
+        data:
+          fixed-version: 1.2-r0
 
-  CVE-2021-30219:
-    - timestamp: 2022-09-19T06:57:25+00:00
-      status: fixed
-      fixed-version: 1.2-r0
+  - id: CVE-2021-30219
+    events:
+      - timestamp: 2022-09-19T06:57:25Z
+        type: fixed
+        data:
+          fixed-version: 1.2-r0

--- a/secrets-store-csi-driver.advisories.yaml
+++ b/secrets-store-csi-driver.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: secrets-store-csi-driver
 
 advisories:
-  CVE-2023-2878:
-    - timestamp: 2023-05-25T20:43:47.068065-04:00
-      status: fixed
-      fixed-version: 1.3.3-r0
+  - id: CVE-2023-2878
+    events:
+      - timestamp: 2023-05-26T00:43:47Z
+        type: fixed
+        data:
+          fixed-version: 1.3.3-r0

--- a/skaffold.advisories.yaml
+++ b/skaffold.advisories.yaml
@@ -1,10 +1,16 @@
+schema-version: "2"
+
 package:
   name: skaffold
 
 advisories:
-  CVE-2023-33199:
-    - timestamp: 2023-08-02T10:03:24.15935-07:00
-      status: under_investigation
-    - timestamp: 2023-08-02T10:04:18.403415-07:00
-      status: fixed
-      fixed-version: 2.6.2-r1
+  - id: CVE-2023-33199
+    events:
+      - timestamp: 2023-08-02T17:03:24Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-02T17:04:18Z
+        type: fixed
+        data:
+          fixed-version: 2.6.2-r1

--- a/snappy.advisories.yaml
+++ b/snappy.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: snappy
 
 advisories:
-  CVE-2023-28115:
-    - timestamp: 2023-03-25T07:00:03.318711-04:00
-      status: not_affected
-      justification: component_not_present
+  - id: CVE-2023-28115
+    events:
+      - timestamp: 2023-03-25T11:00:03Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch

--- a/sqlite.advisories.yaml
+++ b/sqlite.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: sqlite
 
 advisories:
-  CVE-2022-46908:
-    - timestamp: 2022-12-14T10:26:25Z
-      status: fixed
-      fixed-version: 3.40.0-r1
+  - id: CVE-2022-46908
+    events:
+      - timestamp: 2022-12-14T10:26:25Z
+        type: fixed
+        data:
+          fixed-version: 3.40.0-r1

--- a/systemd.advisories.yaml
+++ b/systemd.advisories.yaml
@@ -11,7 +11,7 @@ advisories:
       status: under_investigation
     - timestamp: 2023-06-26T06:40:02.012433-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This has been disputed by upstream and is not considered a security issue.
 
   CVE-2023-31439:
@@ -19,5 +19,5 @@ advisories:
       status: under_investigation
     - timestamp: 2023-06-26T06:41:12.566531-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This has been disputed by upstream and is not considered a security issue.

--- a/systemd.advisories.yaml
+++ b/systemd.advisories.yaml
@@ -1,23 +1,36 @@
+schema-version: "2"
+
 package:
   name: systemd
 
 advisories:
-  CVE-2023-31437:
-    - timestamp: 2023-06-26T06:31:26.158015-04:00
-      status: under_investigation
+  - id: CVE-2023-31437
+    events:
+      - timestamp: 2023-06-26T10:31:26Z
+        type: detection
+        data:
+          type: manual
 
-  CVE-2023-31438:
-    - timestamp: 2023-06-26T06:31:26.158943-04:00
-      status: under_investigation
-    - timestamp: 2023-06-26T06:40:02.012433-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This has been disputed by upstream and is not considered a security issue.
+  - id: CVE-2023-31438
+    events:
+      - timestamp: 2023-06-26T10:31:26Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-06-26T10:40:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This has been disputed by upstream and is not considered a security issue.
 
-  CVE-2023-31439:
-    - timestamp: 2023-06-26T06:31:26.159354-04:00
-      status: under_investigation
-    - timestamp: 2023-06-26T06:41:12.566531-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This has been disputed by upstream and is not considered a security issue.
+  - id: CVE-2023-31439
+    events:
+      - timestamp: 2023-06-26T10:31:26Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-06-26T10:41:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This has been disputed by upstream and is not considered a security issue.

--- a/tekton-chains.advisories.yaml
+++ b/tekton-chains.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: tekton-chains
 
 advisories:
-  CVE-2023-37264:
-    - timestamp: 2023-08-07T15:00:32.868558-04:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerability only present in Tekton Pipelines controller code.
+  - id: CVE-2023-37264
+    events:
+      - timestamp: 2023-08-07T19:00:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerability only present in Tekton Pipelines controller code.

--- a/tekton-chains.advisories.yaml
+++ b/tekton-chains.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2023-37264:
     - timestamp: 2023-08-07T15:00:32.868558-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerability only present in Tekton Pipelines controller code.

--- a/tekton-pipelines.advisories.yaml
+++ b/tekton-pipelines.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: tekton-pipelines
 
 advisories:
-  CVE-2023-1732:
-    - timestamp: 2023-08-11T13:23:33.940995-04:00
-      status: not_affected
-      justification: vulnerable_code_not_in_execute_path
-      impact: Vulnerable packages not in dependency tree.
+  - id: CVE-2023-1732
+    events:
+      - timestamp: 2023-08-11T17:23:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Vulnerable packages not in dependency tree.

--- a/telegraf-1.26.advisories.yaml
+++ b/telegraf-1.26.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   CVE-2019-3826:
     - timestamp: 2023-08-25T15:09:21.35593-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.
 
   CVE-2023-34231:
@@ -15,5 +15,5 @@ advisories:
   GHSA-2w8w-qhg4-f78j:
     - timestamp: 2023-08-25T15:21:50.625645-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This vulnerability only affects Jaeger UI, not the library code imported by telegraf.

--- a/telegraf-1.26.advisories.yaml
+++ b/telegraf-1.26.advisories.yaml
@@ -1,19 +1,28 @@
+schema-version: "2"
+
 package:
   name: telegraf-1.26
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-25T15:09:21.35593-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-25T22:09:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.
 
-  CVE-2023-34231:
-    - timestamp: 2023-08-25T16:13:42.36298-07:00
-      status: under_investigation
+  - id: CVE-2023-34231
+    events:
+      - timestamp: 2023-08-25T23:13:42Z
+        type: detection
+        data:
+          type: manual
 
-  GHSA-2w8w-qhg4-f78j:
-    - timestamp: 2023-08-25T15:21:50.625645-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This vulnerability only affects Jaeger UI, not the library code imported by telegraf.
+  - id: GHSA-2w8w-qhg4-f78j
+    events:
+      - timestamp: 2023-08-25T22:21:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability only affects Jaeger UI, not the library code imported by telegraf.

--- a/telegraf-1.27.advisories.yaml
+++ b/telegraf-1.27.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: telegraf-1.27
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-25T15:09:52.665698-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-25T22:09:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.

--- a/telegraf-1.27.advisories.yaml
+++ b/telegraf-1.27.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2019-3826:
     - timestamp: 2023-08-25T15:09:52.665698-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.

--- a/telegraf.advisories.yaml
+++ b/telegraf.advisories.yaml
@@ -1,20 +1,28 @@
+schema-version: "2"
+
 package:
   name: telegraf
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-11T19:48:34.107747-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-12T02:48:34Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
 
-  CVE-2023-34231:
-    - timestamp: 2023-06-13T07:37:43.741941-04:00
-      status: fixed
-      fixed-version: 1.27.0-r1
+  - id: CVE-2023-34231
+    events:
+      - timestamp: 2023-06-13T11:37:43Z
+        type: fixed
+        data:
+          fixed-version: 1.27.0-r1
 
-  GHSA-2w8w-qhg4-f78j:
-    - timestamp: 2023-08-11T16:14:50.544767-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This only affects jaegertracing/jaeger-ui (TypeScript), not jaegertracing/jaeger Go library which telegraf depends on
+  - id: GHSA-2w8w-qhg4-f78j
+    events:
+      - timestamp: 2023-08-11T23:14:50Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This only affects jaegertracing/jaeger-ui (TypeScript), not jaegertracing/jaeger Go library which telegraf depends on

--- a/thanos-0.31.advisories.yaml
+++ b/thanos-0.31.advisories.yaml
@@ -1,15 +1,21 @@
+schema-version: "2"
+
 package:
   name: thanos-0.31
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-30T14:45:02.177345-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-30T21:45:02Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
 
-  CVE-2023-40577:
-    - timestamp: 2023-08-30T13:54:21.036445-07:00
-      status: not_affected
-      justification: vulnerable-code-not-in-execution-path
-      impact: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.
+  - id: CVE-2023-40577
+    events:
+      - timestamp: 2023-08-30T20:54:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.

--- a/thanos-0.31.advisories.yaml
+++ b/thanos-0.31.advisories.yaml
@@ -11,5 +11,5 @@ advisories:
   CVE-2023-40577:
     - timestamp: 2023-08-30T13:54:21.036445-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-in-execution-path
       impact: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.

--- a/thanos-0.32.advisories.yaml
+++ b/thanos-0.32.advisories.yaml
@@ -1,15 +1,21 @@
+schema-version: "2"
+
 package:
   name: thanos-0.32
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-30T14:45:02.177345-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-30T21:45:02Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
 
-  CVE-2023-40577:
-    - timestamp: 2023-08-30T13:54:21.036445-07:00
-      status: not_affected
-      justification: vulnerable-code-not-in-execution-path
-      impact: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.
+  - id: CVE-2023-40577
+    events:
+      - timestamp: 2023-08-30T20:54:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.

--- a/thanos-0.32.advisories.yaml
+++ b/thanos-0.32.advisories.yaml
@@ -11,5 +11,5 @@ advisories:
   CVE-2023-40577:
     - timestamp: 2023-08-30T13:54:21.036445-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-in-execution-path
       impact: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.

--- a/thanos-operator.advisories.yaml
+++ b/thanos-operator.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: thanos-operator
 
 advisories:
-  CVE-2022-28948:
-    - timestamp: 2023-09-05T10:45:27.49084-04:00
-      status: fixed
-      fixed-version: 0.3.7-r4
+  - id: CVE-2022-28948
+    events:
+      - timestamp: 2023-09-05T14:45:27Z
+        type: fixed
+        data:
+          fixed-version: 0.3.7-r4

--- a/thanos.advisories.yaml
+++ b/thanos.advisories.yaml
@@ -1,15 +1,21 @@
+schema-version: "2"
+
 package:
   name: thanos
 
 advisories:
-  CVE-2019-3826:
-    - timestamp: 2023-08-11T14:45:02.177345-07:00
-      status: not_affected
-      justification: component_not_present
-      impact: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-08-11T21:45:02Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
 
-  CVE-2023-40577:
-    - timestamp: 2023-08-25T13:54:21.036445-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.
+  - id: CVE-2023-40577
+    events:
+      - timestamp: 2023-08-25T20:54:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.

--- a/thanos.advisories.yaml
+++ b/thanos.advisories.yaml
@@ -11,5 +11,5 @@ advisories:
   CVE-2023-40577:
     - timestamp: 2023-08-25T13:54:21.036445-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.

--- a/tiff.advisories.yaml
+++ b/tiff.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: tiff
 
 advisories:
-  CVE-2015-7313:
-    - timestamp: 2023-08-18T12:10:08.055914-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: This was fixed upstream sometime around the 4.0.7 release, prior to wolfi packaging. It was also deemed not a security issue, but it was fixed anyway.
+  - id: CVE-2015-7313
+    events:
+      - timestamp: 2023-08-18T16:10:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This was fixed upstream sometime around the 4.0.7 release, prior to wolfi packaging. It was also deemed not a security issue, but it was fixed anyway.

--- a/tiff.advisories.yaml
+++ b/tiff.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2015-7313:
     - timestamp: 2023-08-18T12:10:08.055914-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: This was fixed upstream sometime around the 4.0.7 release, prior to wolfi packaging. It was also deemed not a security issue, but it was fixed anyway.

--- a/tkn.advisories.yaml
+++ b/tkn.advisories.yaml
@@ -1,21 +1,29 @@
+schema-version: "2"
+
 package:
   name: tkn
 
 advisories:
-  GHSA-2h5h-59f5-c5x9:
-    - timestamp: 2023-07-24T14:38:06.711297-07:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: The libraries this CVE impacts are not used by the Tekton project
+  - id: GHSA-2h5h-59f5-c5x9
+    events:
+      - timestamp: 2023-07-24T21:38:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The libraries this CVE impacts are not used by the Tekton project
 
-  GHSA-frqx-jfcm-6jjr:
-    - timestamp: 2023-07-24T14:43:30.33793-07:00
-      status: not_affected
-      justification: vulnerable_code_cannot_be_controlled_by_adversary
-      impact: Malformed entry requests can cause panics, but Tekton doesn't allow users to generate custom requests
+  - id: GHSA-frqx-jfcm-6jjr
+    events:
+      - timestamp: 2023-07-24T21:43:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Malformed entry requests can cause panics, but Tekton doesn't allow users to generate custom requests
 
-  GHSA-w2h3-vvvq-3m53:
-    - timestamp: 2023-08-11T11:23:31.127149-04:00
-      status: not_affected
-      justification: vulnerable-code-not-included-in-package
-      impact: Vulnerability only present in Tekton Pipelines controller code. Package only relies on client libraries / test utilities.
+  - id: GHSA-w2h3-vvvq-3m53
+    events:
+      - timestamp: 2023-08-11T15:23:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Vulnerability only present in Tekton Pipelines controller code. Package only relies on client libraries / test utilities.

--- a/tkn.advisories.yaml
+++ b/tkn.advisories.yaml
@@ -5,7 +5,7 @@ advisories:
   GHSA-2h5h-59f5-c5x9:
     - timestamp: 2023-07-24T14:38:06.711297-07:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: The libraries this CVE impacts are not used by the Tekton project
 
   GHSA-frqx-jfcm-6jjr:
@@ -17,5 +17,5 @@ advisories:
   GHSA-w2h3-vvvq-3m53:
     - timestamp: 2023-08-11T11:23:31.127149-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-not-included-in-package
       impact: Vulnerability only present in Tekton Pipelines controller code. Package only relies on client libraries / test utilities.

--- a/traefik.advisories.yaml
+++ b/traefik.advisories.yaml
@@ -1,28 +1,40 @@
+schema-version: "2"
+
 package:
   name: traefik
 
 advisories:
-  CVE-2021-41803:
-    - timestamp: 2023-03-07T11:51:57.26224-05:00
-      status: fixed
-      fixed-version: 2.9.8-r1
+  - id: CVE-2021-41803
+    events:
+      - timestamp: 2023-03-07T16:51:57Z
+        type: fixed
+        data:
+          fixed-version: 2.9.8-r1
 
-  CVE-2022-23469:
-    - timestamp: 2023-01-29T11:56:03.991319-05:00
-      status: fixed
-      fixed-version: 2.9.6-r0
+  - id: CVE-2022-23469
+    events:
+      - timestamp: 2023-01-29T16:56:03Z
+        type: fixed
+        data:
+          fixed-version: 2.9.6-r0
 
-  CVE-2022-40716:
-    - timestamp: 2023-03-07T11:52:26.180256-05:00
-      status: fixed
-      fixed-version: 2.9.8-r1
+  - id: CVE-2022-40716
+    events:
+      - timestamp: 2023-03-07T16:52:26Z
+        type: fixed
+        data:
+          fixed-version: 2.9.8-r1
 
-  CVE-2022-46153:
-    - timestamp: 2023-01-29T11:56:03.989795-05:00
-      status: fixed
-      fixed-version: 2.9.6-r0
+  - id: CVE-2022-46153
+    events:
+      - timestamp: 2023-01-29T16:56:03Z
+        type: fixed
+        data:
+          fixed-version: 2.9.6-r0
 
-  CVE-2023-2253:
-    - timestamp: 2023-05-17T17:12:08.098192-04:00
-      status: fixed
-      fixed-version: 2.10.1-r2
+  - id: CVE-2023-2253
+    events:
+      - timestamp: 2023-05-17T21:12:08Z
+        type: fixed
+        data:
+          fixed-version: 2.10.1-r2

--- a/upx.advisories.yaml
+++ b/upx.advisories.yaml
@@ -1,15 +1,24 @@
+schema-version: "2"
+
 package:
   name: upx
 
 advisories:
-  CVE-2023-23456:
-    - timestamp: 2023-06-26T06:31:26.173278-04:00
-      status: under_investigation
+  - id: CVE-2023-23456
+    events:
+      - timestamp: 2023-06-26T10:31:26Z
+        type: detection
+        data:
+          type: manual
 
-  CVE-2023-23457:
-    - timestamp: 2023-06-26T06:31:26.173778-04:00
-      status: under_investigation
-    - timestamp: 2023-06-26T06:42:50.468479-04:00
-      status: not_affected
-      justification: vulnerable-code-version-not-used
-      impact: This was fixed upstream prior to Wolfi packaging - https://github.com/upx/upx/issues/631
+  - id: CVE-2023-23457
+    events:
+      - timestamp: 2023-06-26T10:31:26Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-06-26T10:42:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This was fixed upstream prior to Wolfi packaging - https://github.com/upx/upx/issues/631

--- a/upx.advisories.yaml
+++ b/upx.advisories.yaml
@@ -11,5 +11,5 @@ advisories:
       status: under_investigation
     - timestamp: 2023-06-26T06:42:50.468479-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerable-code-version-not-used
       impact: This was fixed upstream prior to Wolfi packaging - https://github.com/upx/upx/issues/631

--- a/vault-1.13.advisories.yaml
+++ b/vault-1.13.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: vault-1.13
 
 advisories:
-  CVE-2023-3462:
-    - timestamp: 2023-08-30T16:17:02.674057-04:00
-      status: fixed
-      fixed-version: 1.13.6-r0
+  - id: CVE-2023-3462
+    events:
+      - timestamp: 2023-08-30T20:17:02Z
+        type: fixed
+        data:
+          fixed-version: 1.13.6-r0

--- a/vault.advisories.yaml
+++ b/vault.advisories.yaml
@@ -1,25 +1,37 @@
+schema-version: "2"
+
 package:
   name: vault
 
 advisories:
-  CVE-2023-1732:
-    - timestamp: 2023-05-17T17:33:43.983873-04:00
-      status: fixed
-      fixed-version: 1.13.2-r1
+  - id: CVE-2023-1732
+    events:
+      - timestamp: 2023-05-17T21:33:43Z
+        type: fixed
+        data:
+          fixed-version: 1.13.2-r1
 
-  CVE-2023-3462:
-    - timestamp: 2023-08-11T14:49:00.441356-04:00
-      status: fixed
-      fixed-version: 1.14.1-r0
+  - id: CVE-2023-24999
+    events:
+      - timestamp: 2023-03-17T00:08:35Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-03-17T00:20:49Z
+        type: fixed
+        data:
+          fixed-version: 1.12.4-r0
 
-  CVE-2023-24999:
-    - timestamp: 2023-03-16T20:08:35.29356-04:00
-      status: under_investigation
-    - timestamp: 2023-03-16T20:20:49.495382-04:00
-      status: fixed
-      fixed-version: 1.12.4-r0
+  - id: CVE-2023-34231
+    events:
+      - timestamp: 2023-06-13T11:38:00Z
+        type: fixed
+        data:
+          fixed-version: 1.13.3-r1
 
-  CVE-2023-34231:
-    - timestamp: 2023-06-13T07:38:00.329311-04:00
-      status: fixed
-      fixed-version: 1.13.3-r1
+  - id: CVE-2023-3462
+    events:
+      - timestamp: 2023-08-11T18:49:00Z
+        type: fixed
+        data:
+          fixed-version: 1.14.1-r0

--- a/vim.advisories.yaml
+++ b/vim.advisories.yaml
@@ -1,31 +1,49 @@
+schema-version: "2"
+
 package:
   name: vim
 
 advisories:
-  CVE-2023-1127:
-    - timestamp: 2023-03-09T19:43:53.391885-05:00
-      status: under_investigation
-    - timestamp: 2023-03-09T19:45:56.751743-05:00
-      status: fixed
-      fixed-version: 9.0.1378-r0
+  - id: CVE-2023-1127
+    events:
+      - timestamp: 2023-03-10T00:43:53Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-03-10T00:45:56Z
+        type: fixed
+        data:
+          fixed-version: 9.0.1378-r0
 
-  CVE-2023-1175:
-    - timestamp: 2023-03-09T19:43:53.391892-05:00
-      status: under_investigation
-    - timestamp: 2023-03-09T19:46:07.647689-05:00
-      status: fixed
-      fixed-version: 9.0.1378-r0
+  - id: CVE-2023-1175
+    events:
+      - timestamp: 2023-03-10T00:43:53Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-03-10T00:46:07Z
+        type: fixed
+        data:
+          fixed-version: 9.0.1378-r0
 
-  CVE-2023-1264:
-    - timestamp: 2023-03-15T13:55:12.275145-04:00
-      status: under_investigation
-    - timestamp: 2023-03-15T14:57:52.866296-04:00
-      status: fixed
-      fixed-version: 9.0.1392-r0
+  - id: CVE-2023-1264
+    events:
+      - timestamp: 2023-03-15T17:55:12Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-03-15T18:57:52Z
+        type: fixed
+        data:
+          fixed-version: 9.0.1392-r0
 
-  CVE-2023-1355:
-    - timestamp: 2023-03-16T13:28:26.138811-04:00
-      status: under_investigation
-    - timestamp: 2023-03-16T20:13:44.177605-04:00
-      status: fixed
-      fixed-version: 9.0.1402-r0
+  - id: CVE-2023-1355
+    events:
+      - timestamp: 2023-03-16T17:28:26Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-03-17T00:13:44Z
+        type: fixed
+        data:
+          fixed-version: 9.0.1402-r0

--- a/wasmtime.advisories.yaml
+++ b/wasmtime.advisories.yaml
@@ -1,17 +1,27 @@
+schema-version: "2"
+
 package:
   name: wasmtime
 
 advisories:
-  CVE-2023-26489:
-    - timestamp: 2023-03-16T13:28:26.139607-04:00
-      status: under_investigation
-    - timestamp: 2023-03-16T20:27:54.656845-04:00
-      status: fixed
-      fixed-version: 6.0.1-r0
+  - id: CVE-2023-26489
+    events:
+      - timestamp: 2023-03-16T17:28:26Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-03-17T00:27:54Z
+        type: fixed
+        data:
+          fixed-version: 6.0.1-r0
 
-  CVE-2023-27477:
-    - timestamp: 2023-03-16T13:28:26.1396-04:00
-      status: under_investigation
-    - timestamp: 2023-03-16T20:28:06.768799-04:00
-      status: fixed
-      fixed-version: 6.0.1-r0
+  - id: CVE-2023-27477
+    events:
+      - timestamp: 2023-03-16T17:28:26Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-03-17T00:28:06Z
+        type: fixed
+        data:
+          fixed-version: 6.0.1-r0

--- a/wavefront-proxy.advisories.yaml
+++ b/wavefront-proxy.advisories.yaml
@@ -12,5 +12,5 @@ advisories:
   CVE-2023-35116:
     - timestamp: 2023-08-11T14:19:16.019833-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386

--- a/wavefront-proxy.advisories.yaml
+++ b/wavefront-proxy.advisories.yaml
@@ -1,16 +1,24 @@
+schema-version: "2"
+
 package:
   name: wavefront-proxy
 
 advisories:
-  CVE-2023-34462:
-    - timestamp: 2023-08-11T14:20:24.152317-04:00
-      status: under_investigation
-    - timestamp: 2023-08-11T15:56:03.368506-04:00
-      status: fixed
-      fixed-version: 13.1-r1
+  - id: CVE-2023-34462
+    events:
+      - timestamp: 2023-08-11T18:20:24Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-08-11T19:56:03Z
+        type: fixed
+        data:
+          fixed-version: 13.1-r1
 
-  CVE-2023-35116:
-    - timestamp: 2023-08-11T14:19:16.019833-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386
+  - id: CVE-2023-35116
+    events:
+      - timestamp: 2023-08-11T18:19:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386

--- a/yajl.advisories.yaml
+++ b/yajl.advisories.yaml
@@ -1,8 +1,12 @@
+schema-version: "2"
+
 package:
   name: yajl
 
 advisories:
-  CVE-2023-33460:
-    - timestamp: 2023-07-19T10:54:51.518929-07:00
-      status: fixed
-      fixed-version: 2.1.0-r1
+  - id: CVE-2023-33460
+    events:
+      - timestamp: 2023-07-19T17:54:51Z
+        type: fixed
+        data:
+          fixed-version: 2.1.0-r1

--- a/yasm.advisories.yaml
+++ b/yasm.advisories.yaml
@@ -5,5 +5,5 @@ advisories:
   CVE-2023-31975:
     - timestamp: 2023-06-22T08:13:09.069002-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: This isn't a security issue. The community isn't sure why a CVE was filed for this (see https://github.com/yasm/yasm/issues/210).

--- a/yasm.advisories.yaml
+++ b/yasm.advisories.yaml
@@ -1,9 +1,13 @@
+schema-version: "2"
+
 package:
   name: yasm
 
 advisories:
-  CVE-2023-31975:
-    - timestamp: 2023-06-22T08:13:09.069002-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: This isn't a security issue. The community isn't sure why a CVE was filed for this (see https://github.com/yasm/yasm/issues/210).
+  - id: CVE-2023-31975
+    events:
+      - timestamp: 2023-06-22T12:13:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This isn't a security issue. The community isn't sure why a CVE was filed for this (see https://github.com/yasm/yasm/issues/210).

--- a/zlib.advisories.yaml
+++ b/zlib.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: zlib
 
 advisories:
-  CVE-2018-25032:
-    - timestamp: 2022-10-11T12:16:06+01:00
-      status: fixed
-      fixed-version: 1.2.12-r0
+  - id: CVE-2018-25032
+    events:
+      - timestamp: 2022-10-11T11:16:06Z
+        type: fixed
+        data:
+          fixed-version: 1.2.12-r0
 
-  CVE-2022-37434:
-    - timestamp: 2022-10-11T12:16:06+01:00
-      status: fixed
-      fixed-version: 1.2.12-r3
+  - id: CVE-2022-37434
+    events:
+      - timestamp: 2022-10-11T11:16:06Z
+        type: fixed
+        data:
+          fixed-version: 1.2.12-r3

--- a/zookeeper.advisories.yaml
+++ b/zookeeper.advisories.yaml
@@ -15,5 +15,5 @@ advisories:
   CVE-2023-35116:
     - timestamp: 2023-08-11T16:29:47.045796-04:00
       status: not_affected
-      justification: vulnerable_code_not_present
+      justification: vulnerability-record-analysis-contested
       impact: CVE disputed by upstream developers, nothing specific to this application.

--- a/zookeeper.advisories.yaml
+++ b/zookeeper.advisories.yaml
@@ -1,19 +1,27 @@
+schema-version: "2"
+
 package:
   name: zookeeper
 
 advisories:
-  CVE-2023-26048:
-    - timestamp: 2023-05-02T09:44:37.474498-04:00
-      status: fixed
-      fixed-version: 3.4.0-r2
+  - id: CVE-2023-26048
+    events:
+      - timestamp: 2023-05-02T13:44:37Z
+        type: fixed
+        data:
+          fixed-version: 3.4.0-r2
 
-  CVE-2023-26049:
-    - timestamp: 2023-05-02T09:44:26.507148-04:00
-      status: fixed
-      fixed-version: 3.4.0-r2
+  - id: CVE-2023-26049
+    events:
+      - timestamp: 2023-05-02T13:44:26Z
+        type: fixed
+        data:
+          fixed-version: 3.4.0-r2
 
-  CVE-2023-35116:
-    - timestamp: 2023-08-11T16:29:47.045796-04:00
-      status: not_affected
-      justification: vulnerability-record-analysis-contested
-      impact: CVE disputed by upstream developers, nothing specific to this application.
+  - id: CVE-2023-35116
+    events:
+      - timestamp: 2023-08-11T20:29:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE disputed by upstream developers, nothing specific to this application.

--- a/zot.advisories.yaml
+++ b/zot.advisories.yaml
@@ -1,13 +1,19 @@
+schema-version: "2"
+
 package:
   name: zot
 
 advisories:
-  CVE-2023-25656:
-    - timestamp: 2023-08-14T20:41:53.435338-04:00
-      status: affected
-      action: We are waiting on zot to update its code to use a fixed version of the affected notation library.
+  - id: CVE-2023-25656
+    events:
+      - timestamp: 2023-08-15T00:41:53Z
+        type: true-positive-determination
+        data:
+          note: We are waiting on zot to update its code to use a fixed version of the affected notation library.
 
-  CVE-2023-33959:
-    - timestamp: 2023-08-14T20:42:56.411344-04:00
-      status: affected
-      action: We are waiting on zot to update its code to use a fixed version of the affected notation library.
+  - id: CVE-2023-33959
+    events:
+      - timestamp: 2023-08-15T00:42:56Z
+        type: true-positive-determination
+        data:
+          note: We are waiting on zot to update its code to use a fixed version of the affected notation library.


### PR DESCRIPTION
⚠️ Breaking change!

This PR updates all advisory data to use the new v2 schema, which requires `wolfictl` `0.2.0` or later (using changes from https://github.com/wolfi-dev/wolfictl/pull/362).
