### PR TITLE
Adding additional advisories for keycloak

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -9,7 +9,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerability-record-analysis-contested
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1139
 
   - id: CVE-2005-2992
@@ -17,7 +17,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerability-record-analysis-contested
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1139
 
   - id: CVE-2017-12158
@@ -41,7 +41,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerability-record-analysis-contested
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1068
 
   - id: CVE-2018-15529
@@ -49,7 +49,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerability-record-analysis-contested
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1540
 
   - id: CVE-2020-8908
@@ -65,7 +65,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerability-record-analysis-contested
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20228
 
   - id: CVE-2021-40110
@@ -73,7 +73,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerability-record-analysis-contested
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20224
 
   - id: CVE-2021-40111
@@ -81,7 +81,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerability-record-analysis-contested
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20229
 
   - id: CVE-2021-40525
@@ -89,7 +89,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerability-record-analysis-contested
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20223
 
   - id: CVE-2022-21511
@@ -97,7 +97,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerable-code-not-included-in-package
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20227
 
   - id: CVE-2022-21510
@@ -105,7 +105,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerable-code-not-included-in-package
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20226
 
   - id: CVE-2022-37832
@@ -113,7 +113,7 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerable-code-not-included-in-package
+          type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1068
 
   - id: CVE-2023-0264

--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -57,8 +57,8 @@ advisories:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
         data:
-          type: vulnerable-code-not-included-in-package
-          note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/14786
+          type: vulnerable-code-not-in-execution-path
+          note: The affected methods are not in use. See https://github.com/keycloak/keycloak/issues/14786
 
   - id: CVE-2021-38542
     events:

--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -4,6 +4,22 @@ package:
   name: keycloak
 
 advisories:
+  - id: CVE-2005-2945
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1139
+
+  - id: CVE-2005-2992
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1139
+
   - id: CVE-2017-12158
     events:
       - timestamp: 2023-04-09T13:54:02Z
@@ -20,10 +36,98 @@ advisories:
           type: vulnerable-code-version-not-used
           note: The CVE was fixed in a version of keycloak prior to our packaging
 
+  - id: CVE-2013-0136
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1068
+
+  - id: CVE-2018-15529
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1540
+
+  - id: CVE-2020-8908
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/14786
+
+  - id: CVE-2021-38542
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20228
+
+  - id: CVE-2021-40110
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20224
+
+  - id: CVE-2021-40111
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20229
+
+  - id: CVE-2021-40525
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20223
+
+  - id: CVE-2022-21511
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20227
+
+  - id: CVE-2022-21510
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20226
+
+  - id: CVE-2022-37832
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1068
+
   - id: CVE-2023-0264
     events:
       - timestamp: 2023-04-30T11:15:20Z
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used
-          note: The CVE was fixed in a version of keycloak prior to our packaging
+          note: The CVE was fixed in a version of keycloak prior to our packaging. See https://github.com/keycloak/keycloak/issues/21079
+
+  - id: CVE-2023-35116
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386


### PR DESCRIPTION
As part of preparing our keycloak package for a future image, there are a number of false positives returned in scans, most of these are quite old.

This PR updates the keycloak advisories files with entries for each.