### PR TITLE
k3s: log fix for CVE-2023-32187

### DIFF
--- a/k3s.advisories.yaml
+++ b/k3s.advisories.yaml
@@ -1,0 +1,12 @@
+schema-version: "2"
+
+package:
+  name: k3s
+
+advisories:
+  - id: CVE-2023-32187
+    events:
+      - timestamp: 2023-09-12T12:21:44Z
+        type: fixed
+        data:
+          fixed-version: 1.27.5-r0


### PR DESCRIPTION
(alias GHSA-m4hf-6vgr-75r2)

We're currently shipping 1.28.1, which is patched. Before that we were shipping 1.27.5, which is also patched, and was the first patched version we shipped.

This is a case of Go binaries not encoding the main module's version at buildtime, so scanners see `(devel)` and assume the fixed version has not yet been reached.