### PR TITLE
metrics-server: CVE-2023-47108

### DIFF
--- a/metrics-server.advisories.yaml
+++ b/metrics-server.advisories.yaml
@@ -133,3 +133,12 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
+
+  - id: CVE-2023-47108
+    aliases:
+      - GHSA-8pgv-569h-w5rw
+    events:
+      - timestamp: 2023-11-13T18:02:45Z
+        type: pending-upstream-fix
+        data:
+          note: Pending upstream fix, this fix will require some code changes due to the usage of one year old Kubernetes dependencies (e.g. k8s.io/apiserver@v0.23.17). These dependencies need to be updated to upgrade the vulnerable otel dependencies. In addition, the latest stable release of the metrics-server project was triggered on June.


### PR DESCRIPTION
This CVE cannot be fixed without applying major changes to the current source code. In addition, it seems like there isn't any new release since July.