### PR TITLE
Add keda advisory data for older versions

### DIFF
--- a/keda-2.8.advisories.yaml
+++ b/keda-2.8.advisories.yaml
@@ -1,0 +1,26 @@
+schema-version: "2"
+
+package:
+  name: keda-2.8
+
+advisories:
+  - id: CVE-2023-39325
+    events:
+      - timestamp: 2023-10-23T17:15:51Z
+        type: fixed
+        data:
+          fixed-version: 2.8.2-r2
+
+  - id: CVE-2023-44487
+    events:
+      - timestamp: 2023-10-23T17:15:08Z
+        type: fixed
+        data:
+          fixed-version: 2.8.2-r2
+
+  - id: CVE-2023-3978
+    events:
+      - timestamp: 2023-10-23T17:15:08Z
+        type: fixed
+        data:
+          fixed-version: 2.8.2-r2

--- a/keda-2.9.advisories.yaml
+++ b/keda-2.9.advisories.yaml
@@ -1,0 +1,26 @@
+schema-version: "2"
+
+package:
+  name: keda-2.9
+
+advisories:
+  - id: CVE-2023-39325
+    events:
+      - timestamp: 2023-10-23T17:15:51Z
+        type: fixed
+        data:
+          fixed-version: 2.9.1-r4
+
+  - id: CVE-2023-44487
+    events:
+      - timestamp: 2023-10-23T17:15:08Z
+        type: fixed
+        data:
+          fixed-version: 2.9.1-r4
+
+  - id: CVE-2023-3978
+    events:
+      - timestamp: 2023-10-23T17:15:08Z
+        type: fixed
+        data:
+          fixed-version: 2.9.1-r4


### PR DESCRIPTION
After looking at the cve's dashboard, we saw older keda version reporting CVEs. We realized we were missing keda adv data for these enterprise packages.