### PR TITLE
telegraf-1.26: fix GHSA-m425-mq94-257g and CVE-2023-4612

### DIFF
--- a/telegraf-1.26.advisories.yaml
+++ b/telegraf-1.26.advisories.yaml
@@ -40,6 +40,20 @@ advisories:
         data:
           fixed-version: 1.26.3-r4
 
+  - id: CVE-2023-44487
+    events:
+      - timestamp: 2023-11-05T14:53:30Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r6
+
+  - id: CVE-2023-46129
+    events:
+      - timestamp: 2023-11-05T14:55:01Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r6
+
   - id: GHSA-2w8w-qhg4-f78j
     events:
       - timestamp: 2023-08-25T22:21:50Z


### PR DESCRIPTION
related to https://github.com/wolfi-dev/os/pull/8012