### PR TITLE
Add advisories for php-8.1.

### DIFF
--- a/php-8.1.advisories.yaml
+++ b/php-8.1.advisories.yaml
@@ -1,0 +1,34 @@
+schema-version: "2"
+
+package:
+  name: php-8.1
+
+advisories:
+  - id: CVE-2007-2728
+    events:
+      - timestamp: 2023-10-05T22:18:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+
+  - id: CVE-2007-3205
+    events:
+      - timestamp: 2023-10-05T22:18:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+
+  - id: CVE-2007-4596
+    events:
+      - timestamp: 2023-10-05T22:18:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+
+  - id: CVE-2015-3211
+    events:
+      - timestamp: 2023-10-05T22:18:51Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This is a packaging defect specific to the php-fpm package included in RHEL.  The Wolfi php-fpm package does not include this defect.


### PR DESCRIPTION
Grype reports these for php-8.1:
```
NAME     INSTALLED  FIXED-IN  TYPE    VULNERABILITY   SEVERITY
php-8.1  8.1.24-r1            apk     CVE-2007-4596   High
php-8.1  8.1.24-r1            apk     CVE-2007-3205   Medium
php-8.1  8.1.24-r1            apk     CVE-2007-2728   Medium
php-fpm  8.1.24-r1            apk     CVE-2015-3211   Medium
```

These had already been investigated and classified in php-8.2, so porting the ones from there to here as well.

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>