### PR TITLE
go-fips-1.19: note fixes not planned

### DIFF
--- a/go-fips-1.19.advisories.yaml
+++ b/go-fips-1.19.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: go-fips-1.19
@@ -135,6 +135,8 @@ advisories:
           fixed-version: 1.19.9-r0
 
   - id: CVE-2023-39318
+    aliases:
+      - GHSA-vq7j-gx56-rxjh
     events:
       - timestamp: 2023-10-25T23:10:38Z
         type: true-positive-determination
@@ -146,6 +148,8 @@ advisories:
           note: This package is locked to 1.19.x and will not receive a fix.
 
   - id: CVE-2023-39319
+    aliases:
+      - GHSA-vv9m-32rr-3g55
     events:
       - timestamp: 2023-10-25T23:11:54Z
         type: true-positive-determination
@@ -155,3 +159,21 @@ advisories:
         type: fix-not-planned
         data:
           note: This package is locked to 1.19.x and will not receive a fix.
+
+  - id: CVE-2023-39323
+    aliases:
+      - GHSA-679v-hh23-h5jh
+    events:
+      - timestamp: 2023-11-01T15:09:23Z
+        type: fix-not-planned
+        data:
+          note: This version of Go is no longer receiving support upstream.
+
+  - id: CVE-2023-44487
+    aliases:
+      - GHSA-qppj-fm5r-hxr3
+    events:
+      - timestamp: 2023-11-01T15:09:23Z
+        type: fix-not-planned
+        data:
+          note: This version of Go is no longer receiving support upstream.


### PR DESCRIPTION
note: go-fips-1.19 was recently removed from Wolfi