### PR TITLE
postgres-16: CVE-2017-8806 false positive

### DIFF
--- a/postgresql-16.advisories.yaml
+++ b/postgresql-16.advisories.yaml
@@ -1,0 +1,13 @@
+schema-version: "2"
+
+package:
+  name: postgresql-16
+
+advisories:
+  - id: CVE-2017-8806
+    events:
+      - timestamp: 2023-10-11T19:02:51Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This CVE appears to impact only Debian/Ubuntu.


### PR DESCRIPTION
(similar to all other version streams of `postgres-*`)