### PR TITLE
CVE-2023-44487 does not apply to our nodejs packages

### DIFF
--- a/nodejs-16.advisories.yaml
+++ b/nodejs-16.advisories.yaml
@@ -87,3 +87,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 16.20.2-r0
+
+  - id: CVE-2023-44487
+    events:
+      - timestamp: 2023-10-12T11:41:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This package uses an external implementation of HTTP/2 (via nghttp2).

--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -87,3 +87,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 18.17.1-r0
+
+  - id: CVE-2023-44487
+    events:
+      - timestamp: 2023-10-12T11:37:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This package uses an external implementation of HTTP/2 (via nghttp2).

--- a/nodejs-19.advisories.yaml
+++ b/nodejs-19.advisories.yaml
@@ -23,3 +23,11 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: 'This vulnerability only affects some versions of Node.js 20. This package is pinned at version 19. Reference: https://nodejs.org/en/blog/vulnerability/august-2023-security-releases'
+
+  - id: CVE-2023-44487
+    events:
+      - timestamp: 2023-10-12T11:41:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This package uses an external implementation of HTTP/2 (via nghttp2).

--- a/nodejs-20.advisories.yaml
+++ b/nodejs-20.advisories.yaml
@@ -131,3 +131,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 20.5.1-r0
+
+  - id: CVE-2023-44487
+    events:
+      - timestamp: 2023-10-12T11:41:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This package uses an external implementation of HTTP/2 (via nghttp2).


### PR DESCRIPTION
Wolfi's `nodejs-*` packages don't use Node's bundled implementation of nghttp2. Instead they rely on the separate Wolfi package `nghttp2`, which is already patched: https://github.com/wolfi-dev/advisories/pull/310