### PR TITLE
Update advisories for `prometheus-elasticsearch-exporter`

### DIFF
--- a/prometheus-elasticsearch-exporter.advisories.yaml
+++ b/prometheus-elasticsearch-exporter.advisories.yaml
@@ -10,6 +10,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.6.0-r6
+      - timestamp: 2023-10-18T03:55:31Z
+        type: fixed
+        data:
+          fixed-version: 1.6.0-r7
 
   - id: CVE-2023-3978
     events:
@@ -17,3 +21,14 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.6.0-r6
+      - timestamp: 2023-10-18T03:55:16Z
+        type: fixed
+        data:
+          fixed-version: 1.6.0-r7
+
+  - id: CVE-2023-44487
+    events:
+      - timestamp: 2023-10-18T03:55:41Z
+        type: fixed
+        data:
+          fixed-version: 1.6.0-r7


### PR DESCRIPTION
Per my PR in https://github.com/wolfi-dev/os/pull/7009, I see that `-r6` doesn't fix the CVE. But, `-r7` does.

I'm hesitating between replacing the previous `fixed` event and creating a new one. I'm open to both :)