### PR TITLE
NACK CVE-2019-3826 in trillian, istio-pilot-agent-1.19

### DIFF
--- a/istio-pilot-agent-1.19.advisories.yaml
+++ b/istio-pilot-agent-1.19.advisories.yaml
@@ -1,0 +1,13 @@
+schema-version: "2"
+
+package:
+  name: istio-pilot-agent-1.19
+
+advisories:
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-10-01T16:44:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.

--- a/trillian.advisories.yaml
+++ b/trillian.advisories.yaml
@@ -1,0 +1,13 @@
+schema-version: "2"
+
+package:
+  name: trillian
+
+advisories:
+  - id: CVE-2019-3826
+    events:
+      - timestamp: 2023-10-01T16:46:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.


### PR DESCRIPTION
Both FPs caused by Prometheus's incorrect module versioning.