### PR TITLE
publish keda-2.10 advisory from private data

### DIFF
--- a/keda-2.10.advisories.yaml
+++ b/keda-2.10.advisories.yaml
@@ -1,0 +1,13 @@
+schema-version: "2"
+
+package:
+  name: keda-2.10
+
+advisories:
+  - id: CVE-2020-8552
+    events:
+      - timestamp: 2023-09-19T16:55:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Go vulndb has marked this code NOT_IMPORTABLE.


### PR DESCRIPTION
This move accompanies the package transfer to Wolfi: https://github.com/wolfi-dev/os/pull/6228

cc: @found-it 