### PR TITLE
fix: fixed versions that should be FPs

### DIFF
--- a/bind.advisories.yaml
+++ b/bind.advisories.yaml
@@ -9,378 +9,378 @@ advisories:
       - GHSA-75r9-9rpr-7px8
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2016-9147
     aliases:
       - GHSA-q76v-gxg3-wx5g
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2016-9444
     aliases:
       - GHSA-gpxq-r8wx-qxgw
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2017-3136
     aliases:
       - GHSA-835v-j5fw-qqvq
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2017-3137
     aliases:
       - GHSA-wmp5-3j44-5x2x
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2017-3138
     aliases:
       - GHSA-q858-q2j2-9jg4
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2017-3145
     aliases:
       - GHSA-3hx4-77f4-g7cp
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2018-5736
     aliases:
       - GHSA-6p6q-g6w7-h5f9
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2018-5737
     aliases:
       - GHSA-9cxr-pmg7-9w5v
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2018-5738
     aliases:
       - GHSA-cg2m-4gq8-j388
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2018-5740
     aliases:
       - GHSA-rqpc-6vjv-w22p
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2018-5743
     aliases:
       - GHSA-3cr4-c5wq-3ccv
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2018-5744
     aliases:
       - GHSA-xcc7-r4h9-f7ph
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2018-5745
     aliases:
       - GHSA-p5r3-98fj-vgcv
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-6465
     aliases:
       - GHSA-5hgv-gr6q-xvqx
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-6467
     aliases:
       - GHSA-92q8-7pjj-mpmp
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-6470
     aliases:
       - GHSA-w4w8-43xj-r4wr
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-6471
     aliases:
       - GHSA-52fp-qxmc-8q94
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-6475
     aliases:
       - GHSA-2gfp-93f7-f268
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-6476
     aliases:
       - GHSA-7rr8-wvj2-chhv
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-6477
     aliases:
       - GHSA-6q2x-892r-7qm4
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-8616
     aliases:
       - GHSA-rc96-hg8v-6p4g
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-8617
     aliases:
       - GHSA-q6g5-8p95-hqh7
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-8618
     aliases:
       - GHSA-2c3j-p34f-v2cr
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-8619
     aliases:
       - GHSA-fw3j-5rrr-7j3r
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-8620
     aliases:
       - GHSA-p5fp-cw6q-m6xc
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-8621
     aliases:
       - GHSA-7vc6-qmjj-2j83
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-8622
     aliases:
       - GHSA-fh6r-7j2f-pmw4
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-8623
     aliases:
       - GHSA-3hh5-h95j-2cw7
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-8624
     aliases:
       - GHSA-qgv6-6x66-mr9j
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-8625
     aliases:
       - GHSA-mxh3-93ph-p9r2
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2021-25214
     aliases:
       - GHSA-pqmv-mqwc-wmr3
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2021-25215
     aliases:
       - GHSA-r4mp-379r-9756
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2021-25216
     aliases:
       - GHSA-4vh7-r4m9-4w3v
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2021-25218
     aliases:
       - GHSA-cc8x-chx9-c63q
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2021-25219
     aliases:
       - GHSA-x6vq-rxvf-3ggc
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2021-25220
     aliases:
       - GHSA-v8rf-mvwx-cx29
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-0396
     aliases:
       - GHSA-wqqg-j8m9-9rcc
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-2795
     aliases:
       - GHSA-9mq2-v988-m7mr
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-2881
     aliases:
       - GHSA-gjh8-h6gp-pqgr
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-2906
     aliases:
       - GHSA-pqxc-54m5-8r8m
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-3080
     aliases:
       - GHSA-7mrh-jrcg-wc76
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-3094
     aliases:
@@ -405,18 +405,18 @@ advisories:
       - GHSA-5vfq-rv44-c5ff
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-38178
     aliases:
       - GHSA-349w-cgp3-287r
     events:
       - timestamp: 2023-01-15T00:59:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 9.18.10-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-3924
     aliases:

--- a/binutils.advisories.yaml
+++ b/binutils.advisories.yaml
@@ -9,9 +9,9 @@ advisories:
       - GHSA-mc5c-3hv5-5hjw
     events:
       - timestamp: 2022-09-16T16:42:40Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.39-r1
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-38128
     aliases:

--- a/brotli.advisories.yaml
+++ b/brotli.advisories.yaml
@@ -9,6 +9,6 @@ advisories:
       - GHSA-5v8v-66v8-mwm7
     events:
       - timestamp: 2022-09-15T02:40:18Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.0.9-r0
+          type: vulnerable-code-version-not-used

--- a/cadvisor.advisories.yaml
+++ b/cadvisor.advisories.yaml
@@ -9,18 +9,18 @@ advisories:
       - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-05-03T19:00:16Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 0.47.1-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2023-27561
     aliases:
       - GHSA-vpvm-3wq2-2wvm
     events:
       - timestamp: 2023-05-03T19:00:31Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 0.47.1-r0
+          type: vulnerable-code-version-not-used
 
   - id: GHSA-6xv5-86q9-7xr8
     events:

--- a/cups.advisories.yaml
+++ b/cups.advisories.yaml
@@ -19,9 +19,9 @@ advisories:
       - GHSA-h495-hfpg-xw55
     events:
       - timestamp: 2022-10-25T17:38:24Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.4.2-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2023-32324
     events:

--- a/dbus.advisories.yaml
+++ b/dbus.advisories.yaml
@@ -9,24 +9,24 @@ advisories:
       - GHSA-mmv5-g2hf-r8cf
     events:
       - timestamp: 2022-10-25T17:38:24Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.14.4-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-42011
     aliases:
       - GHSA-3g2p-5q22-h774
     events:
       - timestamp: 2022-10-25T17:38:24Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.14.4-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-42012
     aliases:
       - GHSA-7v94-mgqj-cj58
     events:
       - timestamp: 2022-10-25T17:38:24Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.14.4-r0
+          type: vulnerable-code-version-not-used

--- a/freetype.advisories.yaml
+++ b/freetype.advisories.yaml
@@ -9,24 +9,24 @@ advisories:
       - GHSA-22wv-f9f6-xwwm
     events:
       - timestamp: 2022-10-26T20:28:34Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.12.1-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-27405
     aliases:
       - GHSA-3p63-23m4-gmcp
     events:
       - timestamp: 2022-10-26T20:28:34Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.12.1-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-27406
     aliases:
       - GHSA-34wh-7j35-vw3w
     events:
       - timestamp: 2022-10-26T20:28:34Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.12.1-r0
+          type: vulnerable-code-version-not-used

--- a/giflib.advisories.yaml
+++ b/giflib.advisories.yaml
@@ -9,6 +9,6 @@ advisories:
       - GHSA-x77v-4m7v-7fgv
     events:
       - timestamp: 2022-11-16T11:48:05Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 5.2.1-r0
+          type: vulnerable-code-version-not-used

--- a/gnupg.advisories.yaml
+++ b/gnupg.advisories.yaml
@@ -9,27 +9,27 @@ advisories:
       - GHSA-678p-6r6j-65f9
     events:
       - timestamp: 2023-01-15T00:25:50Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.2.41-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-14855
     aliases:
       - GHSA-cpvm-f36g-55vg
     events:
       - timestamp: 2023-01-15T00:25:50Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.2.41-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-25125
     aliases:
       - GHSA-g8h3-hp92-c5qx
     events:
       - timestamp: 2023-01-15T00:25:50Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.2.41-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-3219
     aliases:
@@ -46,6 +46,6 @@ advisories:
       - GHSA-356p-pg27-x2cf
     events:
       - timestamp: 2023-01-15T00:25:50Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.2.41-r0
+          type: vulnerable-code-version-not-used

--- a/gnutls.advisories.yaml
+++ b/gnutls.advisories.yaml
@@ -9,78 +9,78 @@ advisories:
       - GHSA-w59v-wh6q-qc58
     events:
       - timestamp: 2023-01-15T00:22:41Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.7.8-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-3829
     aliases:
       - GHSA-mm54-95hq-f739
     events:
       - timestamp: 2023-01-15T00:22:41Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.7.8-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-3836
     aliases:
       - GHSA-fqw6-7w7w-627p
     events:
       - timestamp: 2023-01-15T00:22:41Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.7.8-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-11501
     aliases:
       - GHSA-j883-wjrw-g444
     events:
       - timestamp: 2023-01-15T00:22:41Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.7.8-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-13777
     aliases:
       - GHSA-cv49-m792-xmjv
     events:
       - timestamp: 2023-01-15T00:22:41Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.7.8-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2020-24659
     aliases:
       - GHSA-wx7m-j6j8-xm63
     events:
       - timestamp: 2023-01-15T00:22:41Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.7.8-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2021-20231
     aliases:
       - GHSA-mqq9-xchh-h97q
     events:
       - timestamp: 2023-01-15T00:22:41Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.7.8-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2021-20232
     aliases:
       - GHSA-p947-gfm7-f4g7
     events:
       - timestamp: 2023-01-15T00:22:41Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.7.8-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-2509
     aliases:
       - GHSA-w33j-4mrg-pgc3
     events:
       - timestamp: 2023-01-15T00:22:41Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.7.8-r0
