### PR TITLE
CVE-2023-45283 and CVE-2023-45284: mark FPs for Go packages

### DIFF
--- a/aactl.advisories.yaml
+++ b/aactl.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: aactl
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:21:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:22:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/actions-runner-controller.advisories.yaml
+++ b/actions-runner-controller.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: actions-runner-controller
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:22:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:22:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/amass.advisories.yaml
+++ b/amass.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: amass
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:22:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:22:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/amazon-corretto-crypto-provider.advisories.yaml
+++ b/amazon-corretto-crypto-provider.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: amazon-corretto-crypto-provider
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:22:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:22:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/apko.advisories.yaml
+++ b/apko.advisories.yaml
@@ -58,6 +58,22 @@ advisories:
         data:
           fixed-version: 0.10.0-r6
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:22:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:03:39Z

--- a/argo-cd-2.7.advisories.yaml
+++ b/argo-cd-2.7.advisories.yaml
@@ -61,6 +61,22 @@ advisories:
         data:
           fixed-version: 2.7.14-r7
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:17:59Z

--- a/argo-cd-2.8.advisories.yaml
+++ b/argo-cd-2.8.advisories.yaml
@@ -51,6 +51,22 @@ advisories:
         data:
           fixed-version: 2.8.4-r4
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:00Z

--- a/argo-workflows.advisories.yaml
+++ b/argo-workflows.advisories.yaml
@@ -4,6 +4,22 @@ package:
   name: argo-workflows
 
 advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:03:40Z

--- a/atlantis.advisories.yaml
+++ b/atlantis.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.26.0-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/aws-ebs-csi-driver.advisories.yaml
+++ b/aws-ebs-csi-driver.advisories.yaml
@@ -41,3 +41,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.23.1-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/aws-efs-csi-driver.advisories.yaml
+++ b/aws-efs-csi-driver.advisories.yaml
@@ -90,3 +90,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.7.0-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/aws-flb-cloudwatch.advisories.yaml
+++ b/aws-flb-cloudwatch.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: aws-flb-cloudwatch
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/aws-flb-firehose.advisories.yaml
+++ b/aws-flb-firehose.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: aws-flb-firehose
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/aws-flb-kinesis.advisories.yaml
+++ b/aws-flb-kinesis.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: aws-flb-kinesis
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/aws-load-balancer-controller.advisories.yaml
+++ b/aws-load-balancer-controller.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.6.1-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/bank-vaults.advisories.yaml
+++ b/bank-vaults.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.20.4-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/bom.advisories.yaml
+++ b/bom.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: bom
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/boring-registry.advisories.yaml
+++ b/boring-registry.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: boring-registry
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/buf.advisories.yaml
+++ b/buf.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: buf
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/buildkitd.advisories.yaml
+++ b/buildkitd.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: buildkitd
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/caddy.advisories.yaml
+++ b/caddy.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.7.5-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/calico.advisories.yaml
+++ b/calico.advisories.yaml
@@ -69,3 +69,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.26.3-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/capslock.advisories.yaml
+++ b/capslock.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: capslock
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cert-manager-1.11.advisories.yaml
+++ b/cert-manager-1.11.advisories.yaml
@@ -32,3 +32,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.11.5-r5
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:23:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:23:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cert-manager-1.12.advisories.yaml
+++ b/cert-manager-1.12.advisories.yaml
@@ -22,3 +22,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.12.5-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cert-manager-1.13.advisories.yaml
+++ b/cert-manager-1.13.advisories.yaml
@@ -22,3 +22,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.13.1-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/certificate-transparency.advisories.yaml
+++ b/certificate-transparency.advisories.yaml
@@ -12,3 +12,19 @@ advisories:
         type: pending-upstream-fix
         data:
           note: Pending upstream fix, this fix will require some code changes.
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cfssl.advisories.yaml
+++ b/cfssl.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: cfssl
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/chartmuseum.advisories.yaml
+++ b/chartmuseum.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.16.0-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cilium-cli.advisories.yaml
+++ b/cilium-cli.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: cilium-cli
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cilium-envoy.advisories.yaml
+++ b/cilium-envoy.advisories.yaml
@@ -13,3 +13,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.25_git20231010-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cilium.advisories.yaml
+++ b/cilium.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: cilium
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cloud-sql-proxy.advisories.yaml
+++ b/cloud-sql-proxy.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.7.0-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cloudflared.advisories.yaml
+++ b/cloudflared.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: cloudflared
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cluster-autoscaler-1.25.advisories.yaml
+++ b/cluster-autoscaler-1.25.advisories.yaml
@@ -50,3 +50,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.25.3-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cluster-autoscaler-1.26.advisories.yaml
+++ b/cluster-autoscaler-1.26.advisories.yaml
@@ -49,3 +49,19 @@ advisories:
         type: true-positive-determination
         data:
           note: Govulncheck confirms the affect symbol is present. But bumping the affected dependency requires third party modules to update their code not to use packages removed in recent versions of OpenTelemtry's modules, so we'll need to wait for upstream changes to fix this.
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cluster-autoscaler-1.27.advisories.yaml
+++ b/cluster-autoscaler-1.27.advisories.yaml
@@ -49,3 +49,19 @@ advisories:
         type: true-positive-determination
         data:
           note: Govulncheck confirms the affect symbol is present. But bumping the affected dependency requires third party modules to update their code not to use packages removed in recent versions of OpenTelemtry's modules, so we'll need to wait for upstream changes to fix this.
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cluster-autoscaler-1.28.advisories.yaml
+++ b/cluster-autoscaler-1.28.advisories.yaml
@@ -59,3 +59,19 @@ advisories:
         type: true-positive-determination
         data:
           note: Govulncheck confirms the affect symbol is present. But bumping the affected dependency requires third party modules to update their code not to use packages removed in recent versions of OpenTelemtry's modules, so we'll need to wait for upstream changes to fix this.
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cluster-proportional-autoscaler.advisories.yaml
+++ b/cluster-proportional-autoscaler.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: cluster-proportional-autoscaler
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cni-plugins.advisories.yaml
+++ b/cni-plugins.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: cni-plugins
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/configmap-reload.advisories.yaml
+++ b/configmap-reload.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: configmap-reload
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/conftest.advisories.yaml
+++ b/conftest.advisories.yaml
@@ -14,6 +14,22 @@ advisories:
         data:
           fixed-version: 0.46.0-r1
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:03:41Z

