### PR TITLE
Advisories for trino

### DIFF
--- a/trino.advisories.yaml
+++ b/trino.advisories.yaml
@@ -1,0 +1,70 @@
+schema-version: 2.0.1
+
+package:
+  name: trino
+
+advisories:
+  - id: CVE-2020-8908
+    aliases:
+      - GHSA-5mg8-w23w-74h3
+    events:
+      - timestamp: 2023-10-27T22:02:37Z
+        type: true-positive-determination
+        data:
+          note: We have determined that the offending java class is included in the package via a number of shaded JARs.
+      - timestamp: 2023-10-27T22:03:34Z
+        type: pending-upstream-fix
+        data:
+          note: 'The upstream project relies on a number of "shaded JARs", making it harder to update dependencies. The upstream project will need to migrate away from a number of shaded JARs, including: "gcs-connector-hadoop3-2.2.17-shaded.jar" and "rubix-presto-shaded-0.3.18.jar" for this vulnerability to be resolved.'
+
+  - id: CVE-2022-25647
+    aliases:
+      - GHSA-4jrv-ppp4-jm57
+    events:
+      - timestamp: 2023-10-27T21:53:42Z
+        type: true-positive-determination
+        data:
+          note: The offending code is included in this package via the JAR "rubix-presto-shaded-0.3.18.jar"
+      - timestamp: 2023-10-27T21:54:48Z
+        type: pending-upstream-fix
+        data:
+          note: The upstream project relies on a number of "shaded JARs", making it harder to update dependencies. The upstream project will need to migrate away from "rubix-presto-shaded-0.3.18.jar" for this vulnerability to be resolved. This will likely involve a migration to a different package, since com.qubole.rubix.rubix-presto-shaded was last updated on 2020-11-24.
+
+  - id: CVE-2023-2976
+    aliases:
+      - GHSA-7g45-4rm6-3mm3
+    events:
+      - timestamp: 2023-10-27T22:03:13Z
+        type: true-positive-determination
+        data:
+          note: We have determined that the offending java class is included in the package via a number of shaded JARs.
+      - timestamp: 2023-10-27T22:03:34Z
+        type: pending-upstream-fix
+        data:
+          note: 'The upstream project relies on a number of "shaded JARs", making it harder to update dependencies. The upstream project will need to migrate away from a number of shaded JARs, including: "gcs-connector-hadoop3-2.2.17-shaded.jar" and "rubix-presto-shaded-0.3.18.jar" for this vulnerability to be resolved.'
+
+  - id: CVE-2023-44981
+    aliases:
+      - GHSA-7286-pgfv-vxvh
+    events:
+      - timestamp: 2023-10-27T21:47:57Z
+        type: true-positive-determination
+        data:
+          note: We have determined that the offending java class is included in the package via the JAR "alluxio-shaded-client-2.9.3.jar". This vulnerability only affects the Zookeeper server, which is likely not used by the package, but the exact impact is unknown.
+      - timestamp: 2023-10-27T21:49:07Z
+        type: pending-upstream-fix
+        data:
+          note: The upstream project relies on a number of "shaded JARs", making it harder to update dependencies. The upstream project will need to migrate away from "alluxio-shaded-client-2.9.3.jar" for this vulnerability to be resolved.
+
+  - id: CVE-2023-46120
+    aliases:
+      - GHSA-mm8h-8587-p46h
+    events:
+      - timestamp: 2023-10-27T21:59:48Z
+        type: true-positive-determination
+        data:
+          note: We have determined that the offending java class is included in the package via the JAR "alluxio-shaded-client-2.9.3.jar".
+      - timestamp: 2023-10-27T22:00:23Z
+        type: pending-upstream-fix
+        data:
+          note: The upstream project relies on a number of "shaded JARs", making it harder to update dependencies. The upstream project will need to migrate away from "alluxio-shaded-client-2.9.3.jar" for this vulnerability to be resolved.


### PR DESCRIPTION
So.... I ended up marking all the `trino` vulnerabilities as true-positive. Arguably CVE-2023-44981 is LIKELY a false-positive, but I can verify that the offending class is included in the package. At that point, I feel more comfortable marking it as a true positive. 