### PR TITLE
add CVE-2023-47108/GHSA-8pgv-569h-w5rw and CVE-2023-5528 for argo-cd-2.7

### DIFF
--- a/argo-cd-2.7.advisories.yaml
+++ b/argo-cd-2.7.advisories.yaml
@@ -81,6 +81,15 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
 
+  - id: CVE-2023-47108
+    aliases:
+      - GHSA-8pgv-569h-w5rw
+    events:
+      - timestamp: 2023-11-17T08:05:25Z
+        type: fixed
+        data:
+          fixed-version: 2.7.15-r0
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:17:59Z

--- a/argo-cd-2.7.advisories.yaml
+++ b/argo-cd-2.7.advisories.yaml
@@ -90,6 +90,16 @@ advisories:
         data:
           fixed-version: 2.7.15-r0
 
+  - id: CVE-2023-5528
+    aliases:
+      - GHSA-hq6q-c2x6-hmch
+    events:
+      - timestamp: 2023-11-17T08:24:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability affects the Kubernetes application, not the golang k8s.io/kubernetes library. Kubernetes clusters are only affected if they are using an in-tree storage plugin for Windows nodes.
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:17:59Z


### PR DESCRIPTION
related to https://github.com/wolfi-dev/os/pull/8756