### PR TITLE
fix: empty data field in kubernetes-1.25

### DIFF
--- a/kubernetes-1.25.advisories.yaml
+++ b/kubernetes-1.25.advisories.yaml
@@ -56,7 +56,6 @@ advisories:
     events:
       - timestamp: 2023-10-03T20:14:22Z
         type: true-positive-determination
-        data:
       - timestamp: 2023-10-03T20:15:00Z
         type: fix-not-planned
         data:


### PR DESCRIPTION
This was caused by a YAML marshaling bug that's being fixed in an upcoming `wolfictl` PR related to aliases.

This PR is needed to ensure the data set passes validation after https://github.com/wolfi-dev/wolfictl/pull/418 is merged.