+          type: vulnerable-code-version-not-used

--- a/go-1.19.advisories.yaml
+++ b/go-1.19.advisories.yaml
@@ -31,27 +31,27 @@ advisories:
       - GHSA-mh68-qf2j-8c5g
     events:
       - timestamp: 2022-11-01T17:39:29Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.19.4-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-41717
     aliases:
       - GHSA-xrjj-mj9h-534m
     events:
       - timestamp: 2022-12-07T08:11:39Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.19.4-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-41720
     aliases:
       - GHSA-cvf9-g74c-vv79
     events:
       - timestamp: 2022-12-07T08:11:39Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.19.4-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-41723
     aliases:

--- a/go-fips-1.20.advisories.yaml
+++ b/go-fips-1.20.advisories.yaml
@@ -35,18 +35,18 @@ advisories:
       - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-03-10T15:38:17Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.20.2-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2023-24532
     aliases:
       - GHSA-x2w5-7wp4-5qff
     events:
       - timestamp: 2023-03-10T15:43:37Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.20.2-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2023-24534
     aliases:

--- a/libidn2.advisories.yaml
+++ b/libidn2.advisories.yaml
@@ -9,15 +9,15 @@ advisories:
       - GHSA-5pjp-55fh-7frw
     events:
       - timestamp: 2023-01-15T00:15:49Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.3.4-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2019-18224
     aliases:
       - GHSA-j2c9-63g7-697x
     events:
       - timestamp: 2023-01-15T00:15:49Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.3.4-r0
+          type: vulnerable-code-version-not-used

--- a/libksba.advisories.yaml
+++ b/libksba.advisories.yaml
@@ -9,15 +9,15 @@ advisories:
       - GHSA-58wq-p76f-6qjh
     events:
       - timestamp: 2023-01-15T00:17:15Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.6.3-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-47629
     aliases:
       - GHSA-j4m3-g4pc-cph8
     events:
       - timestamp: 2023-01-15T00:17:15Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.6.3-r0
+          type: vulnerable-code-version-not-used

--- a/libtasn1.advisories.yaml
+++ b/libtasn1.advisories.yaml
@@ -9,6 +9,6 @@ advisories:
       - GHSA-6468-68pw-9chw
     events:
       - timestamp: 2023-01-11T23:36:05Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 4.19.0-r0
+          type: vulnerable-code-version-not-used

--- a/libxml2.advisories.yaml
+++ b/libxml2.advisories.yaml
@@ -9,18 +9,18 @@ advisories:
       - GHSA-94m8-rgr8-rg5g
     events:
       - timestamp: 2022-10-20T21:07:42Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.10.3-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-40304
     aliases:
       - GHSA-g848-pppp-vg6f
     events:
       - timestamp: 2022-10-20T21:07:42Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.10.3-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2023-45322
     aliases:

--- a/lua5.4.advisories.yaml
+++ b/lua5.4.advisories.yaml
@@ -9,15 +9,15 @@ advisories:
       - GHSA-f6gj-vrmg-ccf7
     events:
       - timestamp: 2023-01-12T09:51:37Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 5.4.4-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-28805
     aliases:
       - GHSA-pxhp-rhgc-5jx8
     events:
       - timestamp: 2023-01-12T09:51:37Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 5.4.4-r0
+          type: vulnerable-code-version-not-used

--- a/mariadb-10.6.advisories.yaml
+++ b/mariadb-10.6.advisories.yaml
@@ -9,6 +9,6 @@ advisories:
       - GHSA-hc8h-974x-98hr
     events:
       - timestamp: 2023-02-12T12:33:40Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 10.6.12-r1
