### PR TITLE
Add GHSA aliases to data set

### DIFF
--- a/apko.advisories.yaml
+++ b/apko.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-28840
+    aliases:
+      - GHSA-232p-vwff-86mp
     events:
       - timestamp: 2023-04-05T14:22:32Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 0.7.3-r1
 
   - id: CVE-2023-28841
+    aliases:
+      - GHSA-33pg-m6jh-5237
     events:
       - timestamp: 2023-04-05T14:22:32Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 0.7.3-r1
 
   - id: CVE-2023-28842
+    aliases:
+      - GHSA-6wrf-mxfj-pf5p
     events:
       - timestamp: 2023-04-05T14:22:32Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 0.7.3-r1
 
   - id: CVE-2023-30551
+    aliases:
+      - GHSA-2h5h-59f5-c5x9
     events:
       - timestamp: 2023-05-04T16:30:46Z
         type: fixed

--- a/argo-cd-2.7.advisories.yaml
+++ b/argo-cd-2.7.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:38:22Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Go vulndb has marked this code NOT_IMPORTABLE.
 
   - id: CVE-2021-25743
+    aliases:
+      - GHSA-f9jg-8p32-2f55
     events:
       - timestamp: 2023-10-03T20:05:42Z
         type: false-positive-determination

--- a/argo-cd-2.8.advisories.yaml
+++ b/argo-cd-2.8.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:39:16Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Go vulndb has marked this code NOT_IMPORTABLE.
 
   - id: CVE-2021-25743
+    aliases:
+      - GHSA-f9jg-8p32-2f55
     events:
       - timestamp: 2023-10-03T20:09:07Z
         type: false-positive-determination

--- a/argo-cd.advisories.yaml
+++ b/argo-cd.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-11T20:38:26Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerable code is part of external-csi-driver which is not included in argo-cd
 
   - id: CVE-2023-1732
+    aliases:
+      - GHSA-2q89-485c-9j2x
     events:
       - timestamp: 2023-05-29T18:53:49Z
         type: fixed
@@ -20,6 +24,8 @@ advisories:
           fixed-version: 2.7.3-r1
 
   - id: CVE-2023-2727
+    aliases:
+      - GHSA-qc2g-gmh6-95p4
     events:
       - timestamp: 2023-07-12T14:31:27Z
         type: fixed
@@ -27,6 +33,8 @@ advisories:
           fixed-version: 2.7.7-r1
 
   - id: CVE-2023-2728
+    aliases:
+      - GHSA-cgcv-5272-97pr
     events:
       - timestamp: 2023-07-12T14:30:52Z
         type: fixed

--- a/avahi.advisories.yaml
+++ b/avahi.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2021-26720
+    aliases:
+      - GHSA-jhxr-wvf5-hrp6
     events:
       - timestamp: 2023-06-20T14:47:42Z
         type: detection
@@ -17,6 +19,8 @@ advisories:
           note: The CVE is only present in a Debian-specific packaging script.
 
   - id: CVE-2021-3468
+    aliases:
+      - GHSA-43rm-fv4g-cmj8
     events:
       - timestamp: 2023-06-20T14:47:42Z
         type: detection

--- a/aws-ebs-csi-driver.advisories.yaml
+++ b/aws-ebs-csi-driver.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-11T20:10:42Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerable code is present in external-csi-driver which is outside of aws-ebs-csi-driver
 
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:39:53Z
         type: false-positive-determination

--- a/aws-efs-csi-driver.advisories.yaml
+++ b/aws-efs-csi-driver.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-11T19:43:11Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerable code is part of an external csi driver outside of Kubernetes source repository
 
   - id: CVE-2021-25743
+    aliases:
+      - GHSA-f9jg-8p32-2f55
     events:
       - timestamp: 2023-10-03T20:11:33Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: The vulnerable code is specific to kubectl.
 
   - id: CVE-2023-2431
+    aliases:
+      - GHSA-xc8m-28vv-4pjc
     events:
       - timestamp: 2023-08-11T19:38:34Z
         type: false-positive-determination
@@ -29,6 +35,8 @@ advisories:
           note: Vulnerable code is part of the Kubernetes kubelet which is not in the execution path of the aws-efs-csi-driver
 
   - id: CVE-2023-2727
+    aliases:
+      - GHSA-qc2g-gmh6-95p4
     events:
       - timestamp: 2023-08-11T19:41:17Z
         type: false-positive-determination
@@ -37,6 +45,8 @@ advisories:
           note: Vulnerable code is part of the Kubernetes API server which is not in the execution path of aws-efs-csi-driver
 
   - id: CVE-2023-2728
+    aliases:
+      - GHSA-cgcv-5272-97pr
     events:
       - timestamp: 2023-08-11T19:45:18Z
         type: false-positive-determination

--- a/bind.advisories.yaml
+++ b/bind.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2016-9131
+    aliases:
+      - GHSA-75r9-9rpr-7px8
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2016-9147
+    aliases:
+      - GHSA-q76v-gxg3-wx5g
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2016-9444
+    aliases:
+      - GHSA-gpxq-r8wx-qxgw
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2017-3136
+    aliases:
+      - GHSA-835v-j5fw-qqvq
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -33,6 +41,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2017-3137
+    aliases:
+      - GHSA-wmp5-3j44-5x2x
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -40,6 +50,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2017-3138
+    aliases:
+      - GHSA-q858-q2j2-9jg4
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -47,6 +59,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2017-3145
+    aliases:
+      - GHSA-3hx4-77f4-g7cp
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -54,6 +68,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2018-5736
+    aliases:
+      - GHSA-6p6q-g6w7-h5f9
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -61,6 +77,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2018-5737
+    aliases:
+      - GHSA-9cxr-pmg7-9w5v
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -68,6 +86,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2018-5738
+    aliases:
+      - GHSA-cg2m-4gq8-j388
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -75,6 +95,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2018-5740
+    aliases:
+      - GHSA-rqpc-6vjv-w22p
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -82,6 +104,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2018-5743
+    aliases:
+      - GHSA-3cr4-c5wq-3ccv
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -89,6 +113,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2018-5744
+    aliases:
+      - GHSA-xcc7-r4h9-f7ph
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -96,6 +122,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2018-5745
+    aliases:
+      - GHSA-p5r3-98fj-vgcv
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -103,6 +131,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2019-6465
+    aliases:
+      - GHSA-5hgv-gr6q-xvqx
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -110,6 +140,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2019-6467
+    aliases:
+      - GHSA-92q8-7pjj-mpmp
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -117,6 +149,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2019-6470
+    aliases:
+      - GHSA-w4w8-43xj-r4wr
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -124,6 +158,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2019-6471
+    aliases:
+      - GHSA-52fp-qxmc-8q94
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -131,6 +167,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2019-6475
+    aliases:
+      - GHSA-2gfp-93f7-f268
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -138,6 +176,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2019-6476
+    aliases:
+      - GHSA-7rr8-wvj2-chhv
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -145,6 +185,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2019-6477
+    aliases:
+      - GHSA-6q2x-892r-7qm4
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -152,6 +194,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2020-8616
+    aliases:
+      - GHSA-rc96-hg8v-6p4g
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -159,6 +203,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2020-8617
+    aliases:
+      - GHSA-q6g5-8p95-hqh7
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -166,6 +212,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2020-8618
+    aliases:
+      - GHSA-2c3j-p34f-v2cr
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -173,6 +221,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2020-8619
+    aliases:
+      - GHSA-fw3j-5rrr-7j3r
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -180,6 +230,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2020-8620
+    aliases:
+      - GHSA-p5fp-cw6q-m6xc
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -187,6 +239,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2020-8621
+    aliases:
+      - GHSA-7vc6-qmjj-2j83
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -194,6 +248,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2020-8622
+    aliases:
+      - GHSA-fh6r-7j2f-pmw4
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -201,6 +257,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2020-8623
+    aliases:
+      - GHSA-3hh5-h95j-2cw7
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -208,6 +266,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2020-8624
+    aliases:
+      - GHSA-qgv6-6x66-mr9j
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -215,6 +275,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2020-8625
+    aliases:
+      - GHSA-mxh3-93ph-p9r2
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -222,6 +284,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2021-25214
+    aliases:
+      - GHSA-pqmv-mqwc-wmr3
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -229,6 +293,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2021-25215
+    aliases:
+      - GHSA-r4mp-379r-9756
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -236,6 +302,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2021-25216
+    aliases:
+      - GHSA-4vh7-r4m9-4w3v
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -243,6 +311,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2021-25218
+    aliases:
+      - GHSA-cc8x-chx9-c63q
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -250,6 +320,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2021-25219
+    aliases:
+      - GHSA-x6vq-rxvf-3ggc
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -257,6 +329,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2021-25220
+    aliases:
+      - GHSA-v8rf-mvwx-cx29
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -264,6 +338,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2022-0396
+    aliases:
+      - GHSA-wqqg-j8m9-9rcc
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -271,6 +347,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2022-2795
+    aliases:
+      - GHSA-9mq2-v988-m7mr
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -278,6 +356,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2022-2881
+    aliases:
+      - GHSA-gjh8-h6gp-pqgr
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -285,6 +365,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2022-2906
+    aliases:
+      - GHSA-pqxc-54m5-8r8m
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -292,6 +374,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2022-3080
+    aliases:
+      - GHSA-7mrh-jrcg-wc76
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -299,6 +383,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2022-3094
+    aliases:
+      - GHSA-8f7f-g9cj-hq6g
     events:
       - timestamp: 2023-01-25T18:13:41Z
         type: fixed
@@ -306,6 +392,8 @@ advisories:
           fixed-version: 9.18.11-r0
 
   - id: CVE-2022-3736
+    aliases:
+      - GHSA-5v6f-5gpq-2628
     events:
       - timestamp: 2023-01-25T18:13:41Z
         type: fixed
@@ -313,6 +401,8 @@ advisories:
           fixed-version: 9.18.11-r0
 
   - id: CVE-2022-38177
+    aliases:
+      - GHSA-5vfq-rv44-c5ff
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -320,6 +410,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2022-38178
+    aliases:
+      - GHSA-349w-cgp3-287r
     events:
       - timestamp: 2023-01-15T00:59:03Z
         type: fixed
@@ -327,6 +419,8 @@ advisories:
           fixed-version: 9.18.10-r0
 
   - id: CVE-2022-3924
+    aliases:
+      - GHSA-29px-hvx8-j7xf
     events:
       - timestamp: 2023-01-25T18:13:41Z
         type: fixed

--- a/binutils.advisories.yaml
+++ b/binutils.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-38126
+    aliases:
+      - GHSA-mc5c-3hv5-5hjw
     events:
       - timestamp: 2022-09-16T16:42:40Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 2.39-r1
 
   - id: CVE-2022-38128
+    aliases:
+      - GHSA-p6mj-rqhq-7523
     events:
       - timestamp: 2022-10-11T20:03:51Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 2.39-r3
 
   - id: CVE-2022-38533
+    aliases:
+      - GHSA-7v55-wrg9-5rfp
     events:
       - timestamp: 2022-09-16T16:42:40Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 2.39-r2
 
   - id: CVE-2023-1579
+    aliases:
+      - GHSA-7p63-jgg6-rgpv
     events:
       - timestamp: 2023-04-12T19:06:15Z
         type: detection
@@ -37,6 +45,8 @@ advisories:
           fixed-version: 2.40-r0
 
   - id: CVE-2023-1972
+    aliases:
+      - GHSA-gxpx-hfgx-m75g
     events:
       - timestamp: 2023-05-27T12:32:23Z
         type: detection

--- a/brotli.advisories.yaml
+++ b/brotli.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8927
+    aliases:
+      - GHSA-5v8v-66v8-mwm7
     events:
       - timestamp: 2022-09-15T02:40:18Z
         type: fixed

--- a/busybox.advisories.yaml
+++ b/busybox.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-28391
+    aliases:
+      - GHSA-h8c3-8522-vxc6
     events:
       - timestamp: 2022-10-11T20:37:21Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.35.0-r3
 
   - id: CVE-2022-30065
+    aliases:
+      - GHSA-gq73-rh3m-3php
     events:
       - timestamp: 2022-10-11T20:37:21Z
         type: fixed

--- a/cadvisor.advisories.yaml
+++ b/cadvisor.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-05-03T19:00:16Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 0.47.1-r0
 
   - id: CVE-2023-27561
+    aliases:
+      - GHSA-vpvm-3wq2-2wvm
     events:
       - timestamp: 2023-05-03T19:00:31Z
         type: fixed

--- a/calico.advisories.yaml
+++ b/calico.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-11T21:07:34Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerable code is part of external-csi-driver and not included in calico
 
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:40:39Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: Go vulndb has marked this code NOT_IMPORTABLE.
 
   - id: CVE-2023-2727
+    aliases:
+      - GHSA-qc2g-gmh6-95p4
     events:
       - timestamp: 2023-07-06T19:08:57Z
         type: fixed
@@ -28,6 +34,8 @@ advisories:
           fixed-version: 3.26.1-r5
 
   - id: CVE-2023-32731
+    aliases:
+      - GHSA-cfgp-2977-2fmm
     events:
       - timestamp: 2023-07-06T19:08:10Z
         type: fixed

--- a/cassandra.advisories.yaml
+++ b/cassandra.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-13946
+    aliases:
+      - GHSA-24ww-mc5x-xc43
     events:
       - timestamp: 2023-08-21T15:48:08Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerable cocode was fixed in Cassandra 2.1.22, 2.2.18, 3.0.22, 3.11.8 and 4.0-beta2. Earliest Wolfi package is 4.1.3
 
   - id: CVE-2020-8908
+    aliases:
+      - GHSA-5mg8-w23w-74h3
     events:
       - timestamp: 2023-08-21T15:36:47Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
 
   - id: CVE-2022-1471
+    aliases:
+      - GHSA-mjmj-j48q-9wg2
     events:
       - timestamp: 2023-08-21T15:40:21Z
         type: false-positive-determination
@@ -29,6 +35,8 @@ advisories:
           note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
 
   - id: CVE-2023-2976
+    aliases:
+      - GHSA-7g45-4rm6-3mm3
     events:
       - timestamp: 2023-08-21T15:38:09Z
         type: false-positive-determination
@@ -37,6 +45,8 @@ advisories:
           note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
 
   - id: CVE-2023-35116
+    aliases:
+      - GHSA-gx6w-fqg7-mc3p
     events:
       - timestamp: 2023-08-21T15:38:35Z
         type: false-positive-determination
@@ -45,6 +55,8 @@ advisories:
           note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-4.1/.build/dependency-check-suppressions.xml'
 
   - id: CVE-2023-43642
+    aliases:
+      - GHSA-55g7-9cwv-5qfv
     events:
       - timestamp: 2023-09-29T23:59:21Z
         type: fixed

--- a/cert-manager-1.11.advisories.yaml
+++ b/cert-manager-1.11.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:40:51Z
         type: false-positive-determination

--- a/cert-manager-1.12.advisories.yaml
+++ b/cert-manager-1.12.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:40:58Z
         type: false-positive-determination

--- a/cloudwatch-exporter.advisories.yaml
+++ b/cloudwatch-exporter.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-34462
+    aliases:
+      - GHSA-6mjq-h674-j845
     events:
       - timestamp: 2023-08-11T21:39:51Z
         type: detection
@@ -16,6 +18,8 @@ advisories:
           fixed-version: 0.15.4-r2
 
   - id: CVE-2023-36479
+    aliases:
+      - GHSA-3gh6-v5v9-6v9j
     events:
       - timestamp: 2023-09-22T19:31:25Z
         type: fixed
@@ -23,6 +27,8 @@ advisories:
           fixed-version: 0.15.4-r3
 
   - id: CVE-2023-40167
+    aliases:
+      - GHSA-hmr7-m48g-48f6
     events:
       - timestamp: 2023-09-22T19:32:39Z
         type: fixed
@@ -30,6 +36,8 @@ advisories:
           fixed-version: 0.15.4-r3
 
   - id: CVE-2023-41900
+    aliases:
+      - GHSA-pwh8-58vv-vw48
     events:
       - timestamp: 2023-09-22T19:33:07Z
         type: fixed

--- a/cluster-autoscaler-1.28.advisories.yaml
+++ b/cluster-autoscaler-1.28.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:41:10Z
         type: false-positive-determination

--- a/cluster-autoscaler.advisories.yaml
+++ b/cluster-autoscaler.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-11T20:57:24Z
         type: false-positive-determination

--- a/conda.advisories.yaml
+++ b/conda.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2007-4559
+    aliases:
+      - GHSA-gw9q-c7gh-j9vm
     events:
       - timestamp: 2023-07-21T18:10:35Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: We have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
   - id: CVE-2018-20225
+    aliases:
+      - GHSA-7p5p-7qq5-cc86
     events:
       - timestamp: 2023-07-21T18:03:13Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
 
   - id: CVE-2023-27043
+    aliases:
+      - GHSA-5mwm-wccq-xqcp
     events:
       - timestamp: 2023-07-21T18:05:18Z
         type: true-positive-determination
@@ -28,6 +34,8 @@ advisories:
           note: There doesn't appear to be a backport of the fix available for Python 3.10.x, see https://github.com/python/cpython/issues/102988.
 
   - id: CVE-2023-36632
+    aliases:
+      - GHSA-gv66-v8c8-v69c
     events:
       - timestamp: 2023-07-21T18:06:11Z
         type: false-positive-determination
@@ -35,7 +43,18 @@ advisories:
           type: vulnerability-record-analysis-contested
           note: The vendor's perspective is that this is neither a vulnerability nor a bug.
 
+  - id: CVE-2023-37920
+    aliases:
+      - GHSA-xqr8-7jwr-rhp7
+    events:
+      - timestamp: 2023-08-11T22:01:28Z
+        type: fixed
+        data:
+          fixed-version: 23.7.2-r1
+
   - id: CVE-2023-38325
+    aliases:
+      - GHSA-cf7p-gm2m-833m
     events:
       - timestamp: 2023-08-11T22:03:52Z
         type: fixed
@@ -52,13 +71,6 @@ advisories:
   - id: GHSA-jm77-qphf-c4w8
     events:
       - timestamp: 2023-08-11T22:04:01Z
-        type: fixed
-        data:
-          fixed-version: 23.7.2-r1
-
-  - id: GHSA-xqr8-7jwr-rhp7
-    events:
-      - timestamp: 2023-08-11T22:01:28Z
         type: fixed
         data:
           fixed-version: 23.7.2-r1

--- a/consul-1.15.advisories.yaml
+++ b/consul-1.15.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-3920
+    aliases:
+      - GHSA-gw2g-hhc9-wgjh
     events:
       - timestamp: 2023-08-11T19:51:12Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.15.5-r0
 
   - id: CVE-2022-40716
+    aliases:
+      - GHSA-m69r-9g56-7mv8
     events:
       - timestamp: 2023-08-11T19:51:56Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 1.15.5-r0
 
   - id: CVE-2023-0845
+    aliases:
+      - GHSA-wj6x-hcc2-f32j
     events:
       - timestamp: 2023-08-11T19:52:24Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 1.15.5-r0
 
   - id: CVE-2023-1297
+    aliases:
+      - GHSA-c57c-7hrj-6q6v
     events:
       - timestamp: 2023-08-11T19:52:43Z
         type: fixed

--- a/consul-1.16.advisories.yaml
+++ b/consul-1.16.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-3518
+    aliases:
+      - GHSA-9rhf-q362-77mx
     events:
       - timestamp: 2023-08-17T21:19:21Z
         type: fixed

--- a/coreutils.advisories.yaml
+++ b/coreutils.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2016-2781
+    aliases:
+      - GHSA-vf3q-65gx-324p
     events:
       - timestamp: 2022-10-11T20:29:31Z
         type: false-positive-determination

--- a/cosign.advisories.yaml
+++ b/cosign.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2007-2233
+    aliases:
+      - GHSA-j44r-c574-p2hv
     events:
       - timestamp: 2023-06-05T17:08:31Z
         type: false-positive-determination

--- a/cri-tools.advisories.yaml
+++ b/cri-tools.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-11T16:52:08Z
         type: false-positive-determination

--- a/croc.advisories.yaml
+++ b/croc.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-43616
+    aliases:
+      - GHSA-8c8w-f7wp-2jr2
     events:
       - timestamp: 2023-09-30T18:59:24Z
         type: detection
@@ -15,6 +17,8 @@ advisories:
             cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
 
   - id: CVE-2023-43617
+    aliases:
+      - GHSA-hp56-xvf4-g6wr
     events:
       - timestamp: 2023-09-30T18:59:24Z
         type: detection
@@ -25,6 +29,8 @@ advisories:
             cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
 
   - id: CVE-2023-43618
+    aliases:
+      - GHSA-7mp6-929p-pqhj
     events:
       - timestamp: 2023-09-30T18:59:24Z
         type: detection
@@ -35,6 +41,8 @@ advisories:
             cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
 
   - id: CVE-2023-43619
+    aliases:
+      - GHSA-ppjh-xp5v-46wc
     events:
       - timestamp: 2023-09-30T18:59:24Z
         type: detection
@@ -45,6 +53,8 @@ advisories:
             cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
 
   - id: CVE-2023-43620
+    aliases:
+      - GHSA-364c-vvqx-446c
     events:
       - timestamp: 2023-09-30T18:59:24Z
         type: detection
@@ -55,6 +65,8 @@ advisories:
             cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
 
   - id: CVE-2023-43621
+    aliases:
+      - GHSA-7g3v-4ggr-xvjf
     events:
       - timestamp: 2023-09-30T18:59:24Z
         type: detection

--- a/cue.advisories.yaml
+++ b/cue.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2008-4470
+    aliases:
+      - GHSA-g98p-mfm5-59p2
     events:
       - timestamp: 2023-06-15T20:59:23Z
         type: false-positive-determination

--- a/cups.advisories.yaml
+++ b/cups.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-6553
+    aliases:
+      - GHSA-2f8v-v7q3-8gqv
     events:
       - timestamp: 2023-07-03T20:39:32Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: The vulnerability only applies to an ubuntu-specific app armor profile which is not included here.
 
   - id: CVE-2022-26691
