### PR TITLE
nodetaint: Advisories for k8s.io/kubernetes related CVEs

### DIFF
--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -54,6 +54,16 @@ advisories:
           type: vulnerable-code-version-not-used
           note: This does not affect k8s.io/client-go@v0.20.0-alpha.2
 
+  - id: CVE-2021-25736
+    aliases:
+      - GHSA-35c7-w35f-xwgh
+    events:
+      - timestamp: 2023-11-12T22:56:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'This vulnerability affects kube-proxy on Windows and the affected code cannot be imported as part of the golang k8s.io/kubernetes library. The golang vulnerability database reports it as a false-positive: https://github.com/golang/vulndb/blob/47864735862dde2f809a19e4f6ffc1de8d6f3703/data/excluded/GO-2023-2159.yaml'
+
   - id: CVE-2021-25740
     aliases:
       - GHSA-vw47-mr44-3jf9
@@ -104,6 +114,16 @@ advisories:
           type: component-vulnerability-mismatch
           note: This only impacts Kubernetes itself, and was also marked NOT_IMPORTABLE by Golang vulndb
 
+  - id: CVE-2023-3676
+    aliases:
+      - GHSA-7fxm-f474-hf8w
+    events:
+      - timestamp: 2023-11-12T22:57:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'This vulnerability affects the Kubernetes application, not the golang k8s.io/kubernetes library. The golang vulnerability database reports it as a false-positive: https://github.com/golang/vulndb/blob/47864735862dde2f809a19e4f6ffc1de8d6f3703/data/excluded/GO-2023-2330.yaml'
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8
@@ -112,6 +132,16 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.0.4-r6
+
+  - id: CVE-2023-3955
+    aliases:
+      - GHSA-q78c-gwqw-jcmc
+    events:
+      - timestamp: 2023-11-12T22:57:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'This vulnerability affects the Kubernetes application, not the golang k8s.io/kubernetes library. The golang vulnerability database reports it as a false-positive: https://github.com/golang/vulndb/blob/47864735862dde2f809a19e4f6ffc1de8d6f3703/data/excluded/GO-2023-2170.yaml'
 
   - id: CVE-2023-3978
     aliases:
@@ -132,6 +162,8 @@ advisories:
           fixed-version: 0.0.4-r6
 
   - id: CVE-2023-45283
+    aliases:
+      - GHSA-vvjp-q62m-2vph
     events:
       - timestamp: 2023-11-07T19:34:00Z
         type: false-positive-determination
@@ -140,6 +172,8 @@ advisories:
           note: Only affects Windows
 
   - id: CVE-2023-45284
+    aliases:
+      - GHSA-rq3x-83w4-p28c
     events:
       - timestamp: 2023-11-07T19:34:03Z
         type: false-positive-determination


### PR DESCRIPTION
As with other packages, I'm still bumping dependencies in this PR: https://github.com/wolfi-dev/os/pull/8401

I verified the updated image still passes the helm test.