### PR TITLE
Add CVE-2023-32558 as fixed to nodejs-20.

### DIFF
--- a/nodejs-20.advisories.yaml
+++ b/nodejs-20.advisories.yaml
@@ -102,6 +102,13 @@ advisories:
         data:
           fixed-version: 20.5.1-r0
 
+  - id: CVE-2023-32558
+    events:
+      - timestamp: 2023-09-16T13:47:40Z
+        type: fixed
+        data:
+          fixed-version: 20.6.1-r0
+
   - id: CVE-2023-32559
     events:
       - timestamp: 2023-08-10T12:00:44Z

--- a/nodejs-20.advisories.yaml
+++ b/nodejs-20.advisories.yaml
@@ -107,7 +107,7 @@ advisories:
       - timestamp: 2023-09-16T13:47:40Z
         type: fixed
         data:
-          fixed-version: 20.6.1-r0
+          fixed-version: 20.5.1-r0
 
   - id: CVE-2023-32559
     events:


### PR DESCRIPTION
Grype just started flagging this, but it looks like the CPE bounds are incorrect. The node release notes show this as fixed in 20.6.1, but the NVD has that version as still vulnerable.

https://nodejs.org/en/blog/vulnerability/august-2023-security-releases
https://nvd.nist.gov/vuln/detail/CVE-2023-32558