+    aliases:
+      - GHSA-h495-hfpg-xw55
     events:
       - timestamp: 2022-10-25T17:38:24Z
         type: fixed

--- a/curl.advisories.yaml
+++ b/curl.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-32221
+    aliases:
+      - GHSA-grfr-78m7-q35q
     events:
       - timestamp: 2022-12-09T17:10:34Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 7.86.0-r0
 
   - id: CVE-2022-42916
+    aliases:
+      - GHSA-6295-5j29-3cc8
     events:
       - timestamp: 2022-11-19T15:37:17Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 7.86.0-r0
 
   - id: CVE-2022-43551
+    aliases:
+      - GHSA-25m2-mpq4-29vh
     events:
       - timestamp: 2022-12-21T13:16:36Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 7.87.0-r0
 
   - id: CVE-2022-43552
+    aliases:
+      - GHSA-6342-4x32-pp8v
     events:
       - timestamp: 2022-12-21T13:16:36Z
         type: fixed
@@ -33,6 +41,8 @@ advisories:
           fixed-version: 7.87.0-r0
 
   - id: CVE-2023-32001
+    aliases:
+      - GHSA-xc3w-ghxg-pw5f
     events:
       - timestamp: 2023-07-19T10:53:06Z
         type: fixed

--- a/dask-gateway.advisories.yaml
+++ b/dask-gateway.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-43804
+    aliases:
+      - GHSA-v845-jxx5-vc9f
     events:
       - timestamp: 2023-10-04T21:16:37Z
         type: fixed

--- a/dbus.advisories.yaml
+++ b/dbus.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-42010
+    aliases:
+      - GHSA-mmv5-g2hf-r8cf
     events:
       - timestamp: 2022-10-25T17:38:24Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.14.4-r0
 
   - id: CVE-2022-42011
+    aliases:
+      - GHSA-3g2p-5q22-h774
     events:
       - timestamp: 2022-10-25T17:38:24Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 1.14.4-r0
 
   - id: CVE-2022-42012
+    aliases:
+      - GHSA-7v94-mgqj-cj58
     events:
       - timestamp: 2022-10-25T17:38:24Z
         type: fixed

--- a/deno.advisories.yaml
+++ b/deno.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-22499
+    aliases:
+      - GHSA-mc52-jpm2-cqh6
     events:
       - timestamp: 2023-02-11T17:51:24Z
         type: fixed

--- a/dotnet-7.advisories.yaml
+++ b/dotnet-7.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-28260
+    aliases:
+      - GHSA-w4m3-43gp-x8hx
     events:
       - timestamp: 2023-04-11T17:23:04Z
         type: fixed

--- a/expat.advisories.yaml
+++ b/expat.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-40674
+    aliases:
+      - GHSA-2vq2-xc55-3j5m
     events:
       - timestamp: 2022-09-21T16:05:50Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 2.4.9-r0
 
   - id: CVE-2022-43680
+    aliases:
+      - GHSA-4hjv-8mmr-jxwv
     events:
       - timestamp: 2022-10-26T15:51:12Z
         type: fixed

--- a/flex.advisories.yaml
+++ b/flex.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-6293
+    aliases:
+      - GHSA-grpp-mcmx-p7pc
     events:
       - timestamp: 2022-10-11T19:48:04Z
         type: false-positive-determination

--- a/flux-helm-controller.advisories.yaml
+++ b/flux-helm-controller.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:41:21Z
         type: false-positive-determination

--- a/freetype.advisories.yaml
+++ b/freetype.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-27404
+    aliases:
+      - GHSA-22wv-f9f6-xwwm
     events:
       - timestamp: 2022-10-26T20:28:34Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 2.12.1-r0
 
   - id: CVE-2022-27405
+    aliases:
+      - GHSA-3p63-23m4-gmcp
     events:
       - timestamp: 2022-10-26T20:28:34Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 2.12.1-r0
 
   - id: CVE-2022-27406
+    aliases:
+      - GHSA-34wh-7j35-vw3w
     events:
       - timestamp: 2022-10-26T20:28:34Z
         type: fixed

--- a/gatekeeper-3.12.advisories.yaml
+++ b/gatekeeper-3.12.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This CVE affects the Prometheus UI (Javascript) and not the Go code
 
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:41:36Z
         type: false-positive-determination

--- a/gatekeeper-3.13.advisories.yaml
+++ b/gatekeeper-3.13.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This CVE affects the Prometheus UI (Javascript) and not the Go code
 
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:42:06Z
         type: false-positive-determination

--- a/gcc-6.advisories.yaml
+++ b/gcc-6.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-12886
+    aliases:
+      - GHSA-5mwp-7q9c-cgg2
     events:
       - timestamp: 2023-04-28T18:46:17Z
         type: detection
@@ -16,6 +18,8 @@ advisories:
           note: We are affected.
 
   - id: CVE-2019-15847
+    aliases:
+      - GHSA-rf68-2835-83vw
     events:
       - timestamp: 2023-04-28T18:46:17Z
         type: detection
@@ -28,6 +32,8 @@ advisories:
           note: We don't support POWER.
 
   - id: CVE-2021-37322
+    aliases:
+      - GHSA-6f99-ppjg-wgj7
     events:
       - timestamp: 2023-04-28T18:46:17Z
         type: detection

--- a/ghostscript.advisories.yaml
+++ b/ghostscript.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-36664
+    aliases:
+      - GHSA-9gf6-5j7x-x3m9
     events:
       - timestamp: 2023-09-06T15:58:48Z
         type: detection
@@ -20,6 +22,8 @@ advisories:
           note: The CPE configuration looks incorrect, 10.01.2 is included in the vulnerable range, but it should be excluded because the ghostpdl-10.01.2 tag upstream already contains the vulnerability-fixing commits.
 
   - id: CVE-2023-43115
+    aliases:
+      - GHSA-9p55-888j-qxrh
     events:
       - timestamp: 2023-09-30T19:00:42Z
         type: detection

--- a/giflib.advisories.yaml
+++ b/giflib.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-28506
+    aliases:
+      - GHSA-x77v-4m7v-7fgv
     events:
       - timestamp: 2022-11-16T11:48:05Z
         type: fixed

--- a/gitness.advisories.yaml
+++ b/gitness.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-20699
+    aliases:
+      - GHSA-m9q8-9m2h-84gh
     events:
       - timestamp: 2023-10-01T13:12:29Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: This vulnerability applies to the Docker daemon program, not the docker client libraries.
 
   - id: CVE-2020-13401
+    aliases:
+      - GHSA-qrrc-ww9x-r43g
     events:
       - timestamp: 2023-10-01T13:11:53Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: This vulnerability applies to the Docker daemon program, not the docker client libraries.
 
   - id: CVE-2023-3515
+    aliases:
+      - GHSA-cf6v-9j57-v6r6
     events:
       - timestamp: 2023-10-01T13:13:09Z
         type: false-positive-determination

--- a/glibc.advisories.yaml
+++ b/glibc.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2010-4756
+    aliases:
+      - GHSA-x2r9-jfjp-jvp9
     events:
       - timestamp: 2023-03-06T17:47:28Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Not a vulnerability. POSIX does not guarantee memory safety; resource limits should be appropriately set on applications which use untrusted inputs to glob. BSD GLOB_LIMIT extension is unreliable and was rejected by the GNU project.
 
   - id: CVE-2019-1010022
+    aliases:
+      - GHSA-hqfh-jh33-mj7r
     events:
       - timestamp: 2023-03-06T13:22:06Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: The CVE itself is disputed and should not be considered a security vulnerability.
 
   - id: CVE-2019-1010023
+    aliases:
+      - GHSA-x8wp-c333-hv92
     events:
       - timestamp: 2023-03-06T13:22:06Z
         type: false-positive-determination
@@ -29,6 +35,8 @@ advisories:
           note: The CVE itself is disputed and should not be considered a security vulnerability.
 
   - id: CVE-2019-1010024
+    aliases:
+      - GHSA-3q29-89cr-qgvj
     events:
       - timestamp: 2023-03-06T13:22:06Z
         type: false-positive-determination
@@ -37,6 +45,8 @@ advisories:
           note: The CVE itself is disputed and should not be considered a security vulnerability.
 
   - id: CVE-2019-1010025
+    aliases:
+      - GHSA-f8pw-hvh2-9x9f
     events:
       - timestamp: 2023-03-06T13:22:07Z
         type: false-positive-determination
@@ -45,6 +55,8 @@ advisories:
           note: The CVE itself is disputed and should not be considered a security vulnerability.
 
   - id: CVE-2022-39046
+    aliases:
+      - GHSA-f6rj-qrpf-jc34
     events:
       - timestamp: 2022-10-11T20:29:19Z
         type: fixed
@@ -52,6 +64,8 @@ advisories:
           fixed-version: 2.36-r1
 
   - id: CVE-2023-0687
+    aliases:
+      - GHSA-5r4p-4pqv-gqhw
     events:
       - timestamp: 2023-08-01T23:33:30Z
         type: false-positive-determination
@@ -60,6 +74,8 @@ advisories:
           note: The CVE itself is disputed and should not be considered a security vulnerability.
 
   - id: CVE-2023-25139
+    aliases:
+      - GHSA-2g67-jw5m-244m
     events:
       - timestamp: 2023-02-23T12:02:55Z
         type: fixed
@@ -67,6 +83,8 @@ advisories:
           fixed-version: 2.37-r1
 
   - id: CVE-2023-4527
+    aliases:
+      - GHSA-hmf7-f8gf-8f4p
     events:
       - timestamp: 2023-09-22T14:14:01Z
         type: fixed
@@ -74,6 +92,8 @@ advisories:
           fixed-version: 2.38-r2
 
   - id: CVE-2023-4911
+    aliases:
+      - GHSA-m77w-6vjw-wh2f
     events:
       - timestamp: 2023-10-03T22:58:32Z
         type: fixed
@@ -81,6 +101,8 @@ advisories:
           fixed-version: 2.38-r5
 
   - id: CVE-2023-5156
+    aliases:
+      - GHSA-m7p3-g2hx-xfc3
     events:
       - timestamp: 2023-09-27T12:40:16Z
         type: fixed

--- a/gmp.advisories.yaml
+++ b/gmp.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2021-43618
+    aliases:
+      - GHSA-mfg4-w44m-wr4g
     events:
       - timestamp: 2022-10-11T19:40:48Z
         type: fixed

--- a/gnupg.advisories.yaml
+++ b/gnupg.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-12020
+    aliases:
+      - GHSA-678p-6r6j-65f9
     events:
       - timestamp: 2023-01-15T00:25:50Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 2.2.41-r0
 
   - id: CVE-2019-14855
+    aliases:
+      - GHSA-cpvm-f36g-55vg
     events:
       - timestamp: 2023-01-15T00:25:50Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 2.2.41-r0
 
   - id: CVE-2020-25125
+    aliases:
+      - GHSA-g8h3-hp92-c5qx
     events:
       - timestamp: 2023-01-15T00:25:50Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 2.2.41-r0
 
   - id: CVE-2022-3219
+    aliases:
+      - GHSA-pf7g-97vv-qmrr
     events:
       - timestamp: 2023-06-05T10:34:22Z
         type: false-positive-determination
@@ -34,6 +42,8 @@ advisories:
           note: The upstream maintainers deem this to be working as intended and not a security issue. See https://dev.gnupg.org/T5993
 
   - id: CVE-2022-34903
+    aliases:
+      - GHSA-356p-pg27-x2cf
     events:
       - timestamp: 2023-01-15T00:25:50Z
         type: fixed

--- a/gnutls.advisories.yaml
+++ b/gnutls.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2017-7507
+    aliases:
+      - GHSA-w59v-wh6q-qc58
     events:
       - timestamp: 2023-01-15T00:22:41Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 3.7.8-r0
 
   - id: CVE-2019-3829
+    aliases:
+      - GHSA-mm54-95hq-f739
     events:
       - timestamp: 2023-01-15T00:22:41Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 3.7.8-r0
 
   - id: CVE-2019-3836
+    aliases:
+      - GHSA-fqw6-7w7w-627p
     events:
       - timestamp: 2023-01-15T00:22:41Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 3.7.8-r0
 
   - id: CVE-2020-11501
+    aliases:
+      - GHSA-j883-wjrw-g444
     events:
       - timestamp: 2023-01-15T00:22:41Z
         type: fixed
@@ -33,6 +41,8 @@ advisories:
           fixed-version: 3.7.8-r0
 
   - id: CVE-2020-13777
+    aliases:
+      - GHSA-cv49-m792-xmjv
     events:
       - timestamp: 2023-01-15T00:22:41Z
         type: fixed
@@ -40,6 +50,8 @@ advisories:
           fixed-version: 3.7.8-r0
 
   - id: CVE-2020-24659
+    aliases:
+      - GHSA-wx7m-j6j8-xm63
     events:
       - timestamp: 2023-01-15T00:22:41Z
         type: fixed
@@ -47,6 +59,8 @@ advisories:
           fixed-version: 3.7.8-r0
 
   - id: CVE-2021-20231
+    aliases:
+      - GHSA-mqq9-xchh-h97q
     events:
       - timestamp: 2023-01-15T00:22:41Z
         type: fixed
@@ -54,6 +68,8 @@ advisories:
           fixed-version: 3.7.8-r0
 
   - id: CVE-2021-20232
+    aliases:
+      - GHSA-p947-gfm7-f4g7
     events:
       - timestamp: 2023-01-15T00:22:41Z
         type: fixed
@@ -61,6 +77,8 @@ advisories:
           fixed-version: 3.7.8-r0
 
   - id: CVE-2022-2509
+    aliases:
+      - GHSA-w33j-4mrg-pgc3
     events:
       - timestamp: 2023-01-15T00:22:41Z
         type: fixed

--- a/go-1.19.advisories.yaml
+++ b/go-1.19.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-29509
+    aliases:
+      - GHSA-xhqq-x44f-9fgg
     events:
       - timestamp: 2023-03-05T01:01:40Z
         type: false-positive-determination
@@ -16,6 +18,8 @@ advisories:
           type: vulnerable-code-not-in-execution-path
 
   - id: CVE-2020-29511
+    aliases:
+      - GHSA-g7v2-7v9m-q9j4
     events:
       - timestamp: 2023-05-03T18:27:20Z
         type: false-positive-determination
@@ -23,6 +27,8 @@ advisories:
           type: vulnerable-code-version-not-used
 
   - id: CVE-2022-41716
+    aliases:
+      - GHSA-mh68-qf2j-8c5g
     events:
       - timestamp: 2022-11-01T17:39:29Z
         type: fixed
@@ -30,6 +36,8 @@ advisories:
           fixed-version: 1.19.3-r0
 
   - id: CVE-2022-41717
+    aliases:
+      - GHSA-xrjj-mj9h-534m
     events:
       - timestamp: 2022-12-07T08:11:39Z
         type: fixed
@@ -37,6 +45,8 @@ advisories:
           fixed-version: 1.19.4-r0
 
   - id: CVE-2022-41720
+    aliases:
+      - GHSA-cvf9-g74c-vv79
     events:
       - timestamp: 2022-12-07T08:11:39Z
         type: fixed
@@ -44,6 +54,8 @@ advisories:
           fixed-version: 1.19.4-r0
 
   - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-03-10T15:37:34Z
         type: fixed
@@ -51,6 +63,8 @@ advisories:
           fixed-version: 1.19.6-r1
 
   - id: CVE-2023-24532
+    aliases:
+      - GHSA-x2w5-7wp4-5qff
     events:
       - timestamp: 2023-03-10T15:43:49Z
         type: fixed
@@ -58,6 +72,8 @@ advisories:
           fixed-version: 1.19.7-r0
 
   - id: CVE-2023-24534
+    aliases:
+      - GHSA-8v5j-pwr7-w5f8
     events:
       - timestamp: 2023-04-05T12:50:56Z
         type: fixed
@@ -65,6 +81,8 @@ advisories:
           fixed-version: 1.19.8-r0
 
   - id: CVE-2023-24536
+    aliases:
+      - GHSA-9f7g-gqwh-jpf5
     events:
       - timestamp: 2023-04-05T12:50:56Z
         type: fixed
@@ -72,6 +90,8 @@ advisories:
           fixed-version: 1.19.8-r0
 
   - id: CVE-2023-24537
+    aliases:
+      - GHSA-fp86-2355-v99r
     events:
       - timestamp: 2023-04-05T12:50:56Z
         type: fixed
@@ -79,6 +99,8 @@ advisories:
           fixed-version: 1.19.8-r0
 
   - id: CVE-2023-24538
+    aliases:
+      - GHSA-v4m2-x4rp-hv22
     events:
       - timestamp: 2023-04-05T12:50:56Z
         type: fixed
@@ -86,6 +108,8 @@ advisories:
           fixed-version: 1.19.8-r0
 
   - id: CVE-2023-24539
+    aliases:
+      - GHSA-3q6h-q44p-xw88
     events:
       - timestamp: 2023-05-02T19:58:58Z
         type: fixed
@@ -93,6 +117,8 @@ advisories:
           fixed-version: 1.19.9-r0
 
   - id: CVE-2023-24540
+    aliases:
+      - GHSA-7qhm-5mxq-x7vp
     events:
       - timestamp: 2023-05-02T19:59:11Z
         type: fixed
@@ -100,6 +126,8 @@ advisories:
           fixed-version: 1.19.9-r0
 
   - id: CVE-2023-29400
+    aliases:
+      - GHSA-c9hr-fvm9-7c49
     events:
       - timestamp: 2023-05-02T19:59:18Z
         type: fixed
@@ -107,6 +135,8 @@ advisories:
           fixed-version: 1.19.9-r0
 
   - id: CVE-2023-29406
+    aliases:
+      - GHSA-f8f7-69v5-w4vx
     events:
       - timestamp: 2023-07-14T13:10:15Z
         type: fixed
@@ -114,6 +144,8 @@ advisories:
           fixed-version: 1.19.11-r0
 
   - id: CVE-2023-39318
+    aliases:
+      - GHSA-vq7j-gx56-rxjh
     events:
       - timestamp: 2023-09-14T17:46:48Z
         type: true-positive-determination
@@ -125,6 +157,8 @@ advisories:
           note: This package is locked to 1.19.x and will not receive a fix.
 
   - id: CVE-2023-39319
+    aliases:
+      - GHSA-vv9m-32rr-3g55
     events:
       - timestamp: 2023-09-14T17:53:53Z
         type: true-positive-determination

--- a/go-1.20.advisories.yaml
+++ b/go-1.20.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-29509
+    aliases:
+      - GHSA-xhqq-x44f-9fgg
     events:
       - timestamp: 2023-03-05T01:01:01Z
         type: false-positive-determination
@@ -16,6 +18,8 @@ advisories:
           type: vulnerable-code-not-in-execution-path
 
   - id: CVE-2020-29511
+    aliases:
+      - GHSA-g7v2-7v9m-q9j4
     events:
       - timestamp: 2023-03-05T01:01:14Z
         type: false-positive-determination
@@ -27,6 +31,8 @@ advisories:
           type: vulnerable-code-not-in-execution-path
 
   - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-03-10T15:38:17Z
         type: fixed
@@ -34,6 +40,8 @@ advisories:
           fixed-version: 1.20.1-r1
 
   - id: CVE-2023-24532
+    aliases:
+      - GHSA-x2w5-7wp4-5qff
     events:
       - timestamp: 2023-03-10T15:43:37Z
         type: fixed
@@ -41,6 +49,8 @@ advisories:
           fixed-version: 1.20.2-r0
 
   - id: CVE-2023-24534
+    aliases:
+      - GHSA-8v5j-pwr7-w5f8
     events:
       - timestamp: 2023-04-05T12:50:58Z
         type: fixed
@@ -48,6 +58,8 @@ advisories:
           fixed-version: 1.20.3-r0
 
   - id: CVE-2023-24536
+    aliases:
+      - GHSA-9f7g-gqwh-jpf5
     events:
       - timestamp: 2023-04-05T12:50:58Z
         type: fixed
@@ -55,6 +67,8 @@ advisories:
           fixed-version: 1.20.3-r0
 
   - id: CVE-2023-24537
+    aliases:
+      - GHSA-fp86-2355-v99r
     events:
       - timestamp: 2023-04-05T12:50:58Z
         type: fixed
@@ -62,6 +76,8 @@ advisories:
           fixed-version: 1.20.3-r0
 
   - id: CVE-2023-24538
+    aliases:
+      - GHSA-v4m2-x4rp-hv22
     events:
       - timestamp: 2023-04-05T12:50:58Z
         type: fixed
@@ -69,6 +85,8 @@ advisories:
           fixed-version: 1.20.3-r0
 
   - id: CVE-2023-24539
+    aliases:
+      - GHSA-3q6h-q44p-xw88
     events:
       - timestamp: 2023-05-02T20:01:15Z
         type: fixed
@@ -76,6 +94,8 @@ advisories:
           fixed-version: 1.20.4-r0
 
   - id: CVE-2023-24540
+    aliases:
+      - GHSA-7qhm-5mxq-x7vp
     events:
       - timestamp: 2023-05-02T20:01:15Z
         type: fixed
@@ -83,6 +103,8 @@ advisories:
           fixed-version: 1.20.4-r0
 
   - id: CVE-2023-29400
+    aliases:
+      - GHSA-c9hr-fvm9-7c49
     events:
       - timestamp: 2023-05-02T20:01:15Z
         type: fixed
@@ -90,6 +112,8 @@ advisories:
           fixed-version: 1.20.4-r0
 
   - id: CVE-2023-29406
+    aliases:
+      - GHSA-f8f7-69v5-w4vx
     events:
       - timestamp: 2023-07-14T13:10:34Z
         type: fixed
@@ -97,6 +121,8 @@ advisories:
           fixed-version: 1.20.6-r0
 
   - id: CVE-2023-29409
+    aliases:
+      - GHSA-xc82-5m89-g4jv
     events:
       - timestamp: 2023-08-14T20:20:14Z
         type: fixed

--- a/go-1.21.advisories.yaml
+++ b/go-1.21.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-29509
+    aliases:
+      - GHSA-xhqq-x44f-9fgg
     events:
       - timestamp: 2023-03-05T01:01:01Z
         type: false-positive-determination
