### PR TITLE
Update advisory for gradle-8

### DIFF
--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -71,6 +71,10 @@ advisories:
         type: detection
         data:
           type: manual
+      - timestamp: 2023-10-26T16:13:17Z
+        type: true-positive-determination
+        data:
+          note: The affected class is included in the package. The upstream project will need to move to a newer BouncyCastle provider (bcprov-lts8on) for this vulnerability to be fixed.
 
   - id: CVE-2023-35116
     aliases:


### PR DESCRIPTION
The affected class is included in our package, so I'm marking this as a true positive. We can't bump the provider's version since the latest version doesn't fix the issue.