### PR TITLE
Triage CVEs surfaced by `wolfictl adv discover`

### DIFF
--- a/croc.advisories.yaml
+++ b/croc.advisories.yaml
@@ -1,0 +1,65 @@
+schema-version: "2"
+
+package:
+  name: croc
+
+advisories:
+  - id: CVE-2023-43616
+    events:
+      - timestamp: 2023-09-30T18:59:24Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:croc:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
+
+  - id: CVE-2023-43617
+    events:
+      - timestamp: 2023-09-30T18:59:24Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:croc:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
+
+  - id: CVE-2023-43618
+    events:
+      - timestamp: 2023-09-30T18:59:24Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:croc:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
+
+  - id: CVE-2023-43619
+    events:
+      - timestamp: 2023-09-30T18:59:24Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:croc:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
+
+  - id: CVE-2023-43620
+    events:
+      - timestamp: 2023-09-30T18:59:24Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:croc:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
+
+  - id: CVE-2023-43621
+    events:
+      - timestamp: 2023-09-30T18:59:24Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:croc:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*

--- a/gcc-6.advisories.yaml
+++ b/gcc-6.advisories.yaml
@@ -38,3 +38,15 @@ advisories:
         data:
           type: vulnerable-code-not-in-execution-path
           note: GCC doesn't use the vulnerable code path in libiberty.
+
+  - id: CVE-2023-4039
+    events:
+      - timestamp: 2023-09-30T19:00:34Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:gcc:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:gnu:gcc:*:*:*:*:*:*:arm64:*
+      - timestamp: 2023-09-30T23:32:34Z
+        type: true-positive-determination

--- a/ghostscript.advisories.yaml
+++ b/ghostscript.advisories.yaml
@@ -18,3 +18,17 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: The CPE configuration looks incorrect, 10.01.2 is included in the vulnerable range, but it should be excluded because the ghostpdl-10.01.2 tag upstream already contains the vulnerability-fixing commits.
+
+  - id: CVE-2023-43115
+    events:
+      - timestamp: 2023-09-30T19:00:42Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:ghostscript:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:artifex:ghostscript:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:07:47Z
+        type: fixed
+        data:
+          fixed-version: 10.02.0-r0

--- a/libvterm.advisories.yaml
+++ b/libvterm.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: "2"
+
+package:
+  name: libvterm
+
+advisories:
+  - id: CVE-2018-20786
+    events:
+      - timestamp: 2023-09-30T19:03:22Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:libvterm:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:leonerd:libvterm:*:*:*:*:*:*:*:*

--- a/openmp-16.advisories.yaml
+++ b/openmp-16.advisories.yaml
@@ -1,0 +1,20 @@
+schema-version: "2"
+
+package:
+  name: openmp-16
+
+advisories:
+  - id: CVE-2022-26345
+    events:
+      - timestamp: 2023-09-30T19:05:11Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:openmp:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:intel:openmp:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:09:11Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Our package is actually the LLVM library for openmp, not openmp itself.

--- a/openvpn.advisories.yaml
+++ b/openvpn.advisories.yaml
@@ -1,0 +1,20 @@
+schema-version: "2"
+
+package:
+  name: openvpn
+
+advisories:
+  - id: CVE-2020-27569
+    events:
+      - timestamp: 2023-09-30T19:05:15Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:openvpn:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:aviatrix:openvpn:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:10:58Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to Aviatrix VPN Client.

--- a/snappy.advisories.yaml
+++ b/snappy.advisories.yaml
@@ -10,3 +10,18 @@ advisories:
         type: false-positive-determination
         data:
           type: component-vulnerability-mismatch
+
+  - id: CVE-2023-41330
+    events:
+      - timestamp: 2023-09-30T19:11:40Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:snappy:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:knplabs:snappy:*:*:*:*:*:*:*:*
+      - timestamp: 2023-09-30T23:43:38Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Broad CPE matched knplabs package, not Google's package.

--- a/supervisor.advisories.yaml
+++ b/supervisor.advisories.yaml
@@ -1,0 +1,20 @@
+schema-version: "2"
+
+package:
+  name: supervisor
+
+advisories:
+  - id: CVE-2023-27482
+    events:
+      - timestamp: 2023-09-30T19:11:57Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:supervisor:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:home-assistant:supervisor:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:12:24Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to component in Home Assistant.