@@ -16,6 +18,8 @@ advisories:
           type: vulnerable-code-not-in-execution-path
 
   - id: CVE-2020-29511
+    aliases:
+      - GHSA-g7v2-7v9m-q9j4
     events:
       - timestamp: 2023-03-05T01:01:14Z
         type: false-positive-determination
@@ -27,6 +31,8 @@ advisories:
           type: vulnerable-code-not-in-execution-path
 
   - id: CVE-2023-29406
+    aliases:
+      - GHSA-f8f7-69v5-w4vx
     events:
       - timestamp: 2023-07-14T13:10:46Z
         type: true-positive-determination
@@ -34,6 +40,8 @@ advisories:
           note: The Go team hasn't applied the patch yet since this is currently an rc release stream.
 
   - id: CVE-2023-29409
+    aliases:
+      - GHSA-xc82-5m89-g4jv
     events:
       - timestamp: 2023-08-14T20:19:14Z
         type: false-positive-determination

--- a/go-fips-1.19.advisories.yaml
+++ b/go-fips-1.19.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-29509
+    aliases:
+      - GHSA-xhqq-x44f-9fgg
     events:
       - timestamp: 2023-03-05T01:01:40Z
         type: false-positive-determination
@@ -16,6 +18,8 @@ advisories:
           type: vulnerable-code-not-in-execution-path
 
   - id: CVE-2020-29511
+    aliases:
+      - GHSA-g7v2-7v9m-q9j4
     events:
       - timestamp: 2023-05-03T18:27:38Z
         type: false-positive-determination
@@ -23,6 +27,8 @@ advisories:
           type: vulnerable-code-version-not-used
 
   - id: CVE-2022-41716
+    aliases:
+      - GHSA-mh68-qf2j-8c5g
     events:
       - timestamp: 2022-11-01T17:39:29Z
         type: fixed
@@ -30,6 +36,8 @@ advisories:
           fixed-version: 1.19.3-r0
 
   - id: CVE-2022-41717
+    aliases:
+      - GHSA-xrjj-mj9h-534m
     events:
       - timestamp: 2022-12-07T08:11:39Z
         type: fixed
@@ -37,6 +45,8 @@ advisories:
           fixed-version: 1.19.4-r0
 
   - id: CVE-2022-41720
+    aliases:
+      - GHSA-cvf9-g74c-vv79
     events:
       - timestamp: 2022-12-07T08:11:39Z
         type: fixed
@@ -44,6 +54,8 @@ advisories:
           fixed-version: 1.19.4-r0
 
   - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-03-10T15:37:34Z
         type: fixed
@@ -51,6 +63,8 @@ advisories:
           fixed-version: 1.19.6-r1
 
   - id: CVE-2023-24532
+    aliases:
+      - GHSA-x2w5-7wp4-5qff
     events:
       - timestamp: 2023-03-10T15:43:49Z
         type: fixed
@@ -58,6 +72,8 @@ advisories:
           fixed-version: 1.19.7-r0
 
   - id: CVE-2023-24534
+    aliases:
+      - GHSA-8v5j-pwr7-w5f8
     events:
       - timestamp: 2023-04-05T12:55:40Z
         type: fixed
@@ -65,6 +81,8 @@ advisories:
           fixed-version: 1.19.8-r0
 
   - id: CVE-2023-24536
+    aliases:
+      - GHSA-9f7g-gqwh-jpf5
     events:
       - timestamp: 2023-04-05T12:55:40Z
         type: fixed
@@ -72,6 +90,8 @@ advisories:
           fixed-version: 1.19.8-r0
 
   - id: CVE-2023-24537
+    aliases:
+      - GHSA-fp86-2355-v99r
     events:
       - timestamp: 2023-04-05T12:55:40Z
         type: fixed
@@ -79,6 +99,8 @@ advisories:
           fixed-version: 1.19.8-r0
 
   - id: CVE-2023-24538
+    aliases:
+      - GHSA-v4m2-x4rp-hv22
     events:
       - timestamp: 2023-04-05T12:55:40Z
         type: fixed
@@ -86,6 +108,8 @@ advisories:
           fixed-version: 1.19.8-r0
 
   - id: CVE-2023-24539
+    aliases:
+      - GHSA-3q6h-q44p-xw88
     events:
       - timestamp: 2023-05-02T19:59:47Z
         type: fixed
@@ -93,6 +117,8 @@ advisories:
           fixed-version: 1.19.9-r0
 
   - id: CVE-2023-24540
+    aliases:
+      - GHSA-7qhm-5mxq-x7vp
     events:
       - timestamp: 2023-05-02T19:59:58Z
         type: fixed
@@ -100,6 +126,8 @@ advisories:
           fixed-version: 1.19.9-r0
 
   - id: CVE-2023-29400
+    aliases:
+      - GHSA-c9hr-fvm9-7c49
     events:
       - timestamp: 2023-05-02T20:00:05Z
         type: fixed

--- a/go-fips-1.20.advisories.yaml
+++ b/go-fips-1.20.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-29509
+    aliases:
+      - GHSA-xhqq-x44f-9fgg
     events:
       - timestamp: 2023-03-05T01:01:01Z
         type: false-positive-determination
@@ -16,6 +18,8 @@ advisories:
           type: vulnerable-code-not-in-execution-path
 
   - id: CVE-2020-29511
+    aliases:
+      - GHSA-g7v2-7v9m-q9j4
     events:
       - timestamp: 2023-03-05T01:01:14Z
         type: false-positive-determination
@@ -27,6 +31,8 @@ advisories:
           type: vulnerable-code-not-in-execution-path
 
   - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-03-10T15:38:17Z
         type: fixed
@@ -34,6 +40,8 @@ advisories:
           fixed-version: 1.20.1-r1
 
   - id: CVE-2023-24532
+    aliases:
+      - GHSA-x2w5-7wp4-5qff
     events:
       - timestamp: 2023-03-10T15:43:37Z
         type: fixed
@@ -41,6 +49,8 @@ advisories:
           fixed-version: 1.20.2-r0
 
   - id: CVE-2023-24534
+    aliases:
+      - GHSA-8v5j-pwr7-w5f8
     events:
       - timestamp: 2023-04-05T12:55:05Z
         type: fixed
@@ -48,6 +58,8 @@ advisories:
           fixed-version: 1.20.3-r0
 
   - id: CVE-2023-24536
+    aliases:
+      - GHSA-9f7g-gqwh-jpf5
     events:
       - timestamp: 2023-04-05T12:55:05Z
         type: fixed
@@ -55,6 +67,8 @@ advisories:
           fixed-version: 1.20.3-r0
 
   - id: CVE-2023-24537
+    aliases:
+      - GHSA-fp86-2355-v99r
     events:
       - timestamp: 2023-04-05T12:55:05Z
         type: fixed
@@ -62,6 +76,8 @@ advisories:
           fixed-version: 1.20.3-r0
 
   - id: CVE-2023-24538
+    aliases:
+      - GHSA-v4m2-x4rp-hv22
     events:
       - timestamp: 2023-04-05T12:55:05Z
         type: fixed
@@ -69,6 +85,8 @@ advisories:
           fixed-version: 1.20.3-r0
 
   - id: CVE-2023-24539
+    aliases:
+      - GHSA-3q6h-q44p-xw88
     events:
       - timestamp: 2023-05-02T20:02:29Z
         type: fixed
@@ -76,6 +94,8 @@ advisories:
           fixed-version: 1.20.4-r0
 
   - id: CVE-2023-24540
+    aliases:
+      - GHSA-7qhm-5mxq-x7vp
     events:
       - timestamp: 2023-05-02T20:02:29Z
         type: fixed
@@ -83,6 +103,8 @@ advisories:
           fixed-version: 1.20.4-r0
 
   - id: CVE-2023-29400
+    aliases:
+      - GHSA-c9hr-fvm9-7c49
     events:
       - timestamp: 2023-05-02T20:02:29Z
         type: fixed

--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8908
+    aliases:
+      - GHSA-5mg8-w23w-74h3
     events:
       - timestamp: 2023-08-10T22:12:46Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 8.2.1-r1
 
   - id: CVE-2022-37866
+    aliases:
+      - GHSA-wv7w-rj2x-556x
     events:
       - timestamp: 2023-08-11T14:59:21Z
         type: false-positive-determination
@@ -20,6 +24,8 @@ advisories:
           note: 'Gradle is not vulnerable because it does not leverage the Apache Ivy dependency cache: https://github.com/gradle/gradle/issues/24795#issuecomment-1623594418'
 
   - id: CVE-2022-45868
+    aliases:
+      - GHSA-22wj-vf5f-wrvj
     events:
       - timestamp: 2023-08-11T14:07:24Z
         type: false-positive-determination
@@ -28,6 +34,8 @@ advisories:
           note: 'CVE is disputed. It relates to exposed passwords when using h2 via command-line. h2 is in use by Gradle as a library, and there is no reference of the CVE-related CLI argument being used in the codebase. Project maintainer''s position: https://github.com/gradle/gradle/issues/24708#issuecomment-1508321833'
 
   - id: CVE-2022-46751
+    aliases:
+      - GHSA-2jc4-r94c-rp7h
     events:
       - timestamp: 2023-08-25T21:31:33Z
         type: detection
@@ -43,6 +51,8 @@ advisories:
           fixed-version: 8.4.0-r0
 
   - id: CVE-2023-2976
+    aliases:
+      - GHSA-7g45-4rm6-3mm3
     events:
       - timestamp: 2023-08-08T21:07:36Z
         type: detection
@@ -54,6 +64,8 @@ advisories:
           fixed-version: 8.2.1-r1
 
   - id: CVE-2023-33201
+    aliases:
+      - GHSA-hr8g-6v94-x4m9
     events:
       - timestamp: 2023-10-04T22:46:36Z
         type: detection
@@ -61,6 +73,8 @@ advisories:
           type: manual
 
   - id: CVE-2023-35116
+    aliases:
+      - GHSA-gx6w-fqg7-mc3p
     events:
       - timestamp: 2023-08-11T15:36:11Z
         type: false-positive-determination
@@ -69,6 +83,8 @@ advisories:
           note: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386
 
   - id: CVE-2023-4759
+    aliases:
+      - GHSA-3p86-9955-h393
     events:
       - timestamp: 2023-09-24T13:16:58Z
         type: false-positive-determination

--- a/grpcurl.advisories.yaml
+++ b/grpcurl.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2021-31525
+    aliases:
+      - GHSA-h86h-8ppg-mxmh
     events:
       - timestamp: 2023-08-11T21:20:17Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.8.7-r7
 
   - id: CVE-2021-33194
+    aliases:
+      - GHSA-83g2-8m93-v3w7
     events:
       - timestamp: 2023-08-11T21:19:46Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 1.8.7-r7
 
   - id: CVE-2022-27664
+    aliases:
+      - GHSA-69cg-p879-7622
     events:
       - timestamp: 2023-08-11T21:18:47Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 1.8.7-r7
 
   - id: CVE-2022-29526
+    aliases:
+      - GHSA-p782-xgp4-8hr8
     events:
       - timestamp: 2023-08-11T21:21:21Z
         type: fixed
@@ -33,6 +41,8 @@ advisories:
           fixed-version: 1.8.7-r7
 
   - id: CVE-2022-32149
+    aliases:
+      - GHSA-69ch-w2m2-3vjp
     events:
       - timestamp: 2023-08-11T21:21:48Z
         type: fixed
@@ -40,6 +50,8 @@ advisories:
           fixed-version: 1.8.7-r7
 
   - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-08-11T21:20:57Z
         type: fixed

--- a/gtk-2.0.advisories.yaml
+++ b/gtk-2.0.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2014-1949
+    aliases:
+      - GHSA-38gw-6g45-69p7
     events:
       - timestamp: 2023-09-06T15:58:48Z
         type: detection

--- a/guacamole-server.advisories.yaml
+++ b/guacamole-server.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-30575
+    aliases:
+      - GHSA-jcgp-rv79-q77m
     events:
       - timestamp: 2023-06-21T22:40:20Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: This was fixed upstream prior to Wolfi packaging.
 
   - id: CVE-2023-30576
+    aliases:
+      - GHSA-q7pp-7w87-cjxp
     events:
       - timestamp: 2023-06-21T22:40:20Z
         type: false-positive-determination

--- a/haproxy-ingress.advisories.yaml
+++ b/haproxy-ingress.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:42:13Z
         type: false-positive-determination

--- a/haproxy.advisories.yaml
+++ b/haproxy.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2016-2102
+    aliases:
+      - GHSA-8g2x-6frq-q83x
     events:
       - timestamp: 2023-02-20T19:35:07Z
         type: false-positive-determination
@@ -16,6 +18,8 @@ advisories:
           type: vulnerable-code-not-in-execution-path
 
   - id: CVE-2023-0056
+    aliases:
+      - GHSA-43q4-pf55-3xhc
     events:
       - timestamp: 2023-05-04T14:59:24Z
         type: fixed
@@ -23,6 +27,8 @@ advisories:
           fixed-version: 2.6.8-r0
 
   - id: CVE-2023-25725
+    aliases:
+      - GHSA-h2p2-w857-329f
     events:
       - timestamp: 2023-02-15T09:12:20Z
         type: fixed
@@ -30,6 +36,8 @@ advisories:
           fixed-version: 2.6.9-r0
 
   - id: CVE-2023-40225
+    aliases:
+      - GHSA-xgq7-jp95-v2qv
     events:
       - timestamp: 2023-08-22T16:38:16Z
         type: fixed

--- a/heimdal.advisories.yaml
+++ b/heimdal.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-45142
+    aliases:
+      - GHSA-5gp7-pf54-xc33
     events:
       - timestamp: 2023-03-15T15:31:20Z
         type: detection

--- a/helm.advisories.yaml
+++ b/helm.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:42:20Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Go vulndb has marked this code NOT_IMPORTABLE.
 
   - id: CVE-2023-25165
+    aliases:
+      - GHSA-pwcw-6f5g-gxf8
     events:
       - timestamp: 2023-02-18T12:29:34Z
         type: fixed
@@ -20,6 +24,8 @@ advisories:
           fixed-version: 3.11.1-r0
 
   - id: CVE-2023-28840
+    aliases:
+      - GHSA-232p-vwff-86mp
     events:
       - timestamp: 2023-08-02T17:08:42Z
         type: detection
@@ -31,6 +37,8 @@ advisories:
           fixed-version: 3.12.2-r1
 
   - id: CVE-2023-28841
+    aliases:
+      - GHSA-33pg-m6jh-5237
     events:
       - timestamp: 2023-08-02T17:08:56Z
         type: detection
@@ -42,6 +50,8 @@ advisories:
           fixed-version: 3.12.2-r1
 
   - id: CVE-2023-28842
+    aliases:
+      - GHSA-6wrf-mxfj-pf5p
     events:
       - timestamp: 2023-08-02T17:09:12Z
         type: detection

--- a/hey.advisories.yaml
+++ b/hey.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-17847
+    aliases:
+      - GHSA-4r78-hx75-jjj2
     events:
       - timestamp: 2023-08-11T17:04:56Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 0.1.4-r3
 
   - id: CVE-2018-17848
+    aliases:
+      - GHSA-mv93-wvcp-7m7r
     events:
       - timestamp: 2023-08-11T17:05:49Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 0.1.4-r3
 
   - id: CVE-2019-9512
+    aliases:
+      - GHSA-hgr8-6h9x-f7q9
     events:
       - timestamp: 2023-08-11T17:05:40Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 0.1.4-r3
 
   - id: CVE-2019-9514
+    aliases:
+      - GHSA-39qc-96h7-956f
     events:
       - timestamp: 2023-08-11T17:03:13Z
         type: fixed
@@ -33,6 +41,8 @@ advisories:
           fixed-version: 0.1.4-r3
 
   - id: CVE-2021-31525
+    aliases:
+      - GHSA-h86h-8ppg-mxmh
     events:
       - timestamp: 2023-08-11T17:05:29Z
         type: fixed
@@ -40,6 +50,8 @@ advisories:
           fixed-version: 0.1.4-r3
 
   - id: CVE-2021-33194
+    aliases:
+      - GHSA-83g2-8m93-v3w7
     events:
       - timestamp: 2023-08-11T17:05:21Z
         type: fixed
@@ -47,6 +59,8 @@ advisories:
           fixed-version: 0.1.4-r3
 
   - id: CVE-2021-38561
+    aliases:
+      - GHSA-ppp9-7jff-5vj2
     events:
       - timestamp: 2023-08-11T17:06:18Z
         type: fixed
@@ -54,6 +68,8 @@ advisories:
           fixed-version: 0.1.4-r3
 
   - id: CVE-2022-27664
+    aliases:
+      - GHSA-69cg-p879-7622
     events:
       - timestamp: 2023-08-11T17:05:11Z
         type: fixed
@@ -61,6 +77,8 @@ advisories:
           fixed-version: 0.1.4-r3
 
   - id: CVE-2022-32149
+    aliases:
+      - GHSA-69ch-w2m2-3vjp
     events:
       - timestamp: 2023-08-11T17:06:08Z
         type: fixed
@@ -68,6 +86,8 @@ advisories:
           fixed-version: 0.1.4-r3
 
   - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-08-11T17:05:58Z
         type: fixed

--- a/httpie.advisories.yaml
+++ b/httpie.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-10751
+    aliases:
+      - GHSA-xjjg-vmw6-c2p9
     events:
       - timestamp: 2023-06-15T16:25:11Z
         type: false-positive-determination

--- a/ingress-nginx-controller.advisories.yaml
+++ b/ingress-nginx-controller.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-41741
+    aliases:
+      - GHSA-3v5h-538g-pr7g
     events:
       - timestamp: 2023-09-13T18:17:39Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: CVE relates to NGINX module ngx_http_mp4_module which is not included in the package
 
   - id: CVE-2022-41742
+    aliases:
+      - GHSA-wj45-j4gh-fm3x
     events:
       - timestamp: 2023-09-13T18:20:22Z
         type: false-positive-determination

--- a/istio-pilot-agent-1.18.advisories.yaml
+++ b/istio-pilot-agent-1.18.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.
 
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:42:29Z
         type: false-positive-determination

--- a/istio-pilot-discovery-1.19.advisories.yaml
+++ b/istio-pilot-discovery-1.19.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.
 
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:42:36Z
         type: false-positive-determination

--- a/jenkins.advisories.yaml
+++ b/jenkins.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2016-1000027
+    aliases:
+      - GHSA-4wrc-f8pq-fpqp
     events:
       - timestamp: 2023-07-21T18:56:46Z
         type: detection
@@ -16,7 +18,19 @@ advisories:
           type: vulnerable-code-not-in-execution-path
           note: Data serialization is performed by the Jenkins framework, nothing specific to this application.
 
+  - id: CVE-2022-1471
+    aliases:
+      - GHSA-mjmj-j48q-9wg2
+    events:
+      - timestamp: 2023-07-24T18:14:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The vulnerable code is not present in the Jenkins snakeyaml plugin, see https://github.com/jenkinsci/snakeyaml-api-plugin/pull/75#issuecomment-1482964755.
+
   - id: CVE-2023-24998
+    aliases:
+      - GHSA-hfrx-6qgj-fp6c
     events:
       - timestamp: 2023-03-26T01:19:30Z
         type: fixed
@@ -24,6 +38,8 @@ advisories:
           fixed-version: 2.394-r0
 
   - id: CVE-2023-27898
+    aliases:
+      - GHSA-j664-qhh4-hpf8
     events:
       - timestamp: 2023-03-11T23:35:43Z
         type: fixed
@@ -31,6 +47,8 @@ advisories:
           fixed-version: 2.394-r0
 
   - id: CVE-2023-27899
+    aliases:
+      - GHSA-hf9h-vv4m-2f33
     events:
       - timestamp: 2023-03-26T01:19:10Z
         type: fixed
@@ -38,6 +56,8 @@ advisories:
           fixed-version: 2.394-r0
 
   - id: CVE-2023-27902
+    aliases:
+      - GHSA-cj6r-8pxj-5jv6
     events:
       - timestamp: 2023-03-26T01:19:39Z
         type: fixed
@@ -45,6 +65,8 @@ advisories:
           fixed-version: 2.394-r0
 
   - id: CVE-2023-27903
+    aliases:
+      - GHSA-584m-7r4m-8j6v
     events:
       - timestamp: 2023-03-26T01:19:51Z
         type: fixed
@@ -52,6 +74,8 @@ advisories:
           fixed-version: 2.394-r0
 
   - id: CVE-2023-27904
+    aliases:
+      - GHSA-rrgp-c2w8-6vg6
     events:
       - timestamp: 2023-03-26T01:19:59Z
         type: fixed
@@ -59,6 +83,8 @@ advisories:
           fixed-version: 2.394-r0
 
   - id: CVE-2023-35116
+    aliases:
+      - GHSA-gx6w-fqg7-mc3p
     events:
       - timestamp: 2023-07-24T16:36:57Z
         type: false-positive-determination
@@ -73,11 +99,3 @@ advisories:
         data:
           type: vulnerability-record-analysis-contested
           note: This was deemed to not be a vulnerability in the code itself. Applications can use it incorrectly, but there's no evidence of that here.
-
-  - id: GHSA-mjmj-j48q-9wg2
-    events:
-      - timestamp: 2023-07-24T18:14:08Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: The vulnerable code is not present in the Jenkins snakeyaml plugin, see https://github.com/jenkinsci/snakeyaml-api-plugin/pull/75#issuecomment-1482964755.

--- a/k3s.advisories.yaml
+++ b/k3s.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-32187
+    aliases:
+      - GHSA-m4hf-6vgr-75r2
     events:
       - timestamp: 2023-09-12T12:21:44Z
         type: fixed

--- a/k8s-sidecar.advisories.yaml
+++ b/k8s-sidecar.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-43804
+    aliases:
+      - GHSA-v845-jxx5-vc9f
     events:
       - timestamp: 2023-10-04T21:16:51Z
         type: fixed

--- a/k8sgpt.advisories.yaml
+++ b/k8sgpt.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:42:53Z
         type: false-positive-determination