--- a/consul-1.15.advisories.yaml
+++ b/consul-1.15.advisories.yaml
@@ -57,3 +57,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.15.6-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:24:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/consul-1.16.advisories.yaml
+++ b/consul-1.16.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.16.2-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:24:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/containerd.advisories.yaml
+++ b/containerd.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.7.7-r2
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/coredns.advisories.yaml
+++ b/coredns.advisories.yaml
@@ -31,3 +31,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.11.1-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cortex.advisories.yaml
+++ b/cortex.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: cortex
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cosign.advisories.yaml
+++ b/cosign.advisories.yaml
@@ -42,6 +42,22 @@ advisories:
         data:
           fixed-version: 2.2.0-r6
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: CVE-2023-46737
     aliases:
       - GHSA-vfp6-jrw2-99g9

--- a/crane.advisories.yaml
+++ b/crane.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: crane
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cri-tools.advisories.yaml
+++ b/cri-tools.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: cri-tools
@@ -13,3 +13,19 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: Vulnerable code is part of an external controller not included kubernetes/kubernetes library
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/croc.advisories.yaml
+++ b/croc.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: croc
@@ -75,3 +75,19 @@ advisories:
           data:
             cpeSearched: cpe:2.3:a:*:croc:*:*:*:*:*:*:*:*
             cpeFound: cpe:2.3:a:schollz:croc:*:*:*:*:*:*:*:*
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/crossplane-provider-aws.advisories.yaml
+++ b/crossplane-provider-aws.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.42.0-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/crossplane-provider-azure.advisories.yaml
+++ b/crossplane-provider-azure.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.37.1-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/crossplane.advisories.yaml
+++ b/crossplane.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: crossplane
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/ctop.advisories.yaml
+++ b/ctop.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: ctop
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/cue.advisories.yaml
+++ b/cue.advisories.yaml
@@ -39,3 +39,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.6.0-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/dask-gateway.advisories.yaml
+++ b/dask-gateway.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: dask-gateway
@@ -12,3 +12,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2023.9.0-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/dataplaneapi.advisories.yaml
+++ b/dataplaneapi.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: dataplaneapi
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/delve.advisories.yaml
+++ b/delve.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: delve
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/dex.advisories.yaml
+++ b/dex.advisories.yaml
@@ -31,3 +31,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.37.0-r8
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/dgraph.advisories.yaml
+++ b/dgraph.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: dgraph
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:25:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/dive.advisories.yaml
+++ b/dive.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.11.0-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:25:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/docker-credential-acr-env.advisories.yaml
+++ b/docker-credential-acr-env.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: docker-credential-acr-env
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/docker-credential-ecr-login.advisories.yaml
+++ b/docker-credential-ecr-login.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: docker-credential-ecr-login
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/docker-credential-gcr.advisories.yaml
+++ b/docker-credential-gcr.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: docker-credential-gcr
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/dockerize.advisories.yaml
+++ b/dockerize.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: dockerize
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/dynamic-localpv-provisioner.advisories.yaml
+++ b/dynamic-localpv-provisioner.advisories.yaml
@@ -122,6 +122,22 @@ advisories:
         data:
           fixed-version: 3.4.1-r4
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-xg2h-wx96-xgxr
     events:
       - timestamp: 2023-10-12T12:48:36Z

--- a/eksctl.advisories.yaml
+++ b/eksctl.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: eksctl
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/envoy-ratelimit.advisories.yaml
+++ b/envoy-ratelimit.advisories.yaml
@@ -13,3 +13,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.0_git20231014-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/esbuild.advisories.yaml
+++ b/esbuild.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: esbuild
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/etcd.advisories.yaml
+++ b/etcd.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.5.9-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/external-dns.advisories.yaml
+++ b/external-dns.advisories.yaml
@@ -31,3 +31,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.13.6-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/external-secrets-operator.advisories.yaml
+++ b/external-secrets-operator.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.9.5-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/falcoctl.advisories.yaml
+++ b/falcoctl.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.6.2-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/ferretdb.advisories.yaml
+++ b/ferretdb.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: ferretdb
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/flannel-cni-plugin.advisories.yaml
+++ b/flannel-cni-plugin.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: flannel-cni-plugin
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/flannel.advisories.yaml
+++ b/flannel.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: flannel
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/flux-helm-controller.advisories.yaml
+++ b/flux-helm-controller.advisories.yaml
@@ -42,6 +42,22 @@ advisories:
         data:
           fixed-version: 0.36.2-r2
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:03Z

--- a/flux-image-automation-controller.advisories.yaml
+++ b/flux-image-automation-controller.advisories.yaml
@@ -22,6 +22,22 @@ advisories:
         data:
           fixed-version: 0.36.1-r3
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:06Z

--- a/flux-image-reflector-controller.advisories.yaml
+++ b/flux-image-reflector-controller.advisories.yaml
@@ -22,6 +22,22 @@ advisories:
         data:
           fixed-version: 0.30.0-r4
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:26:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:03:46Z

--- a/flux-kustomize-controller.advisories.yaml
+++ b/flux-kustomize-controller.advisories.yaml
@@ -32,6 +32,22 @@ advisories:
         data:
           fixed-version: 1.1.1-r2
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:26:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:07Z

