### PR TITLE
Update advisories for `gradle-8`

### DIFF
--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -37,6 +37,10 @@ advisories:
         type: true-positive-determination
         data:
           note: The fix for this vulnerability is in version 2.5.2 of the Apache Ivy dependency. A fix for Gradle was asked via https://github.com/gradle/gradle/issues/24795#issuecomment-1695916608 and is awaiting for a response.
+      - timestamp: 2023-10-04T22:45:49Z
+        type: fixed
+        data:
+          fixed-version: 8.4.0-r0
 
   - id: CVE-2023-2976
     events:
@@ -48,6 +52,13 @@ advisories:
         type: fixed
         data:
           fixed-version: 8.2.1-r1
+
+  - id: CVE-2023-33201
+    events:
+      - timestamp: 2023-10-04T22:46:36Z
+        type: detection
+        data:
+          type: manual
 
   - id: CVE-2023-35116
     events:


### PR DESCRIPTION
8.4.0 was released very recently. We picked up a fix for CVE-2022-46751, and a new vulnerability we have to investigate!

CVE-2023-33201 is affecting bouncycastle. Very likely a true-positive, but only marking the detection for now.