--- a/kafka.advisories.yaml
+++ b/kafka.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-26048
+    aliases:
+      - GHSA-qw69-rqj8-6qw8
     events:
       - timestamp: 2023-05-02T12:42:50Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 3.4.0-r2
 
   - id: CVE-2023-26049
+    aliases:
+      - GHSA-p26g-97m4-6q7c
     events:
       - timestamp: 2023-05-02T12:43:01Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 3.4.0-r2
 
   - id: CVE-2023-35116
+    aliases:
+      - GHSA-gx6w-fqg7-mc3p
     events:
       - timestamp: 2023-08-11T20:30:36Z
         type: false-positive-determination
@@ -27,6 +33,8 @@ advisories:
           note: CVE disputed by upstream developers, nothing specific to this application.
 
   - id: CVE-2023-36479
+    aliases:
+      - GHSA-3gh6-v5v9-6v9j
     events:
       - timestamp: 2023-09-22T20:13:33Z
         type: fixed
@@ -34,6 +42,8 @@ advisories:
           fixed-version: 3.5.1-r2
 
   - id: CVE-2023-40167
+    aliases:
+      - GHSA-hmr7-m48g-48f6
     events:
       - timestamp: 2023-09-22T20:13:39Z
         type: fixed
@@ -41,6 +51,8 @@ advisories:
           fixed-version: 3.5.1-r2
 
   - id: CVE-2023-41900
+    aliases:
+      - GHSA-pwh8-58vv-vw48
     events:
       - timestamp: 2023-09-22T20:13:48Z
         type: fixed
@@ -48,6 +60,8 @@ advisories:
           fixed-version: 3.5.1-r2
 
   - id: CVE-2023-43642
+    aliases:
+      - GHSA-55g7-9cwv-5qfv
     events:
       - timestamp: 2023-09-29T20:39:54Z
         type: fixed

--- a/kargo.advisories.yaml
+++ b/kargo.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T12:04:31Z
         type: false-positive-determination

--- a/keda-2.10.advisories.yaml
+++ b/keda-2.10.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:55:25Z
         type: false-positive-determination

--- a/keda.advisories.yaml
+++ b/keda.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:43:00Z
         type: false-positive-determination

--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2005-2945
+    aliases:
+      - GHSA-wf3w-8qhg-ch8v
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1139
 
   - id: CVE-2005-2992
+    aliases:
+      - GHSA-8699-hqh8-r4f6
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -20,7 +24,19 @@ advisories:
           type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1139
 
+  - id: CVE-2013-0136
+    aliases:
+      - GHSA-fm6j-565p-53h6
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1068
+
   - id: CVE-2017-12158
+    aliases:
+      - GHSA-v38p-mqq3-m6v5
     events:
       - timestamp: 2023-04-09T13:54:02Z
         type: false-positive-determination
@@ -29,6 +45,8 @@ advisories:
           note: The CVE was fixed in a version of keycloak prior to our packaging
 
   - id: CVE-2017-12159
+    aliases:
+      - GHSA-7fmw-85qm-h22p
     events:
       - timestamp: 2023-04-09T13:53:42Z
         type: false-positive-determination
@@ -36,15 +54,9 @@ advisories:
           type: vulnerable-code-version-not-used
           note: The CVE was fixed in a version of keycloak prior to our packaging
 
-  - id: CVE-2013-0136
-    events:
-      - timestamp: 2023-10-04T19:00:00Z
-        type: false-positive-determination
-        data:
-          type: component-vulnerability-mismatch
-          note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1068
-
   - id: CVE-2018-15529
+    aliases:
+      - GHSA-9xfc-48gq-9whq
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -53,6 +65,8 @@ advisories:
           note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1540
 
   - id: CVE-2020-8908
+    aliases:
+      - GHSA-5mg8-w23w-74h3
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -61,6 +75,8 @@ advisories:
           note: The affected methods are not in use. See https://github.com/keycloak/keycloak/issues/14786
 
   - id: CVE-2021-38542
+    aliases:
+      - GHSA-84wg-rgp8-2hg4
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -69,6 +85,8 @@ advisories:
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20228
 
   - id: CVE-2021-40110
+    aliases:
+      - GHSA-r58x-wjg8-63m9
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -77,6 +95,8 @@ advisories:
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20224
 
   - id: CVE-2021-40111
+    aliases:
+      - GHSA-fqgw-6qj5-8hmp
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -85,6 +105,8 @@ advisories:
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20229
 
   - id: CVE-2021-40525
+    aliases:
+      - GHSA-c38m-7h53-g9v4
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -92,15 +114,9 @@ advisories:
           type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20223
 
-  - id: CVE-2022-21511
-    events:
-      - timestamp: 2023-10-04T19:00:00Z
-        type: false-positive-determination
-        data:
-          type: component-vulnerability-mismatch
-          note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20227
-
   - id: CVE-2022-21510
+    aliases:
+      - GHSA-hj7f-p9jx-jpv6
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -108,7 +124,19 @@ advisories:
           type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20226
 
+  - id: CVE-2022-21511
+    aliases:
+      - GHSA-ggc6-2q83-mf7r
+    events:
+      - timestamp: 2023-10-04T19:00:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20227
+
   - id: CVE-2022-28220
+    aliases:
+      - GHSA-w45j-f5g5-w94x
     events:
       - timestamp: 2023-10-05T13:50:00Z
         type: false-positive-determination
@@ -119,6 +147,8 @@ advisories:
             Both are different applications. See https://github.com/keycloak/keycloak/issues/20225
 
   - id: CVE-2022-37832
+    aliases:
+      - GHSA-999r-r2f8-xm55
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -127,6 +157,8 @@ advisories:
           note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1068
 
   - id: CVE-2022-45935
+    aliases:
+      - GHSA-v6vp-62vc-84qw
     events:
       - timestamp: 2023-10-05T13:50:00Z
         type: false-positive-determination
@@ -136,18 +168,9 @@ advisories:
             Scanner is incorrectly matching vulnerabilities for apache:james-server against james.apache-mime4 (installed).
             Both are different applications. See https://github.com/anchore/grype/issues/1138
 
-  - id: CVE-2023-2976
-    events:
-      - timestamp: 2023-10-05T13:50:00Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-version-not-used
-          note: |
-            Scanner is correctly detecting guava v32.0.0 is installed, but is incorrectly
-            reporting that it is vulnerable to this CVE. v32.0.0 contains the fix.
-            See https://github.com/google/guava/releases/tag/v32.0.0 and https://github.com/keycloak/keycloak/pull/21544
-
   - id: CVE-2023-0264
+    aliases:
+      - GHSA-9g98-5mj6-f9mv
     events:
       - timestamp: 2023-04-30T11:15:20Z
         type: false-positive-determination
@@ -158,6 +181,8 @@ advisories:
             however this was fixed in an earlier version: v21.0.1. See https://github.com/advisories/GHSA-9g98-5mj6-f9mv
 
   - id: CVE-2023-26269
+    aliases:
+      - GHSA-w7r6-v4j7-h94w
     events:
       - timestamp: 2023-10-05T13:50:00Z
         type: false-positive-determination
@@ -165,7 +190,22 @@ advisories:
           type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/anchore/grype/issues/1138
 
+  - id: CVE-2023-2976
+    aliases:
+      - GHSA-7g45-4rm6-3mm3
+    events:
+      - timestamp: 2023-10-05T13:50:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: |
+            Scanner is correctly detecting guava v32.0.0 is installed, but is incorrectly
+            reporting that it is vulnerable to this CVE. v32.0.0 contains the fix.
+            See https://github.com/google/guava/releases/tag/v32.0.0 and https://github.com/keycloak/keycloak/pull/21544
+
   - id: CVE-2023-35116
+    aliases:
+      - GHSA-gx6w-fqg7-mc3p
     events:
       - timestamp: 2023-10-04T19:00:00Z
         type: false-positive-determination
@@ -174,6 +214,8 @@ advisories:
           note: CVE is being considered by the community a false positive. See https://github.com/FasterXML/jackson-databind/issues/3972 and https://github.com/anchore/grype/issues/1386
 
   - id: CVE-2023-4586
+    aliases:
+      - GHSA-57m8-f3v5-hm5m
     events:
       - timestamp: 2023-10-09T10:53:00Z
         type: true-positive-determination

--- a/ko.advisories.yaml
+++ b/ko.advisories.yaml
@@ -4,35 +4,45 @@ package:
   name: ko
 
 advisories:
-  - id: GHSA-232p-vwff-86mp
+  - id: CVE-2023-24535
+    aliases:
+      - GHSA-hw7c-3rfg-p46j
     events:
       - timestamp: 2023-05-04T14:34:34Z
         type: fixed
         data:
           fixed-version: 0.13.0-r3
 
-  - id: GHSA-2h5h-59f5-c5x9
+  - id: CVE-2023-28840
+    aliases:
+      - GHSA-232p-vwff-86mp
     events:
       - timestamp: 2023-05-04T14:34:34Z
         type: fixed
         data:
           fixed-version: 0.13.0-r3
 
-  - id: GHSA-33pg-m6jh-5237
+  - id: CVE-2023-28841
+    aliases:
+      - GHSA-33pg-m6jh-5237
     events:
       - timestamp: 2023-05-04T14:34:34Z
         type: fixed
         data:
           fixed-version: 0.13.0-r3
 
-  - id: GHSA-6wrf-mxfj-pf5p
+  - id: CVE-2023-28842
+    aliases:
+      - GHSA-6wrf-mxfj-pf5p
     events:
       - timestamp: 2023-05-04T14:34:34Z
         type: fixed
         data:
           fixed-version: 0.13.0-r3
 
-  - id: GHSA-hw7c-3rfg-p46j
+  - id: CVE-2023-30551
+    aliases:
+      - GHSA-2h5h-59f5-c5x9
     events:
       - timestamp: 2023-05-04T14:34:34Z
         type: fixed

--- a/kots.advisories.yaml
+++ b/kots.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-26290
+    aliases:
+      - GHSA-m9hp-7r99-94h5
     events:
       - timestamp: 2023-08-11T00:35:13Z
         type: detection
@@ -17,6 +19,8 @@ advisories:
           note: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).
 
   - id: CVE-2020-27847
+    aliases:
+      - GHSA-2x32-jm95-2cpx
     events:
       - timestamp: 2023-08-11T00:35:13Z
         type: detection
@@ -29,6 +33,8 @@ advisories:
           note: The vulnerability-fixing commit is an ancestor of the included commit of the dex module (2bb4896d120e).
 
   - id: CVE-2022-39222
+    aliases:
+      - GHSA-vh7g-p26c-j2cw
     events:
       - timestamp: 2023-08-11T00:35:13Z
         type: detection

--- a/kpt.advisories.yaml
+++ b/kpt.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-2253
+    aliases:
+      - GHSA-hqxw-f8mx-cpmw
     events:
       - timestamp: 2023-08-02T17:06:36Z
         type: detection

--- a/kube-downscaler.advisories.yaml
+++ b/kube-downscaler.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-37920
+    aliases:
+      - GHSA-xqr8-7jwr-rhp7
     events:
       - timestamp: 2023-08-25T23:23:14Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 23.2.0-r3
 
   - id: CVE-2023-43804
+    aliases:
+      - GHSA-v845-jxx5-vc9f
     events:
       - timestamp: 2023-10-04T21:17:02Z
         type: fixed

--- a/kube-fluentd-operator.advisories.yaml
+++ b/kube-fluentd-operator.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2008-1145
+    aliases:
+      - GHSA-f279-rf2r-m6m5
     events:
       - timestamp: 2023-07-10T14:15:14Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: The CVE was against an older version of ruby itself which included this in the stdlib.
 
   - id: CVE-2023-36617
+    aliases:
+      - GHSA-hww2-5g85-429m
     events:
       - timestamp: 2023-07-25T15:20:01Z
         type: true-positive-determination
@@ -20,6 +24,8 @@ advisories:
           note: This has been fixed upstream (commit dd73fe077cae077808e820f4765a12b1f4660521) and we're waiting for a release.
 
   - id: CVE-2023-38037
+    aliases:
+      - GHSA-cr5q-6q9f-rq6q
     events:
       - timestamp: 2023-08-29T16:45:48Z
         type: fixed

--- a/kubectl.advisories.yaml
+++ b/kubectl.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-07T19:07:36Z
         type: false-positive-determination

--- a/kubeflow-jupyter-web-app.advisories.yaml
+++ b/kubeflow-jupyter-web-app.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-41419
+    aliases:
+      - GHSA-x7m3-jprg-wc5g
     events:
       - timestamp: 2023-09-26T17:28:14Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.7.0-r4
 
   - id: CVE-2023-43804
+    aliases:
+      - GHSA-v845-jxx5-vc9f
     events:
       - timestamp: 2023-10-04T21:17:16Z
         type: fixed

--- a/kubeflow-pipelines.advisories.yaml
+++ b/kubeflow-pipelines.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-1002101
+    aliases:
+      - GHSA-wqwf-x5cj-rg56
     events:
       - timestamp: 2023-10-03T23:51:37Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerability is only present on Windows.
 
   - id: CVE-2019-1002100
+    aliases:
+      - GHSA-q4rr-64r9-fwgf
     events:
       - timestamp: 2023-09-09T16:57:09Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: Vulnerable code is part of the Kubernetes API server and was also mark EFFECTIVELY_PRIVATE in Golang vulndb
 
   - id: CVE-2019-1002101
+    aliases:
+      - GHSA-34jx-wx69-9x8v
     events:
       - timestamp: 2023-09-19T20:38:12Z
         type: false-positive-determination
@@ -29,6 +35,8 @@ advisories:
           note: Vulnerable code is not importable.
 
   - id: CVE-2019-11250
+    aliases:
+      - GHSA-jmrx-5g74-6v2f
     events:
       - timestamp: 2023-09-09T16:59:32Z
         type: true-positive-determination
@@ -36,6 +44,8 @@ advisories:
           note: Waiting for upstream release to pick up one of k8s.io/kubernetes 0.17.0+.
 
   - id: CVE-2019-11253
+    aliases:
+      - GHSA-pmqp-h87c-mr78
     events:
       - timestamp: 2023-09-30T14:48:25Z
         type: false-positive-determination
@@ -44,6 +54,8 @@ advisories:
           note: The Go team has determined the affected code is effectively private.
 
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:43:31Z
         type: false-positive-determination
@@ -52,6 +64,8 @@ advisories:
           note: Go vulndb has marked this code NOT_IMPORTABLE.
 
   - id: CVE-2020-8554
+    aliases:
+      - GHSA-j9wf-vvm6-4r9w
     events:
       - timestamp: 2023-09-09T17:06:13Z
         type: false-positive-determination
@@ -60,6 +74,8 @@ advisories:
           note: This is a Kubernetes API flaw, and this code is not reachable in our package and also code was marked EFFECTIVELY_PRIVATE in Golang vulndb
 
   - id: CVE-2020-8555
+    aliases:
+      - GHSA-x6mj-w4jf-jmgw
     events:
       - timestamp: 2023-09-19T17:12:25Z
         type: false-positive-determination
@@ -68,6 +84,8 @@ advisories:
           note: Go vulndb has marked this code NOT_IMPORTABLE.
 
   - id: CVE-2020-8558
+    aliases:
+      - GHSA-wqv3-8cm6-h6wg
     events:
       - timestamp: 2023-09-09T16:24:48Z
         type: false-positive-determination
@@ -76,6 +94,8 @@ advisories:
           note: Vulnerable code is part of the Kubernetes kubelet and kube-proxy and code was marked NOT_IMPORTABLE in Golang vulndb
 
   - id: CVE-2020-8561
+    aliases:
+      - GHSA-74j8-88mm-7496
     events:
       - timestamp: 2023-09-09T17:24:33Z
         type: false-positive-determination
@@ -84,6 +104,8 @@ advisories:
           note: This only affects kube-apiserver logs, and code was marked NOT_IMPORTABLE in Golang vulndb
 
   - id: CVE-2020-8562
+    aliases:
+      - GHSA-qh36-44jv-c8xj
     events:
       - timestamp: 2023-09-09T17:33:41Z
         type: false-positive-determination
@@ -92,6 +114,8 @@ advisories:
           note: Vulnerable code is part of a kubeflow-pipelines and code was marked NOT_IMPORTABLE in Golang vulndb
 
   - id: CVE-2020-8564
+    aliases:
+      - GHSA-8mjg-8c8g-6h85
     events:
       - timestamp: 2023-09-09T17:17:43Z
         type: true-positive-determination
@@ -99,6 +123,8 @@ advisories:
           note: Pending upstream project to pick up k8s.io/kubernetes 1.20.0-alpha.1+.
 
   - id: CVE-2020-8565
+    aliases:
+      - GHSA-8cfg-vx93-jvxw
     events:
       - timestamp: 2023-09-09T17:19:43Z
         type: true-positive-determination
@@ -106,6 +132,8 @@ advisories:
           note: Pending upstream project to pick up k8s.io/kubernetes 1.20.0-alpha.2+.
 
   - id: CVE-2021-25735
+    aliases:
+      - GHSA-g42g-737j-qx6j
     events:
       - timestamp: 2023-09-09T17:08:48Z
         type: false-positive-determination
@@ -114,6 +142,8 @@ advisories:
           note: Vulnerable code is part of a kubeflow-pipelines and code was marked NOT_IMPORTABLE in Golang vulndb
 
   - id: CVE-2021-25740
+    aliases:
+      - GHSA-vw47-mr44-3jf9
     events:
       - timestamp: 2023-09-09T17:29:41Z
         type: false-positive-determination
@@ -122,6 +152,8 @@ advisories:
           note: This only affects Kubernetes itself, and code was marked NOT_IMPORTABLE in Golang vulndb
 
   - id: CVE-2021-25741
+    aliases:
+      - GHSA-f5f7-6478-qm6p
     events:
       - timestamp: 2023-09-09T16:37:23Z
         type: false-positive-determination
@@ -130,6 +162,8 @@ advisories:
           note: Vulnerable code is part of a kubeflow-pipelines and code was marked NOT_IMPORTABLE in Golang vulndb
 
   - id: CVE-2021-25743
+    aliases:
+      - GHSA-f9jg-8p32-2f55
     events:
       - timestamp: 2023-10-03T20:15:51Z
         type: false-positive-determination
@@ -138,6 +172,8 @@ advisories:
           note: The vulnerable code is specific to kubectl.
 
   - id: CVE-2023-2431
+    aliases:
+      - GHSA-xc8m-28vv-4pjc
     events:
       - timestamp: 2023-09-09T16:49:11Z
         type: false-positive-determination
@@ -146,6 +182,8 @@ advisories:
           note: Vulnerable code is part of the Kubernetes kubelet which is not in the execution path of the kubeflow-pipelines and code was marked EFFECTIVELY_PRIVATE in Golang vulndb
 
   - id: CVE-2023-2727
+    aliases:
+      - GHSA-qc2g-gmh6-95p4
     events:
       - timestamp: 2023-09-09T16:54:16Z
         type: false-positive-determination
@@ -154,6 +192,8 @@ advisories:
           note: Vulnerable code is part of the Kubernetes API server and was also mark NOT_IMPORTABLE in Golang vulndb
 
   - id: CVE-2023-2728
+    aliases:
+      - GHSA-cgcv-5272-97pr
     events:
       - timestamp: 2023-09-09T17:14:39Z
         type: false-positive-determination

--- a/kubeflow-volumes-web-app.advisories.yaml
+++ b/kubeflow-volumes-web-app.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-41419
+    aliases:
+      - GHSA-x7m3-jprg-wc5g
     events:
       - timestamp: 2023-09-26T17:50:08Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.7.0-r5
 
   - id: CVE-2023-43804
+    aliases:
+      - GHSA-v845-jxx5-vc9f
     events:
       - timestamp: 2023-10-04T21:17:24Z
         type: fixed

--- a/kubernetes-1.24.advisories.yaml
+++ b/kubernetes-1.24.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2015-7561
+    aliases:
+      - GHSA-2h9c-34v6-3qmr
     events:
       - timestamp: 2023-08-18T17:06:31Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2016-1905
+    aliases:
+      - GHSA-xx8c-m748-xr4j
     events:
       - timestamp: 2023-08-18T17:06:32Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: Fixed in Kubernetes 1.2
 
   - id: CVE-2016-1906
+    aliases:
+      - GHSA-m3fm-h5jp-q79p
     events:
       - timestamp: 2023-08-18T17:06:33Z
         type: false-positive-determination
@@ -29,6 +35,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2016-7075
+    aliases:
+      - GHSA-7w66-j2r2-vm3p
     events:
       - timestamp: 2023-08-18T17:06:34Z
         type: false-positive-determination
@@ -37,6 +45,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-18T17:06:34Z
         type: false-positive-determination
@@ -45,6 +55,8 @@ advisories:
           note: Fixed in Kubernetes 2.1
 
   - id: CVE-2020-8554
+    aliases:
+      - GHSA-j9wf-vvm6-4r9w
     events:
       - timestamp: 2023-08-18T17:06:35Z
         type: false-positive-determination

--- a/kubernetes-1.25.advisories.yaml
+++ b/kubernetes-1.25.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2015-7561
+    aliases:
+      - GHSA-2h9c-34v6-3qmr
     events:
       - timestamp: 2023-08-18T17:06:36Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2016-1905
+    aliases:
+      - GHSA-xx8c-m748-xr4j
     events:
       - timestamp: 2023-08-18T17:06:37Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: Fixed in Kubernetes 1.2
 
   - id: CVE-2016-1906
+    aliases:
+      - GHSA-m3fm-h5jp-q79p
     events:
       - timestamp: 2023-08-18T17:06:37Z
         type: false-positive-determination
@@ -29,6 +35,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2016-7075
+    aliases:
+      - GHSA-7w66-j2r2-vm3p
     events:
       - timestamp: 2023-08-18T17:06:39Z
         type: false-positive-determination
@@ -37,6 +45,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-18T17:06:38Z
         type: false-positive-determination
@@ -45,6 +55,8 @@ advisories:
           note: Fixed in Kubernetes 1.2
 
   - id: CVE-2020-8554