--- a/flux-notification-controller.advisories.yaml
+++ b/flux-notification-controller.advisories.yaml
@@ -32,6 +32,22 @@ advisories:
         data:
           fixed-version: 1.1.0-r5
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:10Z

--- a/flux-source-controller.advisories.yaml
+++ b/flux-source-controller.advisories.yaml
@@ -32,6 +32,22 @@ advisories:
         data:
           fixed-version: 1.1.2-r2
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:11Z

--- a/flux.advisories.yaml
+++ b/flux.advisories.yaml
@@ -22,6 +22,22 @@ advisories:
         data:
           fixed-version: 2.1.2-r1
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:03:44Z

--- a/fq.advisories.yaml
+++ b/fq.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: fq
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/frp.advisories.yaml
+++ b/frp.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.52.2-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/fulcio.advisories.yaml
+++ b/fulcio.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: fulcio
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/fuse-overlayfs-snapshotter.advisories.yaml
+++ b/fuse-overlayfs-snapshotter.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.0.7-r2
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/fzf.advisories.yaml
+++ b/fzf.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: fzf
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gatekeeper-3.12.advisories.yaml
+++ b/gatekeeper-3.12.advisories.yaml
@@ -62,3 +62,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.12.0-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gatekeeper-3.13.advisories.yaml
+++ b/gatekeeper-3.13.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.13.3-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gatekeeper-3.14.advisories.yaml
+++ b/gatekeeper-3.14.advisories.yaml
@@ -13,3 +13,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.14.0-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gcsfuse.advisories.yaml
+++ b/gcsfuse.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: gcsfuse
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/git-lfs.advisories.yaml
+++ b/git-lfs.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.4.0-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gitlab-kas.advisories.yaml
+++ b/gitlab-kas.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: gitlab-kas
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gitlab-logger.advisories.yaml
+++ b/gitlab-logger.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: gitlab-logger
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gitlab-pages.advisories.yaml
+++ b/gitlab-pages.advisories.yaml
@@ -35,3 +35,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 16.5.0-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gitlab-runner.advisories.yaml
+++ b/gitlab-runner.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 16.5.0-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gitlab-shell.advisories.yaml
+++ b/gitlab-shell.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 14.29.0-r2
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:27:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gitness.advisories.yaml
+++ b/gitness.advisories.yaml
@@ -60,3 +60,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.0.0_beta2-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:27:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gitsign.advisories.yaml
+++ b/gitsign.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: gitsign
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gke-gcloud-auth-plugin.advisories.yaml
+++ b/gke-gcloud-auth-plugin.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: gke-gcloud-auth-plugin
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/glab.advisories.yaml
+++ b/glab.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: glab
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/go-bindata.advisories.yaml
+++ b/go-bindata.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: go-bindata
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/go-licenses.advisories.yaml
+++ b/go-licenses.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: go-licenses
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/go-md2man.advisories.yaml
+++ b/go-md2man.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: go-md2man
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gobuster.advisories.yaml
+++ b/gobuster.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: gobuster
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/golangci-lint.advisories.yaml
+++ b/golangci-lint.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: golangci-lint
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gops.advisories.yaml
+++ b/gops.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: gops
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/goreleaser-1.18.advisories.yaml
+++ b/goreleaser-1.18.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: goreleaser-1.18
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/goreleaser.advisories.yaml
+++ b/goreleaser.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: goreleaser
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gosu.advisories.yaml
+++ b/gosu.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: gosu
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/govulncheck.advisories.yaml
+++ b/govulncheck.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: govulncheck
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/grafana.advisories.yaml
+++ b/grafana.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: grafana
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/grpc-health-probe.advisories.yaml
+++ b/grpc-health-probe.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: grpc-health-probe
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/grpcurl.advisories.yaml
+++ b/grpcurl.advisories.yaml
@@ -84,3 +84,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.8.8-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/grype.advisories.yaml
+++ b/grype.advisories.yaml
@@ -14,6 +14,22 @@ advisories:
         data:
           fixed-version: 0.72.0-r1
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:03:48Z

--- a/guac.advisories.yaml
+++ b/guac.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: guac
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/haproxy-ingress.advisories.yaml
+++ b/haproxy-ingress.advisories.yaml
@@ -40,3 +40,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.14.5-r5
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/helm-push.advisories.yaml
+++ b/helm-push.advisories.yaml
@@ -4,6 +4,22 @@ package:
   name: helm-push
 
 advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:28:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-11-07T04:26:32Z

--- a/helm.advisories.yaml
+++ b/helm.advisories.yaml
@@ -94,6 +94,22 @@ advisories:
         data:
           fixed-version: 3.13.1-r2
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:28:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:14Z

--- a/hey.advisories.yaml
+++ b/hey.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: hey
@@ -120,3 +120,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.1.4-r8
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/http-echo.advisories.yaml
+++ b/http-echo.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: http-echo
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/hubble-ui.advisories.yaml
+++ b/hubble-ui.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: hubble-ui
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/hubble.advisories.yaml
+++ b/hubble.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: hubble
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/hugo-extended.advisories.yaml
+++ b/hugo-extended.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: hugo-extended
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/hugo.advisories.yaml
+++ b/hugo.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.119.0-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/influx.advisories.yaml
+++ b/influx.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: influx
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/influxd.advisories.yaml
+++ b/influxd.advisories.yaml
@@ -35,3 +35,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.7.3-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/ingress-nginx-controller.advisories.yaml
+++ b/ingress-nginx-controller.advisories.yaml
@@ -43,6 +43,22 @@ advisories:
         data:
           fixed-version: 1.9.3-r1
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: CVE-2023-5043
     aliases:
       - GHSA-5wj4-wffq-3378

