### PR TITLE
Advisories for curl CVEs

### DIFF
--- a/curl-rustls.advisories.yaml
+++ b/curl-rustls.advisories.yaml
@@ -9,11 +9,11 @@ advisories:
       - timestamp: 2023-10-10T18:25:54Z
         type: fixed
         data:
-          fixed-version: <TBD>
+          fixed-version: 8.4.0-r0
 
   - id: CVE-2023-38546
     events:
       - timestamp: 2023-10-10T18:26:08Z
         type: fixed
         data:
-          fixed-version: <TBD>
+          fixed-version: 8.4.0-r0

--- a/curl-rustls.advisories.yaml
+++ b/curl-rustls.advisories.yaml
@@ -1,0 +1,19 @@
+schema-version: "2"
+
+package:
+  name: curl-rustls
+
+advisories:
+  - id: CVE-2023-38545
+    events:
+      - timestamp: 2023-10-10T18:25:54Z
+        type: fixed
+        data:
+          fixed-version: <TBD>
+
+  - id: CVE-2023-38546
+    events:
+      - timestamp: 2023-10-10T18:26:08Z
+        type: fixed
+        data:
+          fixed-version: <TBD>

--- a/curl.advisories.yaml
+++ b/curl.advisories.yaml
@@ -44,11 +44,11 @@ advisories:
       - timestamp: 2023-10-10T18:25:22Z
         type: fixed
         data:
-          fixed-version: <TBD>
+          fixed-version: 8.4.0-r0
 
   - id: CVE-2023-38546
     events:
       - timestamp: 2023-10-10T18:25:44Z
         type: fixed
         data:
-          fixed-version: <TBD>
+          fixed-version: 8.4.0-r0

--- a/curl.advisories.yaml
+++ b/curl.advisories.yaml
@@ -38,3 +38,17 @@ advisories:
         type: fixed
         data:
           fixed-version: 8.2.0-r0
+
+  - id: CVE-2023-38545
+    events:
+      - timestamp: 2023-10-10T18:25:22Z
+        type: fixed
+        data:
+          fixed-version: <TBD>
+
+  - id: CVE-2023-38546
+    events:
+      - timestamp: 2023-10-10T18:25:44Z
+        type: fixed
+        data:
+          fixed-version: <TBD>


### PR DESCRIPTION
This PR creates advisories for CVE-2023-38545 and CVE-2023-38546 in `curl` and `curl-rustls`.

### TODO

- [x] Update `fixed-version` field values once known.