+    aliases:
+      - GHSA-j9wf-vvm6-4r9w
     events:
       - timestamp: 2023-08-18T17:06:40Z
         type: false-positive-determination
@@ -53,6 +65,8 @@ advisories:
           note: Fixed in Kubernetes 1.21
 
   - id: CVE-2021-25743
+    aliases:
+      - GHSA-f9jg-8p32-2f55
     events:
       - timestamp: 2023-10-03T20:14:22Z
         type: true-positive-determination

--- a/kubernetes-1.26.advisories.yaml
+++ b/kubernetes-1.26.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2015-7561
+    aliases:
+      - GHSA-2h9c-34v6-3qmr
     events:
       - timestamp: 2023-08-18T17:06:41Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2016-1905
+    aliases:
+      - GHSA-xx8c-m748-xr4j
     events:
       - timestamp: 2023-08-18T17:06:41Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: Fixed in Kubernetes 1.2
 
   - id: CVE-2016-1906
+    aliases:
+      - GHSA-m3fm-h5jp-q79p
     events:
       - timestamp: 2023-08-18T17:06:42Z
         type: false-positive-determination
@@ -29,6 +35,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2016-7075
+    aliases:
+      - GHSA-7w66-j2r2-vm3p
     events:
       - timestamp: 2023-08-18T17:06:43Z
         type: false-positive-determination
@@ -37,6 +45,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-18T17:06:43Z
         type: false-positive-determination
@@ -45,6 +55,8 @@ advisories:
           note: Fixed in Kubernetes 1.2
 
   - id: CVE-2020-8554
+    aliases:
+      - GHSA-j9wf-vvm6-4r9w
     events:
       - timestamp: 2023-08-18T17:06:44Z
         type: false-positive-determination

--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2015-7561
+    aliases:
+      - GHSA-2h9c-34v6-3qmr
     events:
       - timestamp: 2023-08-18T17:06:45Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2016-1905
+    aliases:
+      - GHSA-xx8c-m748-xr4j
     events:
       - timestamp: 2023-08-18T17:06:46Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: Fixed in Kubernetes 1.2
 
   - id: CVE-2016-1906
+    aliases:
+      - GHSA-m3fm-h5jp-q79p
     events:
       - timestamp: 2023-08-18T17:06:46Z
         type: false-positive-determination
@@ -29,6 +35,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2016-7075
+    aliases:
+      - GHSA-7w66-j2r2-vm3p
     events:
       - timestamp: 2023-08-18T17:06:48Z
         type: false-positive-determination
@@ -37,6 +45,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-18T17:06:47Z
         type: false-positive-determination
@@ -45,6 +55,8 @@ advisories:
           note: Fixed in Kubernetes 1.2
 
   - id: CVE-2020-8554
+    aliases:
+      - GHSA-j9wf-vvm6-4r9w
     events:
       - timestamp: 2023-08-18T17:06:48Z
         type: false-positive-determination

--- a/kubernetes-1.28.advisories.yaml
+++ b/kubernetes-1.28.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2015-7561
+    aliases:
+      - GHSA-2h9c-34v6-3qmr
     events:
       - timestamp: 2023-08-18T17:06:49Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2016-1905
+    aliases:
+      - GHSA-xx8c-m748-xr4j
     events:
       - timestamp: 2023-08-18T17:06:50Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: Fixed in Kubernetes 1.2
 
   - id: CVE-2016-1906
+    aliases:
+      - GHSA-m3fm-h5jp-q79p
     events:
       - timestamp: 2023-08-18T17:06:51Z
         type: false-positive-determination
@@ -29,6 +35,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2016-7075
+    aliases:
+      - GHSA-7w66-j2r2-vm3p
     events:
       - timestamp: 2023-08-18T17:06:52Z
         type: false-positive-determination
@@ -37,6 +45,8 @@ advisories:
           note: Vulnerability only impacts OpenShift
 
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-18T17:06:51Z
         type: false-positive-determination
@@ -45,6 +55,8 @@ advisories:
           note: Fixed in Kubernetes 1.2
 
   - id: CVE-2020-8554
+    aliases:
+      - GHSA-j9wf-vvm6-4r9w
     events:
       - timestamp: 2023-08-18T17:06:53Z
         type: false-positive-determination

--- a/kubernetes-csi-external-provisioner.advisories.yaml
+++ b/kubernetes-csi-external-provisioner.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:43:44Z
         type: false-positive-determination

--- a/kubernetes-csi-external-resizer.advisories.yaml
+++ b/kubernetes-csi-external-resizer.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:44:00Z
         type: false-positive-determination

--- a/kubernetes-dashboard.advisories.yaml
+++ b/kubernetes-dashboard.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-2253
+    aliases:
+      - GHSA-hqxw-f8mx-cpmw
     events:
       - timestamp: 2023-05-26T17:58:25Z
         type: fixed

--- a/kubernetes-dns-node-cache.advisories.yaml
+++ b/kubernetes-dns-node-cache.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-21T16:27:12Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vulnerable code is part of external-csi-driver and not included in kubernetes-dns-node-cache
 
   - id: CVE-2021-25743
+    aliases:
+      - GHSA-f9jg-8p32-2f55
     events:
       - timestamp: 2023-10-03T20:16:15Z
         type: false-positive-determination

--- a/kubevela.advisories.yaml
+++ b/kubevela.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:44:26Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Go vulndb has marked this code NOT_IMPORTABLE.
 
   - id: CVE-2022-39383
+    aliases:
+      - GHSA-m5xf-x7q6-3rm7
     events:
       - timestamp: 2023-08-11T22:59:56Z
         type: false-positive-determination

--- a/kubevela.advisories.yaml
+++ b/kubevela.advisories.yaml
@@ -27,11 +27,3 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: This vulnerability is only present on Windows.
-
-  - id: GHSA-m5xf-x7q6-3rm7
-    events:
-      - timestamp: 2023-08-11T22:58:40Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-version-not-used
-          note: Vulnerable code was fixed in KubeVela 1.5.9/1.6.2.  Earliest Wolfi package is 1.7.0.

--- a/kyverno.advisories.yaml
+++ b/kyverno.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-30551
+    aliases:
+      - GHSA-2h5h-59f5-c5x9
     events:
       - timestamp: 2023-08-08T23:51:19Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: The vulnerable code in Rekor cannot be imported.
 
   - id: CVE-2023-33199
+    aliases:
+      - GHSA-frqx-jfcm-6jjr
     events:
       - timestamp: 2023-08-08T23:51:19Z
         type: false-positive-determination

--- a/libarchive.advisories.yaml
+++ b/libarchive.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-36227
+    aliases:
+      - GHSA-gpgf-w78r-4pvj
     events:
       - timestamp: 2022-12-06T16:23:01Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 3.6.1-r2
 
   - id: CVE-2023-30571
+    aliases:
+      - GHSA-cw7x-3mv7-w6xm
     events:
       - timestamp: 2023-06-11T13:10:50Z
         type: detection

--- a/libidn2.advisories.yaml
+++ b/libidn2.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-12290
+    aliases:
+      - GHSA-5pjp-55fh-7frw
     events:
       - timestamp: 2023-01-15T00:15:49Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 2.3.4-r0
 
   - id: CVE-2019-18224
+    aliases:
+      - GHSA-j2c9-63g7-697x
     events:
       - timestamp: 2023-01-15T00:15:49Z
         type: fixed

--- a/libjpeg-turbo.advisories.yaml
+++ b/libjpeg-turbo.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-2804
+    aliases:
+      - GHSA-jv36-3qpq-7g23
     events:
       - timestamp: 2023-06-07T17:56:43Z
         type: fixed

--- a/libksba.advisories.yaml
+++ b/libksba.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-3515
+    aliases:
+      - GHSA-58wq-p76f-6qjh
     events:
       - timestamp: 2023-01-15T00:17:15Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.6.3-r0
 
   - id: CVE-2022-47629
+    aliases:
+      - GHSA-j4m3-g4pc-cph8
     events:
       - timestamp: 2023-01-15T00:17:15Z
         type: fixed

--- a/libssh.advisories.yaml
+++ b/libssh.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-3603
+    aliases:
+      - GHSA-2c4f-vgwr-82q6
     events:
       - timestamp: 2023-08-11T22:37:30Z
         type: false-positive-determination

--- a/libssh2.advisories.yaml
+++ b/libssh2.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-3603
+    aliases:
+      - GHSA-2c4f-vgwr-82q6
     events:
       - timestamp: 2023-08-11T22:39:49Z
         type: false-positive-determination

--- a/libtasn1.advisories.yaml
+++ b/libtasn1.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2021-46848
+    aliases:
+      - GHSA-6468-68pw-9chw
     events:
       - timestamp: 2023-01-11T23:36:05Z
         type: fixed

--- a/libvterm.advisories.yaml
+++ b/libvterm.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-20786
+    aliases:
+      - GHSA-4r6h-327w-8qwr
     events:
       - timestamp: 2023-09-30T19:03:22Z
         type: detection

--- a/libwebp.advisories.yaml
+++ b/libwebp.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-4863
+    aliases:
+      - GHSA-j7hp-h8jx-5ppr
     events:
       - timestamp: 2023-09-12T14:44:35Z
         type: fixed

--- a/libxml2.advisories.yaml
+++ b/libxml2.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-40303
+    aliases:
+      - GHSA-94m8-rgr8-rg5g
     events:
       - timestamp: 2022-10-20T21:07:42Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 2.10.3-r0
 
   - id: CVE-2022-40304
+    aliases:
+      - GHSA-g848-pppp-vg6f
     events:
       - timestamp: 2022-10-20T21:07:42Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 2.10.3-r0
 
   - id: CVE-2023-45322
+    aliases:
+      - GHSA-vqpg-m25j-7558
     events:
       - timestamp: 2023-10-09T12:23:29Z
         type: fixed

--- a/libxpm.advisories.yaml
+++ b/libxpm.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-44617
+    aliases:
+      - GHSA-xwjc-m85h-pr32
     events:
       - timestamp: 2023-02-18T12:34:06Z
         type: fixed

--- a/loki.advisories.yaml
+++ b/loki.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This CVE affects the Prometheus UI (Javascript) and not the Go code
 
   - id: CVE-2023-40577
+    aliases:
+      - GHSA-v86x-5fm3-5p7j
     events:
       - timestamp: 2023-09-02T01:06:18Z
         type: fixed

--- a/lua5.4.advisories.yaml
+++ b/lua5.4.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-6706
+    aliases:
+      - GHSA-f6gj-vrmg-ccf7
     events:
       - timestamp: 2023-01-12T09:51:37Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 5.4.4-r0
 
   - id: CVE-2022-28805
+    aliases:
+      - GHSA-pxhp-rhgc-5jx8
     events:
       - timestamp: 2023-01-12T09:51:37Z
         type: fixed

--- a/mariadb-10.11.advisories.yaml
+++ b/mariadb-10.11.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-47015
+    aliases:
+      - GHSA-hc8h-974x-98hr
     events:
       - timestamp: 2023-02-12T12:33:40Z
         type: fixed

--- a/mariadb-10.6.advisories.yaml
+++ b/mariadb-10.6.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-47015
+    aliases:
+      - GHSA-hc8h-974x-98hr
     events:
       - timestamp: 2023-02-12T12:33:40Z
         type: fixed

--- a/maven.advisories.yaml
+++ b/maven.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8908
+    aliases:
+      - GHSA-5mg8-w23w-74h3
     events:
       - timestamp: 2023-08-18T21:06:28Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 3.9.3-r1
 
   - id: CVE-2023-2976
+    aliases:
+      - GHSA-7g45-4rm6-3mm3
     events:
       - timestamp: 2023-08-18T21:06:59Z
         type: fixed

--- a/melange.advisories.yaml
+++ b/melange.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-28840
+    aliases:
+      - GHSA-232p-vwff-86mp
     events:
       - timestamp: 2023-04-05T14:22:34Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 0.3.2-r1
 
   - id: CVE-2023-28841
+    aliases:
+      - GHSA-33pg-m6jh-5237
     events:
       - timestamp: 2023-04-05T14:22:34Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 0.3.2-r1
 
   - id: CVE-2023-28842
+    aliases:
+      - GHSA-6wrf-mxfj-pf5p
     events:
       - timestamp: 2023-04-05T14:22:34Z
         type: fixed

--- a/metrics-server.advisories.yaml
+++ b/metrics-server.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This CVE affects the Prometheus UI (Javascript) and not the Go code. See prometheus/prometheus#12403 and prometheus/prometheus#5163
 
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:44:40Z
         type: false-positive-determination

--- a/minio.advisories.yaml
+++ b/minio.advisories.yaml
@@ -12,6 +12,8 @@ advisories:
           type: vulnerable-code-version-not-used
 
   - id: CVE-2020-11012
+    aliases:
+      - GHSA-xv4r-vccv-mg4w
     events:
       - timestamp: 2023-03-25T21:04:39Z
         type: false-positive-determination
@@ -54,6 +56,8 @@ advisories:
           type: vulnerable-code-version-not-used
 
   - id: CVE-2023-28433
+    aliases:
+      - GHSA-w23q-4hw3-2pp6
     events:
       - timestamp: 2023-04-13T21:44:39Z
         type: fixed
@@ -61,6 +65,8 @@ advisories:
           fixed-version: 0.20230413.030807
 
   - id: CVE-2023-28434
+    aliases:
+      - GHSA-2pxw-r47w-4p8c
     events:
       - timestamp: 2023-04-13T21:44:43Z
         type: fixed

--- a/modsecurity.advisories.yaml
+++ b/modsecurity.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-28882
+    aliases:
+      - GHSA-wgcm-rvmx-wh95
     events:
       - timestamp: 2023-06-11T13:10:50Z
         type: detection
@@ -16,6 +18,8 @@ advisories:
           fixed-version: 3.0.9-r0
 
   - id: CVE-2023-38285
+    aliases:
+      - GHSA-wf6m-89q7-h9jh
     events:
       - timestamp: 2023-08-03T18:54:35Z
         type: detection

--- a/ncurses.advisories.yaml
+++ b/ncurses.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-29458
+    aliases:
+      - GHSA-jh4f-5j2m-4v9c
     events:
       - timestamp: 2022-10-11T19:49:30Z
         type: fixed

--- a/nettle.advisories.yaml
+++ b/nettle.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2021-20305
+    aliases:
+      - GHSA-6xrq-2ww3-f6h5
     events:
       - timestamp: 2023-01-15T00:21:09Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 3.8.1-r0
 
   - id: CVE-2021-3580
+    aliases:
+      - GHSA-52fp-4722-wcjw
     events:
       - timestamp: 2023-01-15T00:21:09Z
         type: fixed

--- a/nghttp2.advisories.yaml
+++ b/nghttp2.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-44487
+    aliases:
+      - GHSA-qppj-fm5r-hxr3
     events:
       - timestamp: 2023-10-11T17:18:05Z
         type: fixed

--- a/node-problem-detector.advisories.yaml
+++ b/node-problem-detector.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11250
+    aliases:
+      - GHSA-jmrx-5g74-6v2f
     events:
       - timestamp: 2023-08-11T19:35:15Z
         type: true-positive-determination
@@ -16,6 +18,8 @@ advisories:
           fixed-version: 0.8.14-r0
 
   - id: CVE-2020-8554
+    aliases:
+      - GHSA-j9wf-vvm6-4r9w
     events:
       - timestamp: 2023-08-11T18:24:18Z
         type: false-positive-determination
@@ -24,6 +28,8 @@ advisories:
           note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   - id: CVE-2020-8558
+    aliases:
+      - GHSA-wqv3-8cm6-h6wg
     events:
       - timestamp: 2023-08-11T17:55:42Z
         type: false-positive-determination
@@ -32,6 +38,8 @@ advisories:
           note: Vulnerable code is part of an external controller not included k8s.io/kube-proxy library
 
   - id: CVE-2020-8561
+    aliases:
+      - GHSA-74j8-88mm-7496
     events:
       - timestamp: 2023-08-11T18:22:58Z
         type: false-positive-determination
@@ -40,6 +48,8 @@ advisories:
           note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   - id: CVE-2020-8562
+    aliases:
+      - GHSA-qh36-44jv-c8xj
     events:
       - timestamp: 2023-08-11T17:57:54Z
         type: false-positive-determination
@@ -48,6 +58,8 @@ advisories:
           note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   - id: CVE-2020-8564
+    aliases:
+      - GHSA-8mjg-8c8g-6h85
     events:
       - timestamp: 2023-08-11T19:46:01Z
         type: true-positive-determination
@@ -59,6 +71,8 @@ advisories:
           fixed-version: 0.8.14-r0
 
   - id: CVE-2020-8565
+    aliases:
+      - GHSA-8cfg-vx93-jvxw
     events:
       - timestamp: 2023-08-11T19:45:22Z
         type: true-positive-determination
@@ -70,6 +84,8 @@ advisories:
           fixed-version: 0.8.14-r0
 
   - id: CVE-2021-25735
+    aliases:
+      - GHSA-g42g-737j-qx6j
     events:
       - timestamp: 2023-08-11T18:21:29Z
         type: false-positive-determination
@@ -78,6 +94,8 @@ advisories:
           note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   - id: CVE-2021-25740
+    aliases:
+      - GHSA-vw47-mr44-3jf9
     events:
       - timestamp: 2023-08-11T18:26:56Z
         type: false-positive-determination
@@ -86,6 +104,8 @@ advisories:
           note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   - id: CVE-2021-25741
+    aliases:
+      - GHSA-f5f7-6478-qm6p
     events:
       - timestamp: 2023-08-11T18:11:46Z
         type: false-positive-determination
@@ -94,6 +114,8 @@ advisories:
           note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   - id: CVE-2023-2431
+    aliases:
+      - GHSA-xc8m-28vv-4pjc
     events:
       - timestamp: 2023-08-11T18:14:34Z
         type: false-positive-determination
@@ -102,6 +124,8 @@ advisories:
           note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   - id: CVE-2023-2727
+    aliases:
+      - GHSA-qc2g-gmh6-95p4
     events:
       - timestamp: 2023-08-11T17:42:39Z
         type: false-positive-determination
@@ -110,6 +134,8 @@ advisories:
           note: Vulnerable code is part of an external controller not included k8s.io/kubernetes library
 
   - id: CVE-2023-2728
+    aliases:
+      - GHSA-cgcv-5272-97pr
     events:
       - timestamp: 2023-08-11T17:50:53Z
         type: false-positive-determination

--- a/nodejs-16.advisories.yaml
+++ b/nodejs-16.advisories.yaml
@@ -26,6 +26,8 @@ advisories:
           fixed-version: 16.20.1-r0
 
   - id: CVE-2023-30589
+    aliases:
+      - GHSA-cggh-pq45-6h9x
     events:
       - timestamp: 2023-06-20T17:11:00Z
         type: fixed
@@ -40,6 +42,8 @@ advisories:
           fixed-version: 16.20.1-r0
 
   - id: CVE-2023-32002
+    aliases:
+      - GHSA-9m48-r3w4-x35v
     events:
       - timestamp: 2023-08-10T12:00:44Z
         type: fixed
@@ -47,6 +51,8 @@ advisories:
           fixed-version: 16.20.2-r0
 
   - id: CVE-2023-32003
+    aliases:
+      - GHSA-r874-ffh8-2fvj
     events:
       - timestamp: 2023-08-23T15:15:50Z
         type: false-positive-determination
@@ -55,6 +61,8 @@ advisories:
           note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 16. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
   - id: CVE-2023-32004
+    aliases:
+      - GHSA-x3wm-m4vj-p6px
     events:
       - timestamp: 2023-08-23T15:17:36Z
         type: false-positive-determination
@@ -63,6 +71,8 @@ advisories:
           note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 16. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
   - id: CVE-2023-32006
+    aliases:
+      - GHSA-356r-x8g9-vh8c
     events:
       - timestamp: 2023-08-10T12:00:44Z
         type: fixed
@@ -70,6 +80,8 @@ advisories:
           fixed-version: 16.20.2-r0
 
   - id: CVE-2023-32559
+    aliases:
+      - GHSA-g467-j8jp-rq97
     events:
       - timestamp: 2023-08-10T12:00:44Z
         type: fixed

--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -26,6 +26,8 @@ advisories:
           fixed-version: 18.16.1-r0
 
   - id: CVE-2023-30589
+    aliases:
+      - GHSA-cggh-pq45-6h9x
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed
@@ -40,6 +42,8 @@ advisories:
           fixed-version: 18.16.1-r0
 
   - id: CVE-2023-32002
+    aliases:
+      - GHSA-9m48-r3w4-x35v
     events:
       - timestamp: 2023-08-10T12:00:44Z
         type: fixed
@@ -47,6 +51,8 @@ advisories:
           fixed-version: 18.17.1-r0
 
   - id: CVE-2023-32003
+    aliases:
+      - GHSA-r874-ffh8-2fvj
     events:
       - timestamp: 2023-08-23T15:18:24Z
         type: false-positive-determination
@@ -55,6 +61,8 @@ advisories:
           note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 18. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
   - id: CVE-2023-32004
+    aliases:
+      - GHSA-x3wm-m4vj-p6px
     events:
       - timestamp: 2023-08-23T15:18:42Z
         type: false-positive-determination
@@ -63,6 +71,8 @@ advisories:
           note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 18. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
   - id: CVE-2023-32006
+    aliases:
+      - GHSA-356r-x8g9-vh8c
     events:
       - timestamp: 2023-08-10T12:00:44Z
         type: fixed
@@ -70,6 +80,8 @@ advisories:
           fixed-version: 18.17.1-r0
 
   - id: CVE-2023-32559
+    aliases:
+      - GHSA-g467-j8jp-rq97
     events:
       - timestamp: 2023-08-10T12:00:44Z
         type: fixed

--- a/nodejs-19.advisories.yaml
+++ b/nodejs-19.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-32003
+    aliases:
+      - GHSA-r874-ffh8-2fvj
     events:
       - timestamp: 2023-08-23T15:22:45Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 19. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
 
   - id: CVE-2023-32004
+    aliases:
+      - GHSA-x3wm-m4vj-p6px
     events:
       - timestamp: 2023-08-23T15:23:06Z
         type: false-positive-determination