--- a/ip-masq-agent.advisories.yaml
+++ b/ip-masq-agent.advisories.yaml
@@ -12,3 +12,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.9.3-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/ipfs.advisories.yaml
+++ b/ipfs.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: ipfs
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/istio-cni-1.19.advisories.yaml
+++ b/istio-cni-1.19.advisories.yaml
@@ -12,3 +12,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.19.3-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/istio-operator-1.19.advisories.yaml
+++ b/istio-operator-1.19.advisories.yaml
@@ -21,6 +21,22 @@ advisories:
         data:
           fixed-version: 1.19.3-r0
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-25T20:31:37Z

--- a/istio-pilot-agent-1.18.advisories.yaml
+++ b/istio-pilot-agent-1.18.advisories.yaml
@@ -31,6 +31,22 @@ advisories:
         data:
           fixed-version: 1.18.5-r0
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-13T15:32:21Z

--- a/istio-pilot-agent-1.19.advisories.yaml
+++ b/istio-pilot-agent-1.19.advisories.yaml
@@ -21,6 +21,22 @@ advisories:
         data:
           fixed-version: 1.19.3-r0
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:03:51Z

--- a/istio-pilot-discovery-1.18.advisories.yaml
+++ b/istio-pilot-discovery-1.18.advisories.yaml
@@ -12,3 +12,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.18.5-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/istio-pilot-discovery-1.19.advisories.yaml
+++ b/istio-pilot-discovery-1.19.advisories.yaml
@@ -31,6 +31,22 @@ advisories:
         data:
           fixed-version: 1.19.3-r0
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:29:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:15Z

--- a/jaeger-agent.advisories.yaml
+++ b/jaeger-agent.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: jaeger-agent
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:29:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/k3d.advisories.yaml
+++ b/k3d.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: k3d
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/k8sgpt-operator.advisories.yaml
+++ b/k8sgpt-operator.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.0.21-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/k8sgpt.advisories.yaml
+++ b/k8sgpt.advisories.yaml
@@ -32,6 +32,22 @@ advisories:
         data:
           fixed-version: 0.3.18-r1
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:16Z

--- a/kaf.advisories.yaml
+++ b/kaf.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: kaf
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.2.6-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kaniko.advisories.yaml
+++ b/kaniko.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: kaniko
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kargo.advisories.yaml
+++ b/kargo.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: kargo
@@ -13,3 +13,19 @@ advisories:
         data:
           type: component-vulnerability-mismatch
           note: The vulnerability is against the Kubernetes API server itself, not the apiserver client library.
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/karpenter.advisories.yaml
+++ b/karpenter.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.31.1-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/keda-2.10.advisories.yaml
+++ b/keda-2.10.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: keda-2.10
@@ -49,3 +49,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.10.1-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/keda-2.11.advisories.yaml
+++ b/keda-2.11.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: keda-2.11
@@ -39,3 +39,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.11.2-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/keda.advisories.yaml
+++ b/keda.advisories.yaml
@@ -45,3 +45,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.12.0-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kind.advisories.yaml
+++ b/kind.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: kind
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kine.advisories.yaml
+++ b/kine.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: kine
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/ko.advisories.yaml
+++ b/ko.advisories.yaml
@@ -59,6 +59,22 @@ advisories:
         data:
           fixed-version: 0.15.0-r1
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:03:54Z

--- a/kor.advisories.yaml
+++ b/kor.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: kor
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kots.advisories.yaml
+++ b/kots.advisories.yaml
@@ -78,6 +78,22 @@ advisories:
         data:
           fixed-version: 1.103.3-r1
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-10-02T00:59:21Z

--- a/kpt.advisories.yaml
+++ b/kpt.advisories.yaml
@@ -43,3 +43,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.0.0_beta46-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kube-bench.advisories.yaml
+++ b/kube-bench.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: kube-bench
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:30:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:30:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kube-fluentd-operator.advisories.yaml
+++ b/kube-fluentd-operator.advisories.yaml
@@ -49,3 +49,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.17.6-r8
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kube-logging-operator.advisories.yaml
+++ b/kube-logging-operator.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 4.2.2-r5
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kube-state-metrics.advisories.yaml
+++ b/kube-state-metrics.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.10.0-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubebuilder.advisories.yaml
+++ b/kubebuilder.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: kubebuilder
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubeflow-katib.advisories.yaml
+++ b/kubeflow-katib.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.15.0-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubeflow-pipelines.advisories.yaml
+++ b/kubeflow-pipelines.advisories.yaml
@@ -229,6 +229,22 @@ advisories:
         data:
           note: The project uses an older version of 'k8s.io/kubernetes (v1.11.1)' package. To fix the CVE, we have to upgrade that to '1.24.17' or later. However, the project is not ready to upgrade the package yet since it will require a lot of changes in the codebase.
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-2jcg-qqmg-46q6
     events:
       - timestamp: 2023-11-01T07:13:06Z

