### PR TITLE
Go advisories for CVE-2023-45283

### DIFF
--- a/go-1.19.advisories.yaml
+++ b/go-1.19.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: go-1.19
@@ -206,3 +206,12 @@ advisories:
         type: fix-not-planned
         data:
           note: Go 1.19 is no longer supported upstream.
+
+  - id: CVE-2023-45283
+    aliases:
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-12-12T14:43:21Z
+        type: fix-not-planned
+        data:
+          note: This vulnerability was only backported to 1.20.x and above, and this package is locked to 1.19.x.

--- a/go-1.20.advisories.yaml
+++ b/go-1.20.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: go-1.20
@@ -137,3 +137,12 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.20.10-r0
+
+  - id: CVE-2023-45283
+    aliases:
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-12-12T14:44:11Z
+        type: fixed
+        data:
+          fixed-version: 1.20.12-r0

--- a/go-1.21.advisories.yaml
+++ b/go-1.21.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: go-1.21
@@ -57,3 +57,12 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.21.3-r0
+
+  - id: CVE-2023-45283
+    aliases:
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-12-12T14:44:31Z
+        type: fixed
+        data:
+          fixed-version: 1.21.5-r0


### PR DESCRIPTION
Related: https://groups.google.com/g/golang-announce/c/iLGK3x6yuNo (these releases contain improved fixes to this CVE)