--- a/nodejs-20.advisories.yaml
+++ b/nodejs-20.advisories.yaml
@@ -40,6 +40,8 @@ advisories:
           fixed-version: 20.3.1-r0
 
   - id: CVE-2023-30586
+    aliases:
+      - GHSA-jvqw-9mq6-23h9
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed
@@ -61,6 +63,8 @@ advisories:
           fixed-version: 20.3.1-r0
 
   - id: CVE-2023-30589
+    aliases:
+      - GHSA-cggh-pq45-6h9x
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed
@@ -75,6 +79,8 @@ advisories:
           fixed-version: 20.3.1-r0
 
   - id: CVE-2023-32002
+    aliases:
+      - GHSA-9m48-r3w4-x35v
     events:
       - timestamp: 2023-08-10T12:00:44Z
         type: fixed
@@ -82,6 +88,8 @@ advisories:
           fixed-version: 20.5.1-r0
 
   - id: CVE-2023-32003
+    aliases:
+      - GHSA-r874-ffh8-2fvj
     events:
       - timestamp: 2023-08-23T15:33:03Z
         type: fixed
@@ -89,6 +97,8 @@ advisories:
           fixed-version: 20.5.1-r0
 
   - id: CVE-2023-32004
+    aliases:
+      - GHSA-x3wm-m4vj-p6px
     events:
       - timestamp: 2023-08-23T15:33:23Z
         type: fixed
@@ -96,6 +106,8 @@ advisories:
           fixed-version: 20.5.1-r0
 
   - id: CVE-2023-32006
+    aliases:
+      - GHSA-356r-x8g9-vh8c
     events:
       - timestamp: 2023-08-10T12:00:44Z
         type: fixed
@@ -103,6 +115,8 @@ advisories:
           fixed-version: 20.5.1-r0
 
   - id: CVE-2023-32558
+    aliases:
+      - GHSA-h9p4-9jqg-j34h
     events:
       - timestamp: 2023-09-16T13:47:40Z
         type: fixed
@@ -110,6 +124,8 @@ advisories:
           fixed-version: 20.5.1-r0
 
   - id: CVE-2023-32559
+    aliases:
+      - GHSA-g467-j8jp-rq97
     events:
       - timestamp: 2023-08-10T12:00:44Z
         type: fixed

--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
     events:
       - timestamp: 2023-08-11T17:53:13Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: Vuln only present in Kubernets CSI sidecars external-provisioner, external-snapshotter, external-resizer
 
   - id: CVE-2020-8554
+    aliases:
+      - GHSA-j9wf-vvm6-4r9w
     events:
       - timestamp: 2023-08-11T18:25:13Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: This is a Kubernetes API flaw, but we don't include an API server in this package.
 
   - id: CVE-2020-8561
+    aliases:
+      - GHSA-74j8-88mm-7496
     events:
       - timestamp: 2023-08-11T19:02:42Z
         type: false-positive-determination
@@ -29,6 +35,8 @@ advisories:
           note: This only affects kube-apiserver logs, and code was marked NOT_IMPORTABLE in Golang vulndb
 
   - id: CVE-2020-8564
+    aliases:
+      - GHSA-8mjg-8c8g-6h85
     events:
       - timestamp: 2023-08-11T19:22:26Z
         type: false-positive-determination
@@ -37,6 +45,8 @@ advisories:
           note: This does not affect k8s.io/client-go@v0.20.0-alpha.2
 
   - id: CVE-2020-8565
+    aliases:
+      - GHSA-8cfg-vx93-jvxw
     events:
       - timestamp: 2023-08-11T19:17:00Z
         type: false-positive-determination
@@ -45,6 +55,8 @@ advisories:
           note: This does not affect k8s.io/client-go@v0.20.0-alpha.2
 
   - id: CVE-2021-25740
+    aliases:
+      - GHSA-vw47-mr44-3jf9
     events:
       - timestamp: 2023-08-11T18:11:11Z
         type: false-positive-determination
@@ -53,6 +65,8 @@ advisories:
           note: This only affects Kubernetes itself, and code was marked not importable in Golang vulndb
 
   - id: CVE-2021-25743
+    aliases:
+      - GHSA-f9jg-8p32-2f55
     events:
       - timestamp: 2023-10-03T20:18:12Z
         type: false-positive-determination
@@ -61,6 +75,8 @@ advisories:
           note: Vulnerable code is specific to kubectl.
 
   - id: CVE-2023-2431
+    aliases:
+      - GHSA-xc8m-28vv-4pjc
     events:
       - timestamp: 2023-08-11T18:16:32Z
         type: false-positive-determination
@@ -69,6 +85,8 @@ advisories:
           note: This bug affects Kubelet, which isn't in nodetaint -- also Golang vulndb marked as EFFECTIVELY_PRIVATE
 
   - id: CVE-2023-2727
+    aliases:
+      - GHSA-qc2g-gmh6-95p4
     events:
       - timestamp: 2023-08-11T18:58:45Z
         type: false-positive-determination
@@ -77,6 +95,8 @@ advisories:
           note: This is only affecting Kubernetes, and was also mark NOT_IMPORTABLE in Golang vulndb
 
   - id: CVE-2023-2728
+    aliases:
+      - GHSA-cgcv-5272-97pr
     events:
       - timestamp: 2023-08-11T19:05:59Z
         type: false-positive-determination

--- a/oauth2-proxy.advisories.yaml
+++ b/oauth2-proxy.advisories.yaml
@@ -4,7 +4,9 @@ package:
   name: oauth2-proxy
 
 advisories:
-  - id: GHSA-vvpx-j8f3-3w6h
+  - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-04-17T21:30:27Z
         type: fixed

--- a/openai.advisories.yaml
+++ b/openai.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-37276
+    aliases:
+      - GHSA-45c4-8wx5-qw6w
     events:
       - timestamp: 2023-08-10T18:58:35Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 0.27.8-r1
 
   - id: CVE-2023-37920
+    aliases:
+      - GHSA-xqr8-7jwr-rhp7
     events:
       - timestamp: 2023-08-10T18:58:59Z
         type: fixed

--- a/openjdk-7.advisories.yaml
+++ b/openjdk-7.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-21968
+    aliases:
+      - GHSA-r6j2-4r52-mpg7
     events:
       - timestamp: 2023-09-06T15:58:49Z
         type: detection

--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-21968
+    aliases:
+      - GHSA-r6j2-4r52-mpg7
     events:
       - timestamp: 2023-08-11T20:23:47Z
         type: false-positive-determination

--- a/openjpeg.advisories.yaml
+++ b/openjpeg.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2015-1239
+    aliases:
+      - GHSA-935h-fp8w-9vph
     events:
       - timestamp: 2023-09-20T17:48:28Z
         type: false-positive-determination

--- a/openmp-16.advisories.yaml
+++ b/openmp-16.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-26345
+    aliases:
+      - GHSA-p5mj-2xj9-v4jv
     events:
       - timestamp: 2023-09-30T19:05:11Z
         type: detection

--- a/opensearch-2.advisories.yaml
+++ b/opensearch-2.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-35116
+    aliases:
+      - GHSA-gx6w-fqg7-mc3p
     events:
       - timestamp: 2023-08-11T20:28:34Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: CVE disputed by upstream developers, nothing specific to this application.
 
   - id: CVE-2023-42503
+    aliases:
+      - GHSA-cgwf-w82q-5jrr
     events:
       - timestamp: 2023-10-01T17:49:15Z
         type: fixed

--- a/openssh.advisories.yaml
+++ b/openssh.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-25136
+    aliases:
+      - GHSA-w62j-g234-3f6f
     events:
       - timestamp: 2023-02-06T18:39:35Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 9.2_p1-r0
 
   - id: CVE-2023-38408
+    aliases:
+      - GHSA-px36-p9hv-7h2v
     events:
       - timestamp: 2023-07-19T16:06:22Z
         type: fixed

--- a/openssl.advisories.yaml
+++ b/openssl.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-3358
+    aliases:
+      - GHSA-4f63-89w9-3jjv
     events:
       - timestamp: 2022-11-01T16:49:56Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 3.0.7-r0
 
   - id: CVE-2022-3602
+    aliases:
+      - GHSA-8rwr-x37p-mx23
     events:
       - timestamp: 2022-11-01T16:49:56Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 3.0.7-r0
 
   - id: CVE-2022-3786
+    aliases:
+      - GHSA-h8jm-2x53-xhp5
     events:
       - timestamp: 2022-11-01T16:49:56Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 3.0.7-r0
 
   - id: CVE-2022-3996
+    aliases:
+      - GHSA-vr8j-hgmm-jh9r
     events:
       - timestamp: 2022-12-22T17:26:45Z
         type: fixed
@@ -33,6 +41,8 @@ advisories:
           fixed-version: 3.0.7-r1
 
   - id: CVE-2022-4203
+    aliases:
+      - GHSA-w67w-mw4j-8qrv
     events:
       - timestamp: 2023-02-07T16:50:00Z
         type: fixed
@@ -40,6 +50,8 @@ advisories:
           fixed-version: 3.0.8-r0
 
   - id: CVE-2022-4304
+    aliases:
+      - GHSA-p52g-cm5j-mjv4
     events:
       - timestamp: 2023-02-07T16:49:50Z
         type: fixed
@@ -47,6 +59,8 @@ advisories:
           fixed-version: 3.0.8-r0
 
   - id: CVE-2022-4450
+    aliases:
+      - GHSA-v5w6-wcm8-jm4q
     events:
       - timestamp: 2023-02-07T16:50:17Z
         type: fixed
@@ -54,6 +68,8 @@ advisories:
           fixed-version: 3.0.8-r0
 
   - id: CVE-2023-0215
+    aliases:
+      - GHSA-r7jw-wp68-3xch
     events:
       - timestamp: 2023-02-07T16:50:08Z
         type: fixed
@@ -61,6 +77,8 @@ advisories:
           fixed-version: 3.0.8-r0
 
   - id: CVE-2023-0216
+    aliases:
+      - GHSA-29xx-hcv2-c4cp
     events:
       - timestamp: 2023-02-07T16:50:29Z
         type: fixed
@@ -68,6 +86,8 @@ advisories:
           fixed-version: 3.0.8-r0
 
   - id: CVE-2023-0217
+    aliases:
+      - GHSA-vxrh-cpg7-8vjr
     events:
       - timestamp: 2023-02-07T16:50:39Z
         type: fixed
@@ -75,6 +95,8 @@ advisories:
           fixed-version: 3.0.8-r0
 
   - id: CVE-2023-0286
+    aliases:
+      - GHSA-x4qr-2fvf-3mr5
     events:
       - timestamp: 2023-02-07T16:49:30Z
         type: fixed
@@ -82,6 +104,8 @@ advisories:
           fixed-version: 3.0.8-r0
 
   - id: CVE-2023-0401
+    aliases:
+      - GHSA-vrh7-x64v-7vxq
     events:
       - timestamp: 2023-02-07T16:50:53Z
         type: fixed
@@ -89,6 +113,8 @@ advisories:
           fixed-version: 3.0.8-r0
 
   - id: CVE-2023-0464
+    aliases:
+      - GHSA-w2w6-xp88-5cvw
     events:
       - timestamp: 2023-03-23T09:31:00Z
         type: fixed
@@ -96,6 +122,8 @@ advisories:
           fixed-version: 3.1.0-r1
 
   - id: CVE-2023-0465
+    aliases:
+      - GHSA-77f3-6546-6rj7
     events:
       - timestamp: 2023-03-28T14:54:27Z
         type: fixed
@@ -103,6 +131,8 @@ advisories:
           fixed-version: 3.1.0-r2
 
   - id: CVE-2023-0466
+    aliases:
+      - GHSA-pxvj-4wx4-gv6w
     events:
       - timestamp: 2023-04-08T16:32:54Z
         type: false-positive-determination
@@ -111,6 +141,8 @@ advisories:
           note: This was a case of documentation not matching function behavior. The upstream maintainers decided to update the documentation rather than change the behavior. See https://www.openssl.org/news/secadv/20230328.txt
 
   - id: CVE-2023-1255
+    aliases:
+      - GHSA-4wp2-xw7p-2gfx
     events:
       - timestamp: 2023-04-20T16:29:24Z
         type: fixed
@@ -118,6 +150,8 @@ advisories:
           fixed-version: 3.1.0-r5
 
   - id: CVE-2023-2650
+    aliases:
+      - GHSA-gqxg-9vfr-p9cg
     events:
       - timestamp: 2023-05-30T16:31:01Z
         type: fixed
@@ -125,6 +159,8 @@ advisories:
           fixed-version: 3.1.1-r0
 
   - id: CVE-2023-2975
+    aliases:
+      - GHSA-hpqg-7fjp-436p
     events:
       - timestamp: 2023-07-17T21:45:05Z
         type: fixed
@@ -132,6 +168,8 @@ advisories:
           fixed-version: 3.1.1-r2
 
   - id: CVE-2023-3446
+    aliases:
+      - GHSA-3p3x-vg38-6g9q
     events:
       - timestamp: 2023-07-19T17:06:50Z
         type: fixed
@@ -139,6 +177,8 @@ advisories:
           fixed-version: 3.1.1-r3
 
   - id: CVE-2023-3817
+    aliases:
+      - GHSA-c945-cqj5-wfv6
     events:
       - timestamp: 2023-07-31T21:46:13Z
         type: fixed
@@ -146,6 +186,8 @@ advisories:
           fixed-version: 3.1.1-r4
 
   - id: CVE-2023-4807
+    aliases:
+      - GHSA-53wr-cx66-4578
     events:
       - timestamp: 2023-09-08T16:29:47Z
         type: false-positive-determination

--- a/openvpn.advisories.yaml
+++ b/openvpn.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-27569
+    aliases:
+      - GHSA-hm8q-rqmm-26hq
     events:
       - timestamp: 2023-09-30T19:05:15Z
         type: detection

--- a/orc.advisories.yaml
+++ b/orc.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-8015
+    aliases:
+      - GHSA-mqmp-4mcp-vg8v
     events:
       - timestamp: 2023-07-01T10:54:08Z
         type: detection

--- a/patch.advisories.yaml
+++ b/patch.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-1000156
+    aliases:
+      - GHSA-r9rq-mhxg-686q
     events:
       - timestamp: 2022-09-28T11:06:03Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 2.7.6-r3
 
   - id: CVE-2018-20969
+    aliases:
+      - GHSA-g5pm-269j-95rr
     events:
       - timestamp: 2022-09-28T11:06:03Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 2.7.6-r3
 
   - id: CVE-2018-6951
+    aliases:
+      - GHSA-jx75-987w-4cqc
     events:
       - timestamp: 2022-09-28T11:06:03Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 2.7.6-r3
 
   - id: CVE-2018-6952
+    aliases:
+      - GHSA-ffqc-f68h-qq8w
     events:
       - timestamp: 2022-09-28T11:06:03Z
         type: fixed
@@ -33,6 +41,8 @@ advisories:
           fixed-version: 2.7.6-r3
 
   - id: CVE-2019-13636
+    aliases:
+      - GHSA-f3xm-hqch-mq3q
     events:
       - timestamp: 2022-09-28T11:06:03Z
         type: fixed
@@ -40,6 +50,8 @@ advisories:
           fixed-version: 2.7.6-r3
 
   - id: CVE-2019-13638
+    aliases:
+      - GHSA-vqpq-8jvg-rwmx
     events:
       - timestamp: 2022-09-28T11:06:03Z
         type: fixed
@@ -47,6 +59,8 @@ advisories:
           fixed-version: 2.7.6-r3
 
   - id: CVE-2019-20633
+    aliases:
+      - GHSA-w88p-xvmw-fxgg
     events:
       - timestamp: 2022-09-28T11:06:03Z
         type: fixed

--- a/pcre2.advisories.yaml
+++ b/pcre2.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-1586
+    aliases:
+      - GHSA-f3pv-9fwh-mp3x
     events:
       - timestamp: 2022-09-20T11:15:38Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 10.40-r0
 
   - id: CVE-2022-1587
+    aliases:
+      - GHSA-jmvm-hj36-w5hc
     events:
       - timestamp: 2022-09-20T11:15:38Z
         type: fixed

--- a/php-8.1.advisories.yaml
+++ b/php-8.1.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2007-2728
+    aliases:
+      - GHSA-g6ph-v22v-23j6
     events:
       - timestamp: 2023-10-05T22:18:51Z
         type: false-positive-determination
@@ -12,6 +14,8 @@ advisories:
           type: vulnerability-record-analysis-contested
 
   - id: CVE-2007-3205
+    aliases:
+      - GHSA-9j84-7rq9-w2fq
     events:
       - timestamp: 2023-10-05T22:18:51Z
         type: false-positive-determination
@@ -19,6 +23,8 @@ advisories:
           type: vulnerability-record-analysis-contested
 
   - id: CVE-2007-4596
+    aliases:
+      - GHSA-85qm-c7q8-mxvh
     events:
       - timestamp: 2023-10-05T22:18:51Z
         type: false-positive-determination
@@ -26,6 +32,8 @@ advisories:
           type: vulnerability-record-analysis-contested
 
   - id: CVE-2015-3211
+    aliases:
+      - GHSA-6mh8-r4fc-h3ch
     events:
       - timestamp: 2023-10-05T22:18:51Z
         type: false-positive-determination

--- a/php-8.2.advisories.yaml
+++ b/php-8.2.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2007-2728
+    aliases:
+      - GHSA-g6ph-v22v-23j6
     events:
       - timestamp: 2023-09-07T22:18:51Z
         type: false-positive-determination
@@ -12,6 +14,8 @@ advisories:
           type: vulnerability-record-analysis-contested
 
   - id: CVE-2007-3205
+    aliases:
+      - GHSA-9j84-7rq9-w2fq
     events:
       - timestamp: 2023-09-07T22:18:51Z
         type: false-positive-determination
@@ -19,6 +23,8 @@ advisories:
           type: vulnerability-record-analysis-contested
 
   - id: CVE-2007-4596
+    aliases:
+      - GHSA-85qm-c7q8-mxvh
     events:
       - timestamp: 2023-09-07T22:18:51Z
         type: false-positive-determination
@@ -26,6 +32,8 @@ advisories:
           type: vulnerability-record-analysis-contested
 
   - id: CVE-2015-3211
+    aliases:
+      - GHSA-6mh8-r4fc-h3ch
     events:
       - timestamp: 2023-09-07T22:18:51Z
         type: false-positive-determination
@@ -34,6 +42,8 @@ advisories:
           note: This is a packaging defect specific to the php-fpm package included in RHEL.  The Wolfi php-fpm package does not include this defect.
 
   - id: CVE-2017-6485
+    aliases:
+      - GHSA-76rq-rhfj-3qrf
     events:
       - timestamp: 2023-09-07T22:18:51Z
         type: false-positive-determination
@@ -42,6 +52,8 @@ advisories:
           note: This CVE targets a PHP-based web application called "PHP Calendar," and is unrelated to the PHP calendar extension.
 
   - id: CVE-2022-4455
+    aliases:
+      - GHSA-3957-4jhv-xcc7
     events:
       - timestamp: 2023-09-07T22:18:51Z
         type: false-positive-determination

--- a/php.advisories.yaml
+++ b/php.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2007-2728
+    aliases:
+      - GHSA-g6ph-v22v-23j6
     events:
       - timestamp: 2023-02-16T16:01:48Z
         type: false-positive-determination
@@ -12,6 +14,8 @@ advisories:
           type: vulnerability-record-analysis-contested
 
   - id: CVE-2007-3205
+    aliases:
+      - GHSA-9j84-7rq9-w2fq
     events:
       - timestamp: 2023-02-16T16:01:59Z
         type: false-positive-determination
@@ -19,6 +23,8 @@ advisories:
           type: vulnerability-record-analysis-contested
 
   - id: CVE-2007-4596
+    aliases:
+      - GHSA-85qm-c7q8-mxvh
     events:
       - timestamp: 2023-02-16T16:02:05Z
         type: false-positive-determination
@@ -26,6 +32,8 @@ advisories:
           type: vulnerability-record-analysis-contested
 
   - id: CVE-2015-3211
+    aliases:
+      - GHSA-6mh8-r4fc-h3ch
     events:
       - timestamp: 2023-08-11T22:45:28Z
         type: false-positive-determination
@@ -34,6 +42,8 @@ advisories:
           note: This is a packaging defect specific to the php-fpm package included in RHEL.  The Wolfi php-fpm package does not include this defect.
 
   - id: CVE-2017-6485
+    aliases:
+      - GHSA-76rq-rhfj-3qrf
     events:
       - timestamp: 2023-08-11T22:49:50Z
         type: false-positive-determination
@@ -42,6 +52,8 @@ advisories:
           note: This CVE targets a PHP-based web application called "PHP Calendar," and is unrelated to the PHP calendar extension.
 
   - id: CVE-2022-31630
+    aliases:
+      - GHSA-jw98-jrc9-mrx5
     events:
       - timestamp: 2023-02-12T01:12:25Z
         type: fixed
@@ -49,6 +61,8 @@ advisories:
           fixed-version: 8.1.13-r0
 
   - id: CVE-2022-4455
+    aliases:
+      - GHSA-3957-4jhv-xcc7
     events:
       - timestamp: 2023-08-11T22:50:45Z
         type: false-positive-determination

--- a/pixman.advisories.yaml
+++ b/pixman.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-37769
+    aliases:
+      - GHSA-jhr6-5fqf-6p96
     events:
       - timestamp: 2023-08-11T22:29:36Z
         type: false-positive-determination

--- a/pkgconf.advisories.yaml
+++ b/pkgconf.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-24056
+    aliases:
+      - GHSA-6rfm-3v66-6wr2
     events:
       - timestamp: 2023-01-22T05:08:29Z
         type: fixed

--- a/postgresql-11.advisories.yaml
+++ b/postgresql-11.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2017-8806
+    aliases:
+      - GHSA-xg92-g8h7-v7r4
     events:
       - timestamp: 2023-05-03T17:58:34Z
         type: false-positive-determination