--- a/temporal.advisories.yaml
+++ b/temporal.advisories.yaml
@@ -1,0 +1,20 @@
+schema-version: "2"
+
+package:
+  name: temporal
+
+advisories:
+  - id: CVE-2023-3485
+    events:
+      - timestamp: 2023-09-30T19:12:10Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:temporal:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:temporal:temporal:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:15:29Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Our 'temporal' package is actually the temporal CLI, not the temporal server itself. (The found CPE is a related component.)

--- a/thrift.advisories.yaml
+++ b/thrift.advisories.yaml
@@ -1,0 +1,140 @@
+schema-version: "2"
+
+package:
+  name: thrift
+
+advisories:
+  - id: CVE-2019-11938
+    events:
+      - timestamp: 2023-09-30T19:12:18Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:thrift:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:facebook:thrift:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:17:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
+
+  - id: CVE-2019-11939
+    events:
+      - timestamp: 2023-09-30T19:12:18Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:thrift:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:facebook:thrift:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:17:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
+
+  - id: CVE-2019-3552
+    events:
+      - timestamp: 2023-09-30T19:12:18Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:thrift:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:facebook:thrift:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:17:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
+
+  - id: CVE-2019-3553
+    events:
+      - timestamp: 2023-09-30T19:12:18Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:thrift:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:facebook:thrift:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:17:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
+
+  - id: CVE-2019-3558
+    events:
+      - timestamp: 2023-09-30T19:12:18Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:thrift:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:facebook:thrift:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:17:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
+
+  - id: CVE-2019-3559
+    events:
+      - timestamp: 2023-09-30T19:12:18Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:thrift:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:facebook:thrift:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:17:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
+
+  - id: CVE-2019-3564
+    events:
+      - timestamp: 2023-09-30T19:12:18Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:thrift:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:facebook:thrift:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:17:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
+
+  - id: CVE-2019-3565
+    events:
+      - timestamp: 2023-09-30T19:12:18Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:thrift:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:facebook:thrift:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:17:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
+
+  - id: CVE-2021-24028
+    events:
+      - timestamp: 2023-09-30T19:12:18Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:thrift:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:facebook:thrift:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:17:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.

--- a/trillian.advisories.yaml
+++ b/trillian.advisories.yaml
@@ -4,6 +4,51 @@ package:
   name: trillian
 
 advisories:
+  - id: CVE-2007-3305
+    events:
+      - timestamp: 2023-09-30T19:12:29Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:trillian:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:cerulean_studios:trillian:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:21:54Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to the instant messaging platform called 'Trillian'.
+
+  - id: CVE-2008-2407
+    events:
+      - timestamp: 2023-09-30T19:12:29Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:trillian:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:ceruleanstudios:trillian:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:21:54Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to the instant messaging platform called 'Trillian'.
+
+  - id: CVE-2008-5401
+    events:
+      - timestamp: 2023-09-30T19:12:29Z
+        type: detection
+        data:
+          type: nvdapi
+          data:
+            cpeSearched: cpe:2.3:a:*:trillian:*:*:*:*:*:*:*:*
+            cpeFound: cpe:2.3:a:cerulean_studios:trillian:*:*:*:*:*:*:*:*
+      - timestamp: 2023-10-01T00:21:54Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE refers to the instant messaging platform called 'Trillian'.
+
   - id: CVE-2019-3826
     events:
       - timestamp: 2023-10-01T16:46:09Z


### PR DESCRIPTION
Overall the `discover` command is helpful — but definitely some FPs to look at. Meanwhile, this is good data collection for when we revisit CPE tuning.

Some notes on the CVEs found:

- The `croc` CVEs look like they are recent, filed as public GitHub issues, and no one's fixed them yet.
- I couldn't find a patch for CVE-2023-4039 for `gcc-6`. We already patched our later versions of gcc. Open to suggestions here, or we can mark as `fix-not-planned`.
- For `libvterm`, is CVE-2018-20786 fixed and just not documented in NVD? It looks like our release is more recent than the CVE and the CVE's mentioned version.
- We might consider renaming `openmp-16` with an `llvm-` prefix like we do with our other LLVM libraries.
- We mgiht consider renaming `temporal` to `temporal-cli` or something to further disambiguate it from the temporal server.