### PR TITLE
adds temporal-server advisory

### DIFF
--- a/temporal-server.advisories.yaml
+++ b/temporal-server.advisories.yaml
@@ -23,3 +23,12 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
+
+  - id: CVE-2023-47108
+    aliases:
+      - GHSA-8pgv-569h-w5rw
+    events:
+      - timestamp: 2023-11-20T20:46:14Z
+        type: pending-upstream-fix
+        data:
+          note: Pending upstream fix, this fix will require some code changes which are not visible even in the new possible release https://github.com/temporalio/temporal/blob/v1.23.0-rc0/


### PR DESCRIPTION
This CVE cannot be fixed without applying major changes to the current source code. In addition, it seems like they are not visible even in the new possible release https://github.com/temporalio/temporal/blob/v1.23.0-rc0/ 