--- a/postgresql-12.advisories.yaml
+++ b/postgresql-12.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2017-8806
+    aliases:
+      - GHSA-xg92-g8h7-v7r4
     events:
       - timestamp: 2023-05-03T17:58:26Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: This CVE appears to impact only Debian/Ubuntu.
 
   - id: CVE-2020-21469
+    aliases:
+      - GHSA-w8hm-59h4-7ff2
     events:
       - timestamp: 2023-08-29T22:47:14Z
         type: false-positive-determination

--- a/postgresql-13.advisories.yaml
+++ b/postgresql-13.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2017-8806
+    aliases:
+      - GHSA-xg92-g8h7-v7r4
     events:
       - timestamp: 2023-05-03T17:58:22Z
         type: false-positive-determination

--- a/postgresql-14.advisories.yaml
+++ b/postgresql-14.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2017-8806
+    aliases:
+      - GHSA-xg92-g8h7-v7r4
     events:
       - timestamp: 2023-05-03T17:58:17Z
         type: false-positive-determination

--- a/postgresql-15.advisories.yaml
+++ b/postgresql-15.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2017-8806
+    aliases:
+      - GHSA-xg92-g8h7-v7r4
     events:
       - timestamp: 2022-11-03T12:41:55Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: This CVE appears to impact only Debian/Ubuntu.
 
   - id: CVE-2022-41862
+    aliases:
+      - GHSA-fr68-cm8v-7vv6
     events:
       - timestamp: 2023-03-19T21:21:53Z
         type: fixed

--- a/prometheus-alertmanager.advisories.yaml
+++ b/prometheus-alertmanager.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-40577
+    aliases:
+      - GHSA-v86x-5fm3-5p7j
     events:
       - timestamp: 2023-08-25T20:39:59Z
         type: fixed

--- a/prometheus-config-reloader.advisories.yaml
+++ b/prometheus-config-reloader.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This CVE only impacts prometheus 2.7 but our prometheus-config-reloader is using v0.46.0 Go library which is in fact prometheus 2.46
 
   - id: CVE-2023-40577
+    aliases:
+      - GHSA-v86x-5fm3-5p7j
     events:
       - timestamp: 2023-08-25T20:47:31Z
         type: false-positive-determination

--- a/prometheus-operator.advisories.yaml
+++ b/prometheus-operator.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This CVE only impacts prometheus 2.7 but our prometheus-operator is using v0.46.0 Go library which is in fact prothemeus 2.46
 
   - id: CVE-2023-40577
+    aliases:
+      - GHSA-v86x-5fm3-5p7j
     events:
       - timestamp: 2023-08-25T20:47:54Z
         type: false-positive-determination

--- a/prometheus-stackdriver-exporter.advisories.yaml
+++ b/prometheus-stackdriver-exporter.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-05-02T22:52:07Z
         type: fixed

--- a/prometheus.advisories.yaml
+++ b/prometheus.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-40577
+    aliases:
+      - GHSA-v86x-5fm3-5p7j
     events:
       - timestamp: 2023-08-25T20:46:25Z
         type: false-positive-determination

--- a/protobuf-c.advisories.yaml
+++ b/protobuf-c.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2021-3121
+    aliases:
+      - GHSA-c3h9-896r-86jm
     events:
       - timestamp: 2023-01-15T00:53:43Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.4.1-r0
 
   - id: CVE-2022-33070
+    aliases:
+      - GHSA-xcrq-6j7j-784j
     events:
       - timestamp: 2023-01-15T00:53:43Z
         type: fixed

--- a/pulumi-language-java.advisories.yaml
+++ b/pulumi-language-java.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-1732
+    aliases:
+      - GHSA-2q89-485c-9j2x
     events:
       - timestamp: 2023-06-04T16:04:33Z
         type: fixed

--- a/pulumi.advisories.yaml
+++ b/pulumi.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-20225
+    aliases:
+      - GHSA-7p5p-7qq5-cc86
     events:
       - timestamp: 2023-07-27T23:10:39Z
         type: false-positive-determination

--- a/py3-click.advisories.yaml
+++ b/py3-click.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2015-8768
+    aliases:
+      - GHSA-fgm2-j3wp-hrw5
     events:
       - timestamp: 2023-07-21T12:38:52Z
         type: false-positive-determination

--- a/py3-configobj.advisories.yaml
+++ b/py3-configobj.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-26112
+    aliases:
+      - GHSA-c33w-24p9-8m24
     events:
       - timestamp: 2023-07-21T12:41:52Z
         type: false-positive-determination

--- a/py3-jmespath.advisories.yaml
+++ b/py3-jmespath.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-32511
+    aliases:
+      - GHSA-5c5f-7vfq-3732
     events:
       - timestamp: 2023-06-05T10:37:49Z
         type: false-positive-determination

--- a/py3-urllib3-1.advisories.yaml
+++ b/py3-urllib3-1.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-43804
+    aliases:
+      - GHSA-v845-jxx5-vc9f
     events:
       - timestamp: 2023-10-03T21:24:25Z
         type: fixed

--- a/py3-urllib3.advisories.yaml
+++ b/py3-urllib3.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-43804
+    aliases:
+      - GHSA-v845-jxx5-vc9f
     events:
       - timestamp: 2023-10-03T21:24:42Z
         type: fixed

--- a/py3.10-pip.advisories.yaml
+++ b/py3.10-pip.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-20225
+    aliases:
+      - GHSA-7p5p-7qq5-cc86
     events:
       - timestamp: 2023-03-28T13:38:33Z
         type: false-positive-determination

--- a/py3.11-pip.advisories.yaml
+++ b/py3.11-pip.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-20225
+    aliases:
+      - GHSA-7p5p-7qq5-cc86
     events:
       - timestamp: 2023-03-28T13:38:38Z
         type: false-positive-determination

--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2007-4559
+    aliases:
+      - GHSA-gw9q-c7gh-j9vm
     events:
       - timestamp: 2023-03-11T22:20:54Z
         type: false-positive-determination
@@ -22,6 +24,8 @@ advisories:
           note: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
   - id: CVE-2020-10735
+    aliases:
+      - GHSA-6jr7-xr67-mgxw
     events:
       - timestamp: 2023-02-07T08:34:29Z
         type: fixed
@@ -29,6 +33,8 @@ advisories:
           fixed-version: 3.10.9-r0
 
   - id: CVE-2023-24329
+    aliases:
+      - GHSA-r32r-rqw2-wv5m
     events:
       - timestamp: 2023-03-31T22:57:02Z
         type: false-positive-determination
@@ -37,6 +43,8 @@ advisories:
           note: The upstream issue has been deemed expected behavior, not a security issue. See https://github.com/python/cpython/issues/102153.
 
   - id: CVE-2023-27043
+    aliases:
+      - GHSA-5mwm-wccq-xqcp
     events:
       - timestamp: 2023-08-14T21:08:51Z
         type: true-positive-determination
@@ -44,6 +52,8 @@ advisories:
           note: A fix for this has not yet been released upstream.
 
   - id: CVE-2023-36632
+    aliases:
+      - GHSA-gv66-v8c8-v69c
     events:
       - timestamp: 2023-07-07T11:34:41Z
         type: false-positive-determination

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2007-4559
+    aliases:
+      - GHSA-gw9q-c7gh-j9vm
     events:
       - timestamp: 2023-03-11T22:20:54Z
         type: false-positive-determination
@@ -22,6 +24,8 @@ advisories:
           note: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
   - id: CVE-2020-10735
+    aliases:
+      - GHSA-6jr7-xr67-mgxw
     events:
       - timestamp: 2022-09-12T21:06:30Z
         type: fixed
@@ -29,6 +33,8 @@ advisories:
           fixed-version: 3.0.7-r0
 
   - id: CVE-2023-24329
+    aliases:
+      - GHSA-r32r-rqw2-wv5m
     events:
       - timestamp: 2023-07-21T12:31:48Z
         type: false-positive-determination
@@ -37,6 +43,8 @@ advisories:
           note: The upstream issue has been deemed expected behavior, not a security issue. See https://github.com/python/cpython/issues/102153.
 
   - id: CVE-2023-27043
+    aliases:
+      - GHSA-5mwm-wccq-xqcp
     events:
       - timestamp: 2023-08-14T21:08:51Z
         type: true-positive-determination
@@ -44,6 +52,8 @@ advisories:
           note: A fix for this has not yet been released upstream.
 
   - id: CVE-2023-36632
+    aliases:
+      - GHSA-gv66-v8c8-v69c
     events:
       - timestamp: 2023-07-07T11:34:41Z
         type: false-positive-determination

--- a/python-3.12.advisories.yaml
+++ b/python-3.12.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2007-4559
+    aliases:
+      - GHSA-gw9q-c7gh-j9vm
     events:
       - timestamp: 2023-03-11T22:20:54Z
         type: false-positive-determination
@@ -23,6 +25,8 @@ advisories:
           note: Upon further investigation, we have determined that this is not a security issue in the Python package itself. It's still possible to misuse the Python standard library, such as by supplying untrusted data to the tar extraction functions, in which case a vulnerability should be identified in the caller code.
 
   - id: CVE-2020-10735
+    aliases:
+      - GHSA-6jr7-xr67-mgxw
     events:
       - timestamp: 2022-09-12T21:06:30Z
         type: fixed
@@ -30,6 +34,8 @@ advisories:
           fixed-version: 3.0.7-r0
 
   - id: CVE-2023-24329
+    aliases:
+      - GHSA-r32r-rqw2-wv5m
     events:
       - timestamp: 2023-07-21T12:31:48Z
         type: false-positive-determination
@@ -38,6 +44,8 @@ advisories:
           note: The upstream issue has been deemed expected behavior, not a security issue. See https://github.com/python/cpython/issues/102153.
 
   - id: CVE-2023-36632
+    aliases:
+      - GHSA-gv66-v8c8-v69c
     events:
       - timestamp: 2023-07-07T11:34:41Z
         type: false-positive-determination

--- a/rabbitmq-c.advisories.yaml
+++ b/rabbitmq-c.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-35789
+    aliases:
+      - GHSA-cj9f-gcwh-7q49
     events:
       - timestamp: 2023-09-06T15:58:49Z
         type: detection

--- a/redis-6.2.advisories.yaml
+++ b/redis-6.2.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-0543
+    aliases:
+      - GHSA-9wpj-h5jq-88p9
     events:
       - timestamp: 2023-07-12T16:05:46Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: This is a Debian-specific issue and does not affect Wolfi.
 
   - id: CVE-2022-3647
+    aliases:
+      - GHSA-8vvp-2mv7-px5c
     events:
       - timestamp: 2023-05-22T10:35:07Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: The vulnerability is disputed upstream, indicating that this is expected behavior.
 
   - id: CVE-2022-3734
+    aliases:
+      - GHSA-4x76-2j9h-q9r9
     events:
       - timestamp: 2023-07-12T16:07:06Z
         type: false-positive-determination

--- a/redis-7.0.advisories.yaml
+++ b/redis-7.0.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-0543
+    aliases:
+      - GHSA-9wpj-h5jq-88p9
     events:
       - timestamp: 2023-08-31T17:52:09Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: This is a Debian-specific issue and does not affect Wolfi.
 
   - id: CVE-2022-3647
+    aliases:
+      - GHSA-8vvp-2mv7-px5c
     events:
       - timestamp: 2023-08-31T17:52:09Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: The vulnerability is disputed upstream, indicating that this is expected behavior.
 
   - id: CVE-2022-3734
+    aliases:
+      - GHSA-4x76-2j9h-q9r9
     events:
       - timestamp: 2023-08-31T17:52:09Z
         type: false-positive-determination

--- a/redis.advisories.yaml
+++ b/redis.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-0543
+    aliases:
+      - GHSA-9wpj-h5jq-88p9
     events:
       - timestamp: 2022-12-24T18:35:15Z
         type: fixed
@@ -35,6 +37,8 @@ advisories:
           fixed-version: 7.0.9-r0
 
   - id: CVE-2022-3647
+    aliases:
+      - GHSA-8vvp-2mv7-px5c
     events:
       - timestamp: 2022-12-24T18:35:15Z
         type: fixed
@@ -42,6 +46,8 @@ advisories:
           fixed-version: 7.0.7-r0
 
   - id: CVE-2022-3734
+    aliases:
+      - GHSA-4x76-2j9h-q9r9
     events:
       - timestamp: 2022-12-24T18:35:15Z
         type: fixed

--- a/restic.advisories.yaml
+++ b/restic.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-03-31T13:11:12Z
         type: fixed

--- a/ruby-3.0.advisories.yaml
+++ b/ruby-3.0.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2021-33621
+    aliases:
+      - GHSA-vc47-6rqg-c7f5
     events:
       - timestamp: 2023-03-10T15:57:16Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 3.0.5-r0
 
   - id: CVE-2021-41816
+    aliases:
+      - GHSA-5cqm-crxm-6qpv
     events:
       - timestamp: 2023-06-23T11:48:12Z
         type: false-positive-determination
@@ -20,6 +24,8 @@ advisories:
           note: Wolfi has never shipped an affected version of cgi. This NVD record's CPE configuration 1 looks incorrect based on the description and Ruby's advisory.
 
   - id: CVE-2023-0464
+    aliases:
+      - GHSA-w2w6-xp88-5cvw
     events:
       - timestamp: 2023-06-15T20:11:53Z
         type: false-positive-determination
@@ -27,6 +33,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0465
+    aliases:
+      - GHSA-77f3-6546-6rj7
     events:
       - timestamp: 2023-06-15T20:12:12Z
         type: false-positive-determination
@@ -34,6 +42,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0466
+    aliases:
+      - GHSA-pxvj-4wx4-gv6w
     events:
       - timestamp: 2023-06-15T20:12:30Z
         type: false-positive-determination
@@ -41,6 +51,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-1255
+    aliases:
+      - GHSA-4wp2-xw7p-2gfx
     events:
       - timestamp: 2023-06-15T20:12:38Z
         type: false-positive-determination
@@ -48,6 +60,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-2650
+    aliases:
+      - GHSA-gqxg-9vfr-p9cg
     events:
       - timestamp: 2023-06-15T20:12:44Z
         type: false-positive-determination
@@ -55,6 +69,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-28755
+    aliases:
+      - GHSA-hv5j-3h9f-99c2
     events:
       - timestamp: 2023-04-14T11:20:45Z
         type: fixed
@@ -62,6 +78,8 @@ advisories:
           fixed-version: 3.0.6-r0
 
   - id: CVE-2023-28756
+    aliases:
+      - GHSA-fg7x-g82r-94qc
     events:
       - timestamp: 2023-04-14T11:20:49Z
         type: fixed
@@ -69,6 +87,8 @@ advisories:
           fixed-version: 3.0.6-r0
 
   - id: CVE-2023-36617
+    aliases:
+      - GHSA-hww2-5g85-429m
     events:
       - timestamp: 2023-07-07T16:17:56Z
         type: true-positive-determination

--- a/ruby-3.1.advisories.yaml
+++ b/ruby-3.1.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-0778
+    aliases:
+      - GHSA-x3mh-jvjw-3xwx
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -12,6 +14,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-1292
+    aliases:
+      - GHSA-qjmp-vmxc-7p8r
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -19,6 +23,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-1343
+    aliases:
+      - GHSA-mfm6-r9g2-q4r7
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -26,6 +32,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-1434
+    aliases:
+      - GHSA-638m-m8mh-7gw2
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -33,6 +41,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-1473
+    aliases:
+      - GHSA-g323-fr93-4j3c
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -40,6 +50,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-2068
+    aliases:
+      - GHSA-xjxr-x4h8-946x
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -47,6 +59,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-2097
+    aliases:
+      - GHSA-3wx7-46ch-7rq2
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -54,6 +68,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-3358
+    aliases:
+      - GHSA-4f63-89w9-3jjv
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -61,6 +77,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-3602
+    aliases:
+      - GHSA-8rwr-x37p-mx23
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -68,6 +86,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-3786
+    aliases:
+      - GHSA-h8jm-2x53-xhp5
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -75,6 +95,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-3996
+    aliases:
+      - GHSA-vr8j-hgmm-jh9r
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -82,6 +104,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-4203
+    aliases:
+      - GHSA-w67w-mw4j-8qrv
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -89,6 +113,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-4304
+    aliases:
+      - GHSA-p52g-cm5j-mjv4
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -96,6 +122,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2022-4450
+    aliases:
+      - GHSA-v5w6-wcm8-jm4q
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -103,6 +131,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0215
+    aliases:
+      - GHSA-r7jw-wp68-3xch
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -110,6 +140,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0216
+    aliases:
+      - GHSA-29xx-hcv2-c4cp
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -117,6 +149,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0217
+    aliases:
+      - GHSA-vxrh-cpg7-8vjr
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -124,6 +158,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0286
+    aliases:
+      - GHSA-x4qr-2fvf-3mr5
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -131,6 +167,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0401
+    aliases:
+      - GHSA-vrh7-x64v-7vxq
     events:
       - timestamp: 2023-06-23T03:04:27Z
         type: false-positive-determination
@@ -138,6 +176,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0464
+    aliases:
+      - GHSA-w2w6-xp88-5cvw
     events:
       - timestamp: 2023-06-15T20:10:44Z
         type: false-positive-determination
@@ -145,6 +185,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0465
+    aliases:
+      - GHSA-77f3-6546-6rj7
     events:
       - timestamp: 2023-06-15T20:10:55Z
         type: false-positive-determination
@@ -152,6 +194,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0466
+    aliases:
+      - GHSA-pxvj-4wx4-gv6w
     events:
       - timestamp: 2023-06-15T20:11:03Z
         type: false-positive-determination
@@ -159,6 +203,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-1255
+    aliases:
+      - GHSA-4wp2-xw7p-2gfx
     events:
       - timestamp: 2023-06-15T20:11:32Z
         type: false-positive-determination
@@ -166,6 +212,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-2650
+    aliases:
+      - GHSA-gqxg-9vfr-p9cg
     events:
       - timestamp: 2023-06-15T20:11:41Z
         type: false-positive-determination
@@ -173,6 +221,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-28755
+    aliases:
+      - GHSA-hv5j-3h9f-99c2
     events:
       - timestamp: 2023-04-14T11:20:17Z
         type: fixed
@@ -180,6 +230,8 @@ advisories:
           fixed-version: 3.1.4-r0
 
   - id: CVE-2023-28756
+    aliases:
+      - GHSA-fg7x-g82r-94qc
     events:
       - timestamp: 2023-04-14T11:20:13Z
         type: fixed
@@ -187,6 +239,8 @@ advisories:
           fixed-version: 3.1.4-r0
 
   - id: CVE-2023-36617
+    aliases:
+      - GHSA-hww2-5g85-429m
     events:
       - timestamp: 2023-07-07T16:18:57Z
         type: true-positive-determination

--- a/ruby-3.2.advisories.yaml
+++ b/ruby-3.2.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-0464
+    aliases:
+      - GHSA-w2w6-xp88-5cvw
     events:
       - timestamp: 2023-06-13T22:47:44Z
         type: false-positive-determination
@@ -12,6 +14,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0465
+    aliases:
+      - GHSA-77f3-6546-6rj7
     events:
       - timestamp: 2023-06-13T22:51:00Z
         type: false-positive-determination
@@ -19,6 +23,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-0466
+    aliases:
+      - GHSA-pxvj-4wx4-gv6w
     events:
       - timestamp: 2023-06-13T22:51:18Z
         type: false-positive-determination
@@ -26,6 +32,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-1255
+    aliases:
+      - GHSA-4wp2-xw7p-2gfx
     events:
       - timestamp: 2023-06-13T22:51:41Z
         type: false-positive-determination
@@ -33,6 +41,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-2650
+    aliases:
+      - GHSA-gqxg-9vfr-p9cg
     events:
       - timestamp: 2023-06-13T22:51:52Z
         type: false-positive-determination
@@ -40,6 +50,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-28755
+    aliases:
+      - GHSA-hv5j-3h9f-99c2
     events:
       - timestamp: 2023-04-14T11:19:28Z
         type: fixed
@@ -47,6 +59,8 @@ advisories:
           fixed-version: 3.2.2-r0
 
   - id: CVE-2023-28756
+    aliases:
+      - GHSA-fg7x-g82r-94qc
     events:
       - timestamp: 2023-04-14T11:19:41Z
         type: fixed
@@ -54,6 +68,8 @@ advisories:
           fixed-version: 3.2.2-r0
 
   - id: CVE-2023-36617
+    aliases:
+      - GHSA-hww2-5g85-429m
     events:
       - timestamp: 2023-07-07T16:19:11Z
         type: true-positive-determination

--- a/ruby3.2-fluentd14.advisories.yaml
+++ b/ruby3.2-fluentd14.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-39379
+    aliases:
+      - GHSA-fppq-mj76-fpj2
     events:
       - timestamp: 2023-03-22T23:39:59Z
         type: fixed

--- a/ruby3.2-webrick.advisories.yaml
+++ b/ruby3.2-webrick.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2008-1145
+    aliases:
+      - GHSA-f279-rf2r-m6m5
     events:
       - timestamp: 2023-06-05T13:58:31Z
         type: false-positive-determination

--- a/samurai.advisories.yaml
+++ b/samurai.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2021-30218
+    aliases:
+      - GHSA-xh35-9rm8-7v5q
     events:
       - timestamp: 2022-09-19T06:57:25Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.2-r0
 
   - id: CVE-2021-30219
+    aliases:
+      - GHSA-mmpx-fx25-f58m
     events:
       - timestamp: 2022-09-19T06:57:25Z
         type: fixed

--- a/secrets-store-csi-driver.advisories.yaml
+++ b/secrets-store-csi-driver.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-2878
+    aliases:
+      - GHSA-g82w-58jf-gcxx
     events:
       - timestamp: 2023-05-26T00:43:47Z
         type: fixed

--- a/skaffold.advisories.yaml
+++ b/skaffold.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-33199
+    aliases:
+      - GHSA-frqx-jfcm-6jjr
     events:
       - timestamp: 2023-08-02T17:03:24Z
         type: detection

