### PR TITLE
nodejs-19: Advisory for CVE-2023-30581

### DIFF
--- a/nodejs-19.advisories.yaml
+++ b/nodejs-19.advisories.yaml
@@ -4,6 +4,19 @@ package:
   name: nodejs-19
 
 advisories:
+  - id: CVE-2023-30581
+    aliases:
+      - GHSA-86v4-9wq7-fx97
+    events:
+      - timestamp: 2023-12-08T19:43:06Z
+        type: true-positive-determination
+        data:
+          note: The fix for this vulnerability is in version 20.3.1 of the upstream source code.
+      - timestamp: 2023-12-08T19:44:48Z
+        type: fix-not-planned
+        data:
+          note: This package is locked to 19.x.x and will not receive a fix.
+
   - id: CVE-2023-32003
     aliases:
       - GHSA-r874-ffh8-2fvj


### PR DESCRIPTION
This CVE was part of the June 2023 update: https://nodejs.org/en/blog/release/v20.3.1/

Security support ended on 01 Jun 2023 for NodeJS 19.