--- a/kubernetes-1.24.advisories.yaml
+++ b/kubernetes-1.24.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: kubernetes-1.24
@@ -63,3 +63,19 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: Fixed in Kubernetes 1.21
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-1.25.advisories.yaml
+++ b/kubernetes-1.25.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: kubernetes-1.25
@@ -74,3 +74,19 @@ advisories:
         type: fix-not-planned
         data:
           note: Fixed version (1.26) is out of scope for this version stream.
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-1.26.advisories.yaml
+++ b/kubernetes-1.26.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: kubernetes-1.26
@@ -63,3 +63,19 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: Fixed in Kubernetes 1.21
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: kubernetes-1.27
@@ -63,3 +63,19 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: Fixed in Kubernetes 1.21
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-1.28.advisories.yaml
+++ b/kubernetes-1.28.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: kubernetes-1.28
@@ -63,3 +63,19 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: Fixed in Kubernetes 1.21
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-csi-external-attacher-4.3.advisories.yaml
+++ b/kubernetes-csi-external-attacher-4.3.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 4.3.0-r9
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-csi-external-attacher-4.4.advisories.yaml
+++ b/kubernetes-csi-external-attacher-4.4.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 4.4.0-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-csi-external-provisioner.advisories.yaml
+++ b/kubernetes-csi-external-provisioner.advisories.yaml
@@ -31,3 +31,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.6.0-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-csi-external-resizer.advisories.yaml
+++ b/kubernetes-csi-external-resizer.advisories.yaml
@@ -31,3 +31,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.9.0-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-csi-external-snapshotter.advisories.yaml
+++ b/kubernetes-csi-external-snapshotter.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 6.3.0-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:31:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:31:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-csi-livenessprobe.advisories.yaml
+++ b/kubernetes-csi-livenessprobe.advisories.yaml
@@ -31,3 +31,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.11.0-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-csi-node-driver-registrar-2.9.advisories.yaml
+++ b/kubernetes-csi-node-driver-registrar-2.9.advisories.yaml
@@ -31,3 +31,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.9.0-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-dashboard-metrics-scraper.advisories.yaml
+++ b/kubernetes-dashboard-metrics-scraper.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.0.9-r9
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-dashboard.advisories.yaml
+++ b/kubernetes-dashboard.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.7.0-r9
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-dns-node-cache.advisories.yaml
+++ b/kubernetes-dns-node-cache.advisories.yaml
@@ -32,3 +32,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.22.20-r5
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubernetes-ingress-defaultbackend.advisories.yaml
+++ b/kubernetes-ingress-defaultbackend.advisories.yaml
@@ -12,3 +12,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.25.1-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubescape.advisories.yaml
+++ b/kubescape.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.0.0-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kubevela.advisories.yaml
+++ b/kubevela.advisories.yaml
@@ -51,6 +51,22 @@ advisories:
         data:
           fixed-version: 1.9.6-r4
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:17Z

--- a/kubewatch.advisories.yaml
+++ b/kubewatch.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.5.0-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kustomize.advisories.yaml
+++ b/kustomize.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: kustomize
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kyverno-policy-reporter-kyverno-plugin.advisories.yaml
+++ b/kyverno-policy-reporter-kyverno-plugin.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: kyverno-policy-reporter-kyverno-plugin
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kyverno-policy-reporter-ui.advisories.yaml
+++ b/kyverno-policy-reporter-ui.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: kyverno-policy-reporter-ui
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kyverno-policy-reporter.advisories.yaml
+++ b/kyverno-policy-reporter.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: kyverno-policy-reporter
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/kyverno.advisories.yaml
+++ b/kyverno.advisories.yaml
@@ -60,6 +60,22 @@ advisories:
         data:
           note: Confirmed that the affected code is present in the binary, but Kyverno needs to migrate its code off of the Go packages keeping it at the affected version of go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp. It looks like the release-1.11 branch has made these adjustments and dependency updates, and once the final 1.11 release is out, this Wolfi package will get updated.
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:18Z

--- a/litefs.advisories.yaml
+++ b/litefs.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: litefs
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/local-path-provisioner.advisories.yaml
+++ b/local-path-provisioner.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: local-path-provisioner
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/loki.advisories.yaml
+++ b/loki.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: loki
@@ -20,3 +20,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.8.4-r5
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/mage.advisories.yaml
+++ b/mage.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: mage
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/mc.advisories.yaml
+++ b/mc.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.20230628.215417-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:32:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:32:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/melange.advisories.yaml
+++ b/melange.advisories.yaml
@@ -31,6 +31,22 @@ advisories:
         data:
           fixed-version: 0.3.2-r1
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:03:58Z

--- a/memcached-exporter.advisories.yaml
+++ b/memcached-exporter.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.13.0-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/metacontroller.advisories.yaml
+++ b/metacontroller.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 4.11.0-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/metallb.advisories.yaml
+++ b/metallb.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: metallb
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/metrics-server.advisories.yaml
+++ b/metrics-server.advisories.yaml
@@ -112,3 +112,19 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: Govulncheck confirms that the affected code is not actually present in the compiled binary.
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/minify.advisories.yaml
+++ b/minify.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: minify
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/minio.advisories.yaml
+++ b/minio.advisories.yaml
@@ -109,6 +109,22 @@ advisories:
         data:
           fixed-version: 0.20231025.063325-r0
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: CVE-2023-46129
     aliases:
       - GHSA-mr45-rx8q-wcm9

--- a/mongo-tools.advisories.yaml
+++ b/mongo-tools.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: mongo-tools
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nats-server.advisories.yaml
+++ b/nats-server.advisories.yaml
@@ -4,6 +4,22 @@ package:
   name: nats-server
 
 advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: CVE-2023-46129
     aliases:
       - GHSA-mr45-rx8q-wcm9

--- a/nats.advisories.yaml
+++ b/nats.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nats
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nerdctl.advisories.yaml
+++ b/nerdctl.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nerdctl
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: newrelic-fluent-bit-output
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/newrelic-infra-operator.advisories.yaml
+++ b/newrelic-infra-operator.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: newrelic-infra-operator
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/newrelic-infrastructure-agent.advisories.yaml
+++ b/newrelic-infrastructure-agent.advisories.yaml
@@ -31,6 +31,22 @@ advisories:
         data:
           fixed-version: 1.47.2-r3
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:03:59Z

--- a/newrelic-infrastructure-bundle.advisories.yaml
+++ b/newrelic-infrastructure-bundle.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: newrelic-infrastructure-bundle
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/newrelic-nri-kube-events.advisories.yaml
+++ b/newrelic-nri-kube-events.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: newrelic-nri-kube-events
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/newrelic-prometheus-configurator.advisories.yaml
+++ b/newrelic-prometheus-configurator.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: newrelic-prometheus-configurator
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nfs-subdir-external-provisioner.advisories.yaml
+++ b/nfs-subdir-external-provisioner.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: nfs-subdir-external-provisioner
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 4.0.18-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/node-problem-detector-0.8.advisories.yaml
+++ b/node-problem-detector-0.8.advisories.yaml
@@ -36,6 +36,22 @@ advisories:
         data:
           fixed-version: 0.8.14-r6
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:33:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:33:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:18Z

