### PR TITLE
ffmpeg: Mark CVE-2023-46407 as fixed

### DIFF
--- a/ffmpeg.advisories.yaml
+++ b/ffmpeg.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: 2.0.1
+
+package:
+  name: ffmpeg
+
+advisories:
+  - id: CVE-2023-46407
+    aliases:
+      - GHSA-9j42-4j78-g4mh
+    events:
+      - timestamp: 2023-11-12T05:43:07Z
+        type: fixed
+        data:
+          fixed-version: 6.1-r0


### PR DESCRIPTION
The CVE has been fixed by this PR: https://github.com/wolfi-dev/os/pull/8373

The identified fix commit is: https://github.com/FFmpeg/FFmpeg/commit/bf814387f42e9b0dea9d75c03db4723c88e7d962

Our version `6.0.1` did not have the fix:
```
git merge-base --is-ancestor bf814387f42e9b0dea9d75c03db4723c88e7d962 c41ff724ede7da657762d61097e26fac296c53bf && echo yes || echo no
```

Our version `6.1` has the fix!
```
git merge-base --is-ancestor bf814387f42e9b0dea9d75c03db4723c88e7d962 d4ff0020b40b524a490cf62eccbd3a318f4c0e58 && echo yes || echo no
```