--- a/snappy.advisories.yaml
+++ b/snappy.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-28115
+    aliases:
+      - GHSA-gq6w-q6wh-jggc
     events:
       - timestamp: 2023-03-25T11:00:03Z
         type: false-positive-determination
@@ -12,6 +14,8 @@ advisories:
           type: component-vulnerability-mismatch
 
   - id: CVE-2023-41330
+    aliases:
+      - GHSA-92rv-4j2h-8mjj
     events:
       - timestamp: 2023-09-30T19:11:40Z
         type: detection

--- a/spark-operator.advisories.yaml
+++ b/spark-operator.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8554
+    aliases:
+      - GHSA-j9wf-vvm6-4r9w
     events:
       - timestamp: 2023-09-07T13:49:44Z
         type: false-positive-determination
@@ -13,6 +15,8 @@ advisories:
           note: This is a Kubernetes API flaw, and this code is not reachable in our package.
 
   - id: CVE-2020-8561
+    aliases:
+      - GHSA-74j8-88mm-7496
     events:
       - timestamp: 2023-09-07T14:01:11Z
         type: false-positive-determination
@@ -21,6 +25,8 @@ advisories:
           note: This only affects kube-apiserver logs, and code was marked NOT_IMPORTABLE in Golang vulndb
 
   - id: CVE-2020-8564
+    aliases:
+      - GHSA-8mjg-8c8g-6h85
     events:
       - timestamp: 2023-09-07T13:55:27Z
         type: true-positive-determination
@@ -28,6 +34,8 @@ advisories:
           note: Pending upstream project to pick up k8s.io/kubernetes 1.20.0-alpha.1+.
 
   - id: CVE-2020-8565
+    aliases:
+      - GHSA-8cfg-vx93-jvxw
     events:
       - timestamp: 2023-09-07T13:59:27Z
         type: true-positive-determination
@@ -35,6 +43,8 @@ advisories:
           note: Pending upstream project to pick up k8s.io/kubernetes 1.20.0-alpha.2+.
 
   - id: CVE-2021-25740
+    aliases:
+      - GHSA-vw47-mr44-3jf9
     events:
       - timestamp: 2023-09-07T14:04:51Z
         type: false-positive-determination
@@ -43,6 +53,8 @@ advisories:
           note: This only affects Kubernetes itself, and code was marked not importable in Golang vulndb
 
   - id: CVE-2021-25743
+    aliases:
+      - GHSA-f9jg-8p32-2f55
     events:
       - timestamp: 2023-10-03T20:18:35Z
         type: false-positive-determination
@@ -51,6 +63,8 @@ advisories:
           note: Vulnerable code is specific to kubectl.
 
   - id: CVE-2023-2431
+    aliases:
+      - GHSA-xc8m-28vv-4pjc
     events:
       - timestamp: 2023-09-07T13:45:11Z
         type: false-positive-determination
@@ -59,6 +73,8 @@ advisories:
           note: Vulnerable code is part of the Kubernetes kubelet which is not in the execution path of the spark-operator
 
   - id: CVE-2023-2727
+    aliases:
+      - GHSA-qc2g-gmh6-95p4
     events:
       - timestamp: 2023-09-07T13:47:12Z
         type: false-positive-determination
@@ -67,6 +83,8 @@ advisories:
           note: Vulnerable code is part of the Kubernetes API server and not importable.
 
   - id: CVE-2023-2728
+    aliases:
+      - GHSA-cgcv-5272-97pr
     events:
       - timestamp: 2023-09-07T13:53:32Z
         type: false-positive-determination

--- a/sqlite.advisories.yaml
+++ b/sqlite.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-46908
+    aliases:
+      - GHSA-993x-6558-2xmj
     events:
       - timestamp: 2022-12-14T10:26:25Z
         type: fixed

--- a/sysstat.advisories.yaml
+++ b/sysstat.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-33204
+    aliases:
+      - GHSA-57g7-qvg2-m23f
     events:
       - timestamp: 2023-09-06T15:58:49Z
         type: detection

--- a/systemd.advisories.yaml
+++ b/systemd.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-31437
+    aliases:
+      - GHSA-9mv8-4v9g-hm48
     events:
       - timestamp: 2023-06-26T10:31:26Z
         type: detection
@@ -12,6 +14,8 @@ advisories:
           type: manual
 
   - id: CVE-2023-31438
+    aliases:
+      - GHSA-m3qw-f5f6-m6r3
     events:
       - timestamp: 2023-06-26T10:31:26Z
         type: detection
@@ -24,6 +28,8 @@ advisories:
           note: This has been disputed by upstream and is not considered a security issue.
 
   - id: CVE-2023-31439
+    aliases:
+      - GHSA-mvwm-rcrw-pr2j
     events:
       - timestamp: 2023-06-26T10:31:26Z
         type: detection

--- a/tekton-chains.advisories.yaml
+++ b/tekton-chains.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-37264
+    aliases:
+      - GHSA-w2h3-vvvq-3m53
     events:
       - timestamp: 2023-08-07T19:00:32Z
         type: false-positive-determination

--- a/tekton-pipelines.advisories.yaml
+++ b/tekton-pipelines.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-1732
+    aliases:
+      - GHSA-2q89-485c-9j2x
     events:
       - timestamp: 2023-08-11T17:23:33Z
         type: false-positive-determination

--- a/telegraf-1.26.advisories.yaml
+++ b/telegraf-1.26.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.
 
   - id: CVE-2023-34231
+    aliases:
+      - GHSA-fwv2-65wh-2w8c
     events:
       - timestamp: 2023-08-25T23:13:42Z
         type: detection

--- a/telegraf.advisories.yaml
+++ b/telegraf.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
 
   - id: CVE-2023-34231
+    aliases:
+      - GHSA-fwv2-65wh-2w8c
     events:
       - timestamp: 2023-06-13T11:37:43Z
         type: fixed

--- a/temporal.advisories.yaml
+++ b/temporal.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-3485
+    aliases:
+      - GHSA-gm2g-2xr9-pxxj
     events:
       - timestamp: 2023-09-30T19:12:10Z
         type: detection

--- a/thanos-0.31.advisories.yaml
+++ b/thanos-0.31.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
 
   - id: CVE-2023-40577
+    aliases:
+      - GHSA-v86x-5fm3-5p7j
     events:
       - timestamp: 2023-08-30T20:54:21Z
         type: false-positive-determination

--- a/thanos-0.32.advisories.yaml
+++ b/thanos-0.32.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
 
   - id: CVE-2023-40577
+    aliases:
+      - GHSA-v86x-5fm3-5p7j
     events:
       - timestamp: 2023-08-30T20:54:21Z
         type: false-positive-determination

--- a/thanos-operator.advisories.yaml
+++ b/thanos-operator.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2022-28948
+    aliases:
+      - GHSA-hp87-p4gw-j4gq
     events:
       - timestamp: 2023-09-05T14:45:27Z
         type: fixed

--- a/thanos.advisories.yaml
+++ b/thanos.advisories.yaml
@@ -13,6 +13,8 @@ advisories:
           note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
 
   - id: CVE-2023-40577
+    aliases:
+      - GHSA-v86x-5fm3-5p7j
     events:
       - timestamp: 2023-08-25T20:54:21Z
         type: false-positive-determination

--- a/thrift.advisories.yaml
+++ b/thrift.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2019-11938
+    aliases:
+      - GHSA-hr4p-8hm2-w85x
     events:
       - timestamp: 2023-09-30T19:12:18Z
         type: detection
@@ -20,6 +22,8 @@ advisories:
           note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
 
   - id: CVE-2019-11939
+    aliases:
+      - GHSA-w3r9-r9w7-8h48
     events:
       - timestamp: 2023-09-30T19:12:18Z
         type: detection
@@ -35,6 +39,8 @@ advisories:
           note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
 
   - id: CVE-2019-3552
+    aliases:
+      - GHSA-h27g-g76x-xqpw
     events:
       - timestamp: 2023-09-30T19:12:18Z
         type: detection
@@ -50,6 +56,8 @@ advisories:
           note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
 
   - id: CVE-2019-3553
+    aliases:
+      - GHSA-859v-9mcv-7rw3
     events:
       - timestamp: 2023-09-30T19:12:18Z
         type: detection
@@ -65,6 +73,8 @@ advisories:
           note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
 
   - id: CVE-2019-3558
+    aliases:
+      - GHSA-7vv7-v9gp-whmr
     events:
       - timestamp: 2023-09-30T19:12:18Z
         type: detection
@@ -80,6 +90,8 @@ advisories:
           note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
 
   - id: CVE-2019-3559
+    aliases:
+      - GHSA-6627-jcx5-j2g8
     events:
       - timestamp: 2023-09-30T19:12:18Z
         type: detection
@@ -95,6 +107,8 @@ advisories:
           note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
 
   - id: CVE-2019-3564
+    aliases:
+      - GHSA-x4rg-4545-4w7w
     events:
       - timestamp: 2023-09-30T19:12:18Z
         type: detection
@@ -110,6 +124,8 @@ advisories:
           note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
 
   - id: CVE-2019-3565
+    aliases:
+      - GHSA-j98f-h9mx-xrxq
     events:
       - timestamp: 2023-09-30T19:12:18Z
         type: detection
@@ -125,6 +141,8 @@ advisories:
           note: CVE refers to Facebook's fork of Thrift, not the original Apache Thrift.
 
   - id: CVE-2021-24028
+    aliases:
+      - GHSA-qrr3-c36x-2pcc
     events:
       - timestamp: 2023-09-30T19:12:18Z
         type: detection

--- a/tiff.advisories.yaml
+++ b/tiff.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2015-7313
+    aliases:
+      - GHSA-2j29-7372-8rgg
     events:
       - timestamp: 2023-08-18T16:10:08Z
         type: false-positive-determination

--- a/tigera-operator.advisories.yaml
+++ b/tigera-operator.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2020-8552
+    aliases:
+      - GHSA-82hx-w2r5-c2wq
     events:
       - timestamp: 2023-09-19T16:44:48Z
         type: false-positive-determination

--- a/tinyxml.advisories.yaml
+++ b/tinyxml.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2021-42260
+    aliases:
+      - GHSA-x43j-m68c-2qxf
     events:
       - timestamp: 2023-09-06T15:58:49Z
         type: detection

--- a/tkn.advisories.yaml
+++ b/tkn.advisories.yaml
@@ -4,7 +4,9 @@ package:
   name: tkn
 
 advisories:
-  - id: GHSA-2h5h-59f5-c5x9
+  - id: CVE-2023-30551
+    aliases:
+      - GHSA-2h5h-59f5-c5x9
     events:
       - timestamp: 2023-07-24T21:38:06Z
         type: false-positive-determination
@@ -12,7 +14,9 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: The libraries this CVE impacts are not used by the Tekton project
 
-  - id: GHSA-frqx-jfcm-6jjr
+  - id: CVE-2023-33199
+    aliases:
+      - GHSA-frqx-jfcm-6jjr
     events:
       - timestamp: 2023-07-24T21:43:30Z
         type: false-positive-determination
@@ -20,7 +24,9 @@ advisories:
           type: vulnerable-code-cannot-be-controlled-by-adversary
           note: Malformed entry requests can cause panics, but Tekton doesn't allow users to generate custom requests
 
-  - id: GHSA-w2h3-vvvq-3m53
+  - id: CVE-2023-37264
+    aliases:
+      - GHSA-w2h3-vvvq-3m53
     events:
       - timestamp: 2023-08-11T15:23:31Z
         type: false-positive-determination

--- a/traefik.advisories.yaml
+++ b/traefik.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2021-41803
+    aliases:
+      - GHSA-hr3v-8cp3-68rf
     events:
       - timestamp: 2023-03-07T16:51:57Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 2.9.8-r1
 
   - id: CVE-2022-23469
+    aliases:
+      - GHSA-h2ph-vhm7-g4hp
     events:
       - timestamp: 2023-01-29T16:56:03Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 2.9.6-r0
 
   - id: CVE-2022-40716
+    aliases:
+      - GHSA-m69r-9g56-7mv8
     events:
       - timestamp: 2023-03-07T16:52:26Z
         type: fixed
@@ -26,6 +32,8 @@ advisories:
           fixed-version: 2.9.8-r1
 
   - id: CVE-2022-46153
+    aliases:
+      - GHSA-468w-8x39-gj5v
     events:
       - timestamp: 2023-01-29T16:56:03Z
         type: fixed
@@ -33,6 +41,8 @@ advisories:
           fixed-version: 2.9.6-r0
 
   - id: CVE-2023-2253
+    aliases:
+      - GHSA-hqxw-f8mx-cpmw
     events:
       - timestamp: 2023-05-17T21:12:08Z
         type: fixed

--- a/trillian.advisories.yaml
+++ b/trillian.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2007-3305
+    aliases:
+      - GHSA-235f-6f76-gpqc
     events:
       - timestamp: 2023-09-30T19:12:29Z
         type: detection
@@ -20,6 +22,8 @@ advisories:
           note: CVE refers to the instant messaging platform called 'Trillian'.
 
   - id: CVE-2008-2407
+    aliases:
+      - GHSA-j525-vjc7-j6rq
     events:
       - timestamp: 2023-09-30T19:12:29Z
         type: detection
@@ -35,6 +39,8 @@ advisories:
           note: CVE refers to the instant messaging platform called 'Trillian'.
 
   - id: CVE-2008-5401
+    aliases:
+      - GHSA-25w9-qw26-8c4r
     events:
       - timestamp: 2023-09-30T19:12:29Z
         type: detection

--- a/upx.advisories.yaml
+++ b/upx.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-23456
+    aliases:
+      - GHSA-3j7g-922g-j6r3
     events:
       - timestamp: 2023-06-26T10:31:26Z
         type: detection
@@ -12,6 +14,8 @@ advisories:
           type: manual
 
   - id: CVE-2023-23457
+    aliases:
+      - GHSA-qcvq-w335-8gh3
     events:
       - timestamp: 2023-06-26T10:31:26Z
         type: detection

--- a/vault-1.13.advisories.yaml
+++ b/vault-1.13.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-3462
+    aliases:
+      - GHSA-9v3w-w2jh-4hff
     events:
       - timestamp: 2023-08-30T20:17:02Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.13.6-r0
 
   - id: CVE-2023-4680
+    aliases:
+      - GHSA-v84f-6r39-cpfc
     events:
       - timestamp: 2023-09-18T16:56:53Z
         type: fixed

--- a/vault-1.14.advisories.yaml
+++ b/vault-1.14.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-4680
+    aliases:
+      - GHSA-v84f-6r39-cpfc
     events:
       - timestamp: 2023-09-18T16:57:02Z
         type: fixed

--- a/vault.advisories.yaml
+++ b/vault.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-1732
+    aliases:
+      - GHSA-2q89-485c-9j2x
     events:
       - timestamp: 2023-05-17T21:33:43Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.13.2-r1
 
   - id: CVE-2023-24999
+    aliases:
+      - GHSA-wmg5-g953-qqfw
     events:
       - timestamp: 2023-03-17T00:08:35Z
         type: detection
@@ -23,6 +27,8 @@ advisories:
           fixed-version: 1.12.4-r0
 
   - id: CVE-2023-34231
+    aliases:
+      - GHSA-fwv2-65wh-2w8c
     events:
       - timestamp: 2023-06-13T11:38:00Z
         type: fixed
@@ -30,6 +36,8 @@ advisories:
           fixed-version: 1.13.3-r1
 
   - id: CVE-2023-3462
+    aliases:
+      - GHSA-9v3w-w2jh-4hff
     events:
       - timestamp: 2023-08-11T18:49:00Z
         type: fixed

--- a/vim.advisories.yaml
+++ b/vim.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-1127
+    aliases:
+      - GHSA-wvg5-x3jq-vp4g
     events:
       - timestamp: 2023-03-10T00:43:53Z
         type: detection
@@ -16,6 +18,8 @@ advisories:
           fixed-version: 9.0.1378-r0
 
   - id: CVE-2023-1175
+    aliases:
+      - GHSA-w4c8-8fhq-883p
     events:
       - timestamp: 2023-03-10T00:43:53Z
         type: detection
@@ -27,6 +31,8 @@ advisories:
           fixed-version: 9.0.1378-r0
 
   - id: CVE-2023-1264
+    aliases:
+      - GHSA-mrf7-wp64-3p45
     events:
       - timestamp: 2023-03-15T17:55:12Z
         type: detection
@@ -38,6 +44,8 @@ advisories:
           fixed-version: 9.0.1392-r0
 
   - id: CVE-2023-1355
+    aliases:
+      - GHSA-cr28-mcq5-hjmg
     events:
       - timestamp: 2023-03-16T17:28:26Z
         type: detection

--- a/wasmtime.advisories.yaml
+++ b/wasmtime.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-26489
+    aliases:
+      - GHSA-ff4p-7xrq-q5r8
     events:
       - timestamp: 2023-03-16T17:28:26Z
         type: detection
@@ -16,6 +18,8 @@ advisories:
           fixed-version: 6.0.1-r0
 
   - id: CVE-2023-27477
+    aliases:
+      - GHSA-xm67-587q-r2vw
     events:
       - timestamp: 2023-03-16T17:28:26Z
         type: detection

--- a/wavefront-proxy.advisories.yaml
+++ b/wavefront-proxy.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-34462
+    aliases:
+      - GHSA-6mjq-h674-j845
     events:
       - timestamp: 2023-08-11T18:20:24Z
         type: detection
@@ -16,6 +18,8 @@ advisories:
           fixed-version: 13.1-r1
 
   - id: CVE-2023-35116
+    aliases:
+      - GHSA-gx6w-fqg7-mc3p
     events:
       - timestamp: 2023-08-11T18:19:16Z
         type: false-positive-determination

--- a/yajl.advisories.yaml
+++ b/yajl.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-33460
+    aliases:
+      - GHSA-cqgm-m7h3-xgwm
     events:
       - timestamp: 2023-07-19T17:54:51Z
         type: fixed

--- a/yasm.advisories.yaml
+++ b/yasm.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-31975
+    aliases:
+      - GHSA-g56w-fm5h-cwrp
     events:
       - timestamp: 2023-06-22T12:13:09Z
         type: false-positive-determination

--- a/zlib.advisories.yaml
+++ b/zlib.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2018-25032
+    aliases:
+      - GHSA-jc36-42cf-vqwj
     events:
       - timestamp: 2022-10-11T11:16:06Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 1.2.12-r0
 
   - id: CVE-2022-37434
+    aliases:
+      - GHSA-cfmr-vrgj-vqwv
     events:
       - timestamp: 2022-10-11T11:16:06Z
         type: fixed

--- a/zola.advisories.yaml
+++ b/zola.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-40274
+    aliases:
+      - GHSA-xvv9-5j67-3rpq
     events:
       - timestamp: 2023-09-30T19:13:14Z
         type: detection

--- a/zookeeper.advisories.yaml
+++ b/zookeeper.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-26048
+    aliases:
+      - GHSA-qw69-rqj8-6qw8
     events:
       - timestamp: 2023-05-02T13:44:37Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 3.4.0-r2
 
   - id: CVE-2023-26049
+    aliases:
+      - GHSA-p26g-97m4-6q7c
     events:
       - timestamp: 2023-05-02T13:44:26Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 3.4.0-r2
 
   - id: CVE-2023-35116
+    aliases:
+      - GHSA-gx6w-fqg7-mc3p
     events:
       - timestamp: 2023-08-11T20:29:47Z
         type: false-positive-determination
@@ -27,6 +33,8 @@ advisories:
           note: CVE disputed by upstream developers, nothing specific to this application.
 
   - id: CVE-2023-36479
+    aliases:
+      - GHSA-3gh6-v5v9-6v9j
     events:
       - timestamp: 2023-09-22T19:58:51Z
         type: fixed
@@ -34,6 +42,8 @@ advisories:
           fixed-version: 3.9.0.1-r1
 
   - id: CVE-2023-40167
+    aliases:
+      - GHSA-hmr7-m48g-48f6
     events:
       - timestamp: 2023-09-22T19:59:09Z
         type: fixed
@@ -41,6 +51,8 @@ advisories:
           fixed-version: 3.9.0.1-r1
 
   - id: CVE-2023-41900
+    aliases:
+      - GHSA-pwh8-58vv-vw48
     events:
       - timestamp: 2023-09-22T19:59:17Z
         type: fixed
@@ -48,6 +60,8 @@ advisories:
           fixed-version: 3.9.0.1-r1
 
   - id: CVE-2023-43642
+    aliases:
+      - GHSA-55g7-9cwv-5qfv
     events:
       - timestamp: 2023-09-30T14:57:52Z
         type: fixed
@@ -55,6 +69,8 @@ advisories:
           fixed-version: 3.9.0.1-r2
 
   - id: CVE-2023-44487
+    aliases:
+      - GHSA-qppj-fm5r-hxr3
     events:
       - timestamp: 2023-10-11T05:12:56Z
         type: fixed
@@ -62,6 +78,8 @@ advisories:
           fixed-version: 3.9.1.0-r1
 
   - id: CVE-2023-4586
+    aliases:
+      - GHSA-57m8-f3v5-hm5m
     events:
       - timestamp: 2023-10-11T05:11:48Z
         type: fixed

--- a/zot.advisories.yaml
+++ b/zot.advisories.yaml
@@ -5,6 +5,8 @@ package:
 
 advisories:
   - id: CVE-2023-25656
+    aliases:
+      - GHSA-87x9-7grx-m28v
     events:
       - timestamp: 2023-08-15T00:41:53Z
         type: true-positive-determination
@@ -12,6 +14,8 @@ advisories:
           note: We are waiting on zot to update its code to use a fixed version of the affected notation library.
 
   - id: CVE-2023-33959
+    aliases:
+      - GHSA-xhg5-42rf-296r
     events:
       - timestamp: 2023-08-15T00:42:56Z
         type: true-positive-determination


### PR DESCRIPTION
This uses the new `wolfictl adv alias discover` command to find GHSA aliases for existing advisories.

Noteworthy benefits to having alias data:

- Standardize on _CVE-based_ advisory IDs where possible
- Link to additional informational resources, which helps add context to vulnerability investigations
- More complete filtering against scanner results
- Reduces risk of duplicate investigation work