--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -130,3 +130,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.0.4-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-apache.advisories.yaml
+++ b/nri-apache.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-apache
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-cassandra.advisories.yaml
+++ b/nri-cassandra.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-cassandra
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-consul.advisories.yaml
+++ b/nri-consul.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-consul
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-couchbase.advisories.yaml
+++ b/nri-couchbase.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-couchbase
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-discovery-kubernetes.advisories.yaml
+++ b/nri-discovery-kubernetes.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-discovery-kubernetes
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-elasticsearch.advisories.yaml
+++ b/nri-elasticsearch.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-elasticsearch
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-f5.advisories.yaml
+++ b/nri-f5.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-f5
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-haproxy.advisories.yaml
+++ b/nri-haproxy.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-haproxy
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-jmx.advisories.yaml
+++ b/nri-jmx.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-jmx
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-kafka.advisories.yaml
+++ b/nri-kafka.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-kafka
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-kubernetes.advisories.yaml
+++ b/nri-kubernetes.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-kubernetes
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-memcached.advisories.yaml
+++ b/nri-memcached.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-memcached
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-mongodb.advisories.yaml
+++ b/nri-mongodb.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-mongodb
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-mssql.advisories.yaml
+++ b/nri-mssql.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-mssql
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-mysql.advisories.yaml
+++ b/nri-mysql.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-mysql
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-nagios.advisories.yaml
+++ b/nri-nagios.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-nagios
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-nginx.advisories.yaml
+++ b/nri-nginx.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-nginx
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-postgresql.advisories.yaml
+++ b/nri-postgresql.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-postgresql
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-prometheus.advisories.yaml
+++ b/nri-prometheus.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.18.7-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-rabbitmq.advisories.yaml
+++ b/nri-rabbitmq.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-rabbitmq
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:34:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nri-redis.advisories.yaml
+++ b/nri-redis.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nri-redis
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:34:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nsc.advisories.yaml
+++ b/nsc.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nsc
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nuclei.advisories.yaml
+++ b/nuclei.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: nuclei
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/nvidia-device-plugin.advisories.yaml
+++ b/nvidia-device-plugin.advisories.yaml
@@ -35,3 +35,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.14.2-r2
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/oauth2-proxy.advisories.yaml
+++ b/oauth2-proxy.advisories.yaml
@@ -44,3 +44,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 7.5.1-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/ollama.advisories.yaml
+++ b/ollama.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.1.4-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/opentelemetry-collector-contrib.advisories.yaml
+++ b/opentelemetry-collector-contrib.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: opentelemetry-collector-contrib
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/opentofu.advisories.yaml
+++ b/opentofu.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.6.0_alpha2-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/oras.advisories.yaml
+++ b/oras.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: oras
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/osv-scanner.advisories.yaml
+++ b/osv-scanner.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: osv-scanner
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/paranoia.advisories.yaml
+++ b/paranoia.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: paranoia
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/petname.advisories.yaml
+++ b/petname.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: petname
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/policy-controller.advisories.yaml
+++ b/policy-controller.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: policy-controller
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-adapter.advisories.yaml
+++ b/prometheus-adapter.advisories.yaml
@@ -40,3 +40,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.11.1-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-alertmanager.advisories.yaml
+++ b/prometheus-alertmanager.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.26.0-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-bind-exporter.advisories.yaml
+++ b/prometheus-bind-exporter.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: prometheus-bind-exporter
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-blackbox-exporter.advisories.yaml
+++ b/prometheus-blackbox-exporter.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: prometheus-blackbox-exporter
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-elasticsearch-exporter.advisories.yaml
+++ b/prometheus-elasticsearch-exporter.advisories.yaml
@@ -38,3 +38,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.6.0-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-mongodb-exporter.advisories.yaml
+++ b/prometheus-mongodb-exporter.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.39.0-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:35:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:35:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-mysqld-exporter.advisories.yaml
+++ b/prometheus-mysqld-exporter.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.15.0-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-nats-exporter.advisories.yaml
+++ b/prometheus-nats-exporter.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: prometheus-nats-exporter
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-node-exporter.advisories.yaml
+++ b/prometheus-node-exporter.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.6.1-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-operator.advisories.yaml
+++ b/prometheus-operator.advisories.yaml
@@ -39,3 +39,19 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-postgres-exporter.advisories.yaml
+++ b/prometheus-postgres-exporter.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.14.0-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-pushgateway.advisories.yaml
+++ b/prometheus-pushgateway.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.6.2-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-redis-exporter.advisories.yaml
+++ b/prometheus-redis-exporter.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: prometheus-redis-exporter
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-stackdriver-exporter.advisories.yaml
+++ b/prometheus-stackdriver-exporter.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: prometheus-stackdriver-exporter
@@ -12,3 +12,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.13.0-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus-statsd-exporter.advisories.yaml
+++ b/prometheus-statsd-exporter.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.24.0-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/prometheus.advisories.yaml
+++ b/prometheus.advisories.yaml
@@ -51,6 +51,22 @@ advisories:
         data:
           fixed-version: 2.47.2-r3
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:04:00Z

--- a/protoc-gen-go-grpc.advisories.yaml
+++ b/protoc-gen-go-grpc.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: protoc-gen-go-grpc
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/protoc-gen-go.advisories.yaml
+++ b/protoc-gen-go.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: protoc-gen-go
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/pulumi-kubernetes-operator.advisories.yaml
+++ b/pulumi-kubernetes-operator.advisories.yaml
@@ -32,6 +32,22 @@ advisories:
         data:
           fixed-version: 1.13.0-r5
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:19Z

