### PR TITLE
update busybox entries for CVE-2023-4236x

### DIFF
--- a/busybox.advisories.yaml
+++ b/busybox.advisories.yaml
@@ -31,6 +31,11 @@ advisories:
         data:
           type: inline-mitigations-exist
           note: This vulnerability is a use-after-free that requires a specific Busybox configuration flag "CONFIG_FEATURE_CLEAN_UP" set to trigger. We don't use that configuration flag, so the free logic isn't called.
+      - timestamp: 2023-12-04T23:49:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This vulnerability is a use-after-free that requires a specific Busybox configuration flag "CONFIG_FEATURE_CLEAN_UP" set to trigger. We don't use that configuration flag, so the free logic isn't called
 
   - id: CVE-2023-42364
     aliases:
@@ -41,6 +46,21 @@ advisories:
         data:
           type: inline-mitigations-exist
           note: This vulnerability is a use-after-free that requires a specific Busybox configuration flag "CONFIG_FEATURE_CLEAN_UP" set to trigger. We don't use that configuration flag, so the free logic isn't called.
+      - timestamp: 2023-12-04T23:49:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This vulnerability is a use-after-free that requires a specific Busybox configuration flag "CONFIG_FEATURE_CLEAN_UP" set to trigger. We don't use that configuration flag, so the free logic isn't called
+
+  - id: CVE-2023-42365
+    aliases:
+      - GHSA-j44g-3846-7q49
+    events:
+      - timestamp: 2023-12-04T23:48:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This vulnerability is a use-after-free that requires a specific Busybox configuration flag "CONFIG_FEATURE_CLEAN_UP" set to trigger. We don't use that configuration flag, so the free logic isn't called
 
   - id: CVE-2023-42366
     aliases:
@@ -51,3 +71,8 @@ advisories:
         data:
           type: inline-mitigations-exist
           note: This vulnerability is a use-after-free that requires a specific Busybox configuration flag "CONFIG_FEATURE_CLEAN_UP" set to trigger. We don't use that configuration flag, so the free logic isn't called.
+      - timestamp: 2023-12-04T23:50:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This vulnerability is a use-after-free that requires a specific Busybox configuration flag "CONFIG_FEATURE_CLEAN_UP" set to trigger. We don't use that configuration flag, so the free logic isn't called


### PR DESCRIPTION
This just updates our recent busybox entries to use the FP type `vulnerable-code-not-in-execution-path`.

This also adds an entry for CVE-2023-42365, which is related to the other advisories here.

Follow up to #583 