+          type: vulnerable-code-version-not-used

--- a/ncurses.advisories.yaml
+++ b/ncurses.advisories.yaml
@@ -9,6 +9,6 @@ advisories:
       - GHSA-jh4f-5j2m-4v9c
     events:
       - timestamp: 2022-10-11T19:49:30Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 6.3-r2
+          type: vulnerable-code-version-not-used

--- a/nettle.advisories.yaml
+++ b/nettle.advisories.yaml
@@ -9,15 +9,15 @@ advisories:
       - GHSA-6xrq-2ww3-f6h5
     events:
       - timestamp: 2023-01-15T00:21:09Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.8.1-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2021-3580
     aliases:
       - GHSA-52fp-4722-wcjw
     events:
       - timestamp: 2023-01-15T00:21:09Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.8.1-r0
+          type: vulnerable-code-version-not-used

--- a/oauth2-proxy.advisories.yaml
+++ b/oauth2-proxy.advisories.yaml
@@ -9,9 +9,9 @@ advisories:
       - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-04-17T21:30:27Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 7.4.0-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2023-39325
     aliases:

--- a/pcre2.advisories.yaml
+++ b/pcre2.advisories.yaml
@@ -9,15 +9,15 @@ advisories:
       - GHSA-f3pv-9fwh-mp3x
     events:
       - timestamp: 2022-09-20T11:15:38Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 10.40-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-1587
     aliases:
       - GHSA-jmvm-hj36-w5hc
     events:
       - timestamp: 2022-09-20T11:15:38Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 10.40-r0
+          type: vulnerable-code-version-not-used

--- a/prometheus-stackdriver-exporter.advisories.yaml
+++ b/prometheus-stackdriver-exporter.advisories.yaml
@@ -9,9 +9,9 @@ advisories:
       - GHSA-vvpx-j8f3-3w6h
     events:
       - timestamp: 2023-05-02T22:52:07Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 0.13.0-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2023-45283
     aliases:

--- a/protobuf-c.advisories.yaml
+++ b/protobuf-c.advisories.yaml
@@ -9,15 +9,15 @@ advisories:
       - GHSA-c3h9-896r-86jm
     events:
       - timestamp: 2023-01-15T00:53:43Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.4.1-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-33070
     aliases:
       - GHSA-xcrq-6j7j-784j
     events:
       - timestamp: 2023-01-15T00:53:43Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.4.1-r0
+          type: vulnerable-code-version-not-used

--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -28,9 +28,9 @@ advisories:
       - GHSA-6jr7-xr67-mgxw
     events:
       - timestamp: 2023-02-07T08:34:29Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.10.9-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2023-24329
     aliases:

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -28,9 +28,9 @@ advisories:
       - GHSA-6jr7-xr67-mgxw
     events:
       - timestamp: 2022-09-12T21:06:30Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 3.11.1-r5
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2023-24329
     aliases:

--- a/samurai.advisories.yaml
+++ b/samurai.advisories.yaml
@@ -9,15 +9,15 @@ advisories:
       - GHSA-xh35-9rm8-7v5q
     events:
       - timestamp: 2022-09-19T06:57:25Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.2-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2021-30219
     aliases:
       - GHSA-mmpx-fx25-f58m
     events:
       - timestamp: 2022-09-19T06:57:25Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 1.2-r0
+          type: vulnerable-code-version-not-used

--- a/traefik.advisories.yaml
+++ b/traefik.advisories.yaml
@@ -18,9 +18,9 @@ advisories:
       - GHSA-h2ph-vhm7-g4hp
     events:
       - timestamp: 2023-01-29T16:56:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.9.6-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2022-40716
     aliases:
@@ -36,9 +36,9 @@ advisories:
       - GHSA-468w-8x39-gj5v
     events:
       - timestamp: 2023-01-29T16:56:03Z
-        type: fixed
+        type: false-positive-determination
         data:
-          fixed-version: 2.9.6-r0
+          type: vulnerable-code-version-not-used
 
   - id: CVE-2023-2253
     aliases:


### PR DESCRIPTION
It's semantically incorrect to say that the first version of a given package is the "fixed version" for a given vulnerability, since that distro package version didn't resolve a problem in the distro package. New validation in `wolfictl` catches this case.

These cases should instead be recorded as false positives, using the FP type of "vulnerable code version not used".