--- a/pulumi-language-dotnet.advisories.yaml
+++ b/pulumi-language-dotnet.advisories.yaml
@@ -31,3 +31,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.58.0-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/pulumi-language-java.advisories.yaml
+++ b/pulumi-language-java.advisories.yaml
@@ -40,3 +40,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.9.8-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/pulumi-language-yaml.advisories.yaml
+++ b/pulumi-language-yaml.advisories.yaml
@@ -31,3 +31,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.4.0-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/pulumi.advisories.yaml
+++ b/pulumi.advisories.yaml
@@ -49,3 +49,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.91.1-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/q.advisories.yaml
+++ b/q.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: q
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/rabbitmq-cluster-operator.advisories.yaml
+++ b/rabbitmq-cluster-operator.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: rabbitmq-cluster-operator
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:36:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:36:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/rabbitmq-messaging-topology-operator.advisories.yaml
+++ b/rabbitmq-messaging-topology-operator.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: rabbitmq-messaging-topology-operator
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/rclone.advisories.yaml
+++ b/rclone.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: rclone
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/regclient.advisories.yaml
+++ b/regclient.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: regclient
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/rekor.advisories.yaml
+++ b/rekor.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: rekor
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/render-template.advisories.yaml
+++ b/render-template.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: render-template
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/restic.advisories.yaml
+++ b/restic.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: restic
@@ -12,3 +12,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.15.1-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/rootlesskit.advisories.yaml
+++ b/rootlesskit.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: rootlesskit
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/rqlite.advisories.yaml
+++ b/rqlite.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 7.21.4-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/runc.advisories.yaml
+++ b/runc.advisories.yaml
@@ -22,6 +22,22 @@ advisories:
         data:
           fixed-version: 1.1.9-r5
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:20Z

--- a/sbom-scorecard.advisories.yaml
+++ b/sbom-scorecard.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: sbom-scorecard
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/sbomqs.advisories.yaml
+++ b/sbomqs.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: sbomqs
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/scorecard.advisories.yaml
+++ b/scorecard.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: scorecard
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/secrets-store-csi-driver-provider-aws.advisories.yaml
+++ b/secrets-store-csi-driver-provider-aws.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: secrets-store-csi-driver-provider-aws
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/secrets-store-csi-driver-provider-azure.advisories.yaml
+++ b/secrets-store-csi-driver-provider-azure.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: secrets-store-csi-driver-provider-azure
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/secrets-store-csi-driver-provider-gcp.advisories.yaml
+++ b/secrets-store-csi-driver-provider-gcp.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.3.0-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/secrets-store-csi-driver.advisories.yaml
+++ b/secrets-store-csi-driver.advisories.yaml
@@ -48,3 +48,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.3.4-r7
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/sigstore-scaffolding.advisories.yaml
+++ b/sigstore-scaffolding.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.6.8-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/skaffold.advisories.yaml
+++ b/skaffold.advisories.yaml
@@ -43,3 +43,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.8.0-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/skopeo.advisories.yaml
+++ b/skopeo.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: skopeo
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/slsa-verifier.advisories.yaml
+++ b/slsa-verifier.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: slsa-verifier
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:37:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:37:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/smarter-device-manager.advisories.yaml
+++ b/smarter-device-manager.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: smarter-device-manager
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/sonobuoy.advisories.yaml
+++ b/sonobuoy.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: sonobuoy
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/sops.advisories.yaml
+++ b/sops.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: sops
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/spark-operator.advisories.yaml
+++ b/spark-operator.advisories.yaml
@@ -128,3 +128,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.1.27-r13
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/spicedb.advisories.yaml
+++ b/spicedb.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: spicedb
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/spire-server.advisories.yaml
+++ b/spire-server.advisories.yaml
@@ -4,6 +4,22 @@ package:
   name: spire-server
 
 advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T16:32:53Z

--- a/src-fingerprint.advisories.yaml
+++ b/src-fingerprint.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: src-fingerprint
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/src.advisories.yaml
+++ b/src.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: src
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/stakater-reloader.advisories.yaml
+++ b/stakater-reloader.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.0.43-r2
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/step-ca.advisories.yaml
+++ b/step-ca.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: step-ca
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/step.advisories.yaml
+++ b/step.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: step
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/supercronic.advisories.yaml
+++ b/supercronic.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: supercronic
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/syft.advisories.yaml
+++ b/syft.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: syft
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/tailscale.advisories.yaml
+++ b/tailscale.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: tailscale
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/task.advisories.yaml
+++ b/task.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: task
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/tctl.advisories.yaml
+++ b/tctl.advisories.yaml
@@ -48,3 +48,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.18.0-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/tekton-chains.advisories.yaml
+++ b/tekton-chains.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: tekton-chains
@@ -22,3 +22,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.18.0-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/tekton-pipelines.advisories.yaml
+++ b/tekton-pipelines.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: tekton-pipelines
@@ -13,3 +13,19 @@ advisories:
         data:
           type: vulnerable-code-not-in-execution-path
           note: Vulnerable packages not in dependency tree.
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/telegraf-1.26.advisories.yaml
+++ b/telegraf-1.26.advisories.yaml
@@ -53,6 +53,22 @@ advisories:
         data:
           fixed-version: 1.26.3-r6
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: CVE-2023-46129
     aliases:
       - GHSA-mr45-rx8q-wcm9

--- a/telegraf-1.27.advisories.yaml
+++ b/telegraf-1.27.advisories.yaml
@@ -35,6 +35,22 @@ advisories:
         data:
           fixed-version: 1.27.4-r6
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:38:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:38:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:04:03Z

--- a/temporal-server.advisories.yaml
+++ b/temporal-server.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: temporal-server
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/temporal-ui-server.advisories.yaml
+++ b/temporal-ui-server.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: temporal-ui-server
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/temporal.advisories.yaml
+++ b/temporal.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.1
 
 package:
   name: temporal
