### PR TITLE
Run CVE discovery and triage 6 CVEs

### DIFF
--- a/ghostscript.advisories.yaml
+++ b/ghostscript.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: "2"
+
+package:
+  name: ghostscript
+
+advisories:
+  - id: CVE-2023-36664
+    events:
+      - timestamp: 2023-09-06T15:58:48Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:ghostscript:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:artifex:ghostscript:*:*:*:*:*:*:*:*

--- a/ghostscript.advisories.yaml
+++ b/ghostscript.advisories.yaml
@@ -13,3 +13,8 @@ advisories:
           data:
             cpeSearched: cpe:2.3:a:*:ghostscript:*:*:*:*:*:*:*:*
             cpeFound: cpe:2.3:a:artifex:ghostscript:*:*:*:*:*:*:*:*
+      - timestamp: 2023-09-06T18:50:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The CPE configuration looks incorrect, 10.01.2 is included in the vulnerable range, but it should be excluded because the ghostpdl-10.01.2 tag upstream already contains the vulnerability-fixing commits.

--- a/gtk-2.0.advisories.yaml
+++ b/gtk-2.0.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: "2"
+
+package:
+  name: gtk-2.0
+
+advisories:
+  - id: CVE-2014-1949
+    events:
+      - timestamp: 2023-09-06T15:58:48Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:gtk:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:gnome:gtk:*:*:*:*:*:*:*:*

--- a/gtk-2.0.advisories.yaml
+++ b/gtk-2.0.advisories.yaml
@@ -13,3 +13,8 @@ advisories:
           data:
             cpeSearched: cpe:2.3:a:*:gtk:*:*:*:*:*:*:*:*
             cpeFound: cpe:2.3:a:gnome:gtk:*:*:*:*:*:*:*:*
+      - timestamp: 2023-09-06T21:05:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This vulnerability affects gtk 3.x, not 2.x.

--- a/openjdk-7.advisories.yaml
+++ b/openjdk-7.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: "2"
+
+package:
+  name: openjdk-7
+
+advisories:
+  - id: CVE-2023-21968
+    events:
+      - timestamp: 2023-09-06T15:58:49Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:oracle:openjdk:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:oracle:openjdk:*:*:*:*:*:*:*:*

--- a/openjdk-7.advisories.yaml
+++ b/openjdk-7.advisories.yaml
@@ -13,3 +13,11 @@ advisories:
           data:
             cpeSearched: cpe:2.3:a:oracle:openjdk:*:*:*:*:*:*:*:*
             cpeFound: cpe:2.3:a:oracle:openjdk:*:*:*:*:*:*:*:*
+      - timestamp: 2023-09-06T21:14:10Z
+        type: true-positive-determination
+        data:
+          note: There isn't much information in the CVE record, but Oracle says this affects openjdk versions prior to 8 (among other version ranges).
+      - timestamp: 2023-09-06T21:15:38Z
+        type: fix-not-planned
+        data:
+          note: No fix available in version stream.

--- a/rabbitmq-c.advisories.yaml
+++ b/rabbitmq-c.advisories.yaml
@@ -13,3 +13,7 @@ advisories:
           data:
             cpeSearched: cpe:2.3:a:*:rabbitmq-c:*:*:*:*:*:*:*:*
             cpeFound: cpe:2.3:a:rabbitmq-c_project:rabbitmq-c:*:*:*:*:*:*:*:*
+      - timestamp: 2023-09-06T21:21:50Z
+        type: true-positive-determination
+        data:
+          note: Waiting for an upstream release that includes the fix from https://github.com/alanxz/rabbitmq-c/pull/781.

--- a/rabbitmq-c.advisories.yaml
+++ b/rabbitmq-c.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: "2"
+
+package:
+  name: rabbitmq-c
+
+advisories:
+  - id: CVE-2023-35789
+    events:
+      - timestamp: 2023-09-06T15:58:49Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:rabbitmq-c:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:rabbitmq-c_project:rabbitmq-c:*:*:*:*:*:*:*:*

--- a/sysstat.advisories.yaml
+++ b/sysstat.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: "2"
+
+package:
+  name: sysstat
+
+advisories:
+  - id: CVE-2023-33204
+    events:
+      - timestamp: 2023-09-06T15:58:49Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:sysstat:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:sysstat_project:sysstat:*:*:*:*:*:*:*:*

--- a/sysstat.advisories.yaml
+++ b/sysstat.advisories.yaml
@@ -13,3 +13,9 @@ advisories:
           data:
             cpeSearched: cpe:2.3:a:*:sysstat:*:*:*:*:*:*:*:*
             cpeFound: cpe:2.3:a:sysstat_project:sysstat:*:*:*:*:*:*:*:*
+      - timestamp: 2023-09-06T23:44:37Z
+        type: true-positive-determination
+      - timestamp: 2023-09-06T23:45:08Z
+        type: fixed
+        data:
+          fixed-version: 12.7.4-r0

--- a/tinyxml.advisories.yaml
+++ b/tinyxml.advisories.yaml
@@ -13,3 +13,7 @@ advisories:
           data:
             cpeSearched: cpe:2.3:a:*:tinyxml:*:*:*:*:*:*:*:*
             cpeFound: cpe:2.3:a:tinyxml_project:tinyxml:*:*:*:*:*:*:*:*
+      - timestamp: 2023-09-07T00:06:55Z
+        type: fixed
+        data:
+          fixed-version: 2.6.2-r1

--- a/tinyxml.advisories.yaml
+++ b/tinyxml.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: "2"
+
+package:
+  name: tinyxml
+
+advisories:
+  - id: CVE-2021-42260
+    events:
+      - timestamp: 2023-09-06T15:58:49Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:tinyxml:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:tinyxml_project:tinyxml:*:*:*:*:*:*:*:*


### PR DESCRIPTION
I started dusting off the `wolfcitl adv discover` command, and found it surfaced 6 CVEs. It correctly recorded them as new advisories using the v2 schema, and I've triaged these findings in this PR.

The discovery worked pretty well, and highlighted a few data errors in NVD itself.

The recorded fix for `tinyxml` refers to this PR: https://github.com/wolfi-dev/os/pull/5222