### PR TITLE
Correct advisory entry for zlib

### DIFF
--- a/zlib.advisories.yaml
+++ b/zlib.advisories.yaml
@@ -22,7 +22,7 @@ advisories:
         data:
           fixed-version: 1.2.12-r3
 
-  - id: CVE-2023-40283
+  - id: CVE-2023-45853
     events:
       - timestamp: 2023-10-20T08:03:07Z
         type: fixed


### PR DESCRIPTION
CVE-2023-45853 was fixed, not CVE-2023-40283