@@ -20,3 +20,19 @@ advisories:
         data:
           type: component-vulnerability-mismatch
           note: Our 'temporal' package is actually the temporal CLI, not the temporal server itself. (The found CPE is a related component.)
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/terraform-provider-aws.advisories.yaml
+++ b/terraform-provider-aws.advisories.yaml
@@ -13,3 +13,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 5.22.0-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/terraform-provider-azurerm.advisories.yaml
+++ b/terraform-provider-azurerm.advisories.yaml
@@ -13,3 +13,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.77.0-r1
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/terraform.advisories.yaml
+++ b/terraform.advisories.yaml
@@ -39,3 +39,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.5.7-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/terragrunt.advisories.yaml
+++ b/terragrunt.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: terragrunt
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/tflint.advisories.yaml
+++ b/tflint.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: tflint
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/thanos-0.31.advisories.yaml
+++ b/thanos-0.31.advisories.yaml
@@ -58,3 +58,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.31.0-r6
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/thanos-0.32.advisories.yaml
+++ b/thanos-0.32.advisories.yaml
@@ -58,3 +58,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.32.4-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/thanos-operator.advisories.yaml
+++ b/thanos-operator.advisories.yaml
@@ -30,3 +30,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.3.7-r8
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/tigera-operator-1.30.advisories.yaml
+++ b/tigera-operator-1.30.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: tigera-operator-1.30
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/tigera-operator-1.31.advisories.yaml
+++ b/tigera-operator-1.31.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: tigera-operator-1.31
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/timestamp-authority.advisories.yaml
+++ b/timestamp-authority.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: timestamp-authority
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/timoni.advisories.yaml
+++ b/timoni.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.14.2-r2
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/tkn.advisories.yaml
+++ b/tkn.advisories.yaml
@@ -51,3 +51,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.32.0-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/traefik.advisories.yaml
+++ b/traefik.advisories.yaml
@@ -58,6 +58,22 @@ advisories:
         data:
           fixed-version: 2.10.5-r0
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: GHSA-jq35-85cj-fj4p
     events:
       - timestamp: 2023-10-31T20:04:04Z

--- a/trillian.advisories.yaml
+++ b/trillian.advisories.yaml
@@ -80,3 +80,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.5.2-r4
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/trivy.advisories.yaml
+++ b/trivy.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: trivy
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:39:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:39:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/trust-manager.advisories.yaml
+++ b/trust-manager.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.6.0-r5
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/up.advisories.yaml
+++ b/up.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: up
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/vault-1.13.advisories.yaml
+++ b/vault-1.13.advisories.yaml
@@ -31,6 +31,22 @@ advisories:
         data:
           fixed-version: 1.13.8-r3
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: CVE-2023-4680
     aliases:
       - GHSA-v84f-6r39-cpfc

--- a/vault-1.14.advisories.yaml
+++ b/vault-1.14.advisories.yaml
@@ -22,6 +22,22 @@ advisories:
         data:
           fixed-version: 1.14.4-r3
 
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: CVE-2023-4680
     aliases:
       - GHSA-v84f-6r39-cpfc

--- a/vault-csi-provider.advisories.yaml
+++ b/vault-csi-provider.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: vault-csi-provider
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/vault-k8s.advisories.yaml
+++ b/vault-k8s.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.2.1-r8
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/velero.advisories.yaml
+++ b/velero.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: velero
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/vertical-pod-autoscaler.advisories.yaml
+++ b/vertical-pod-autoscaler.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.14.0-r5
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/vexctl.advisories.yaml
+++ b/vexctl.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: vexctl
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/volume-modifier-for-k8s.advisories.yaml
+++ b/volume-modifier-for-k8s.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: volume-modifier-for-k8s
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/vt-cli.advisories.yaml
+++ b/vt-cli.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: vt-cli
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/wait-for-port.advisories.yaml
+++ b/wait-for-port.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: wait-for-port
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/wazero.advisories.yaml
+++ b/wazero.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: wazero
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/weaviate.advisories.yaml
+++ b/weaviate.advisories.yaml
@@ -31,3 +31,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.22.0-r0
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/wire-go.advisories.yaml
+++ b/wire-go.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: wire-go
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/wireguard-go.advisories.yaml
+++ b/wireguard-go.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: wireguard-go
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/wolfictl.advisories.yaml
+++ b/wolfictl.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: wolfictl
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/yq.advisories.yaml
+++ b/yq.advisories.yaml
@@ -21,3 +21,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 4.35.2-r3
+
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/ytt.advisories.yaml
+++ b/ytt.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: ytt
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/zarf.advisories.yaml
+++ b/zarf.advisories.yaml
@@ -1,0 +1,21 @@
+schema-version: 2.0.1
+
+package:
+  name: zarf
+
+advisories:
+  - id: CVE-2023-45283
+    events:
+      - timestamp: 2023-11-07T19:40:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CVE-2023-45284
+    events:
+      - timestamp: 2023-11-07T19:40:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows


### PR DESCRIPTION
See https://go.dev/issue/63713

These CVEs are fixed in the latest version of Go, but only affect applications running on Windows, so these are all FPs for our packages.

This was done by finding packages built with go:

```
git grep -l \
  -e " - go$" \
  -e " - go-1.20$" \
  -e "uses: go/install$" \
  -e "uses: go/build$" | xargs yq .package.name > pkgs
```

Then creating advisories for each of them:

```
while read p; do
echo $p
  wolfictl adv create -V CVE-2023-45283 --fp-type=vulnerable-code-not-included-in-package --fp-note="Only affects Windows" -t false-positive-determination --package=$p
  wolfictl adv create -V CVE-2023-45284 --fp-type=vulnerable-code-not-included-in-package --fp-note="Only affects Windows" -t false-positive-determination --package=$p
done < pkgs
```