### PR TITLE
kube-fluentd-operator: Update fixed version to the next non-withdrawn version

### DIFF
--- a/kube-fluentd-operator.advisories.yaml
+++ b/kube-fluentd-operator.advisories.yaml
@@ -30,7 +30,7 @@ advisories:
       - timestamp: 2023-08-29T16:45:48Z
         type: fixed
         data:
-          fixed-version: 1.17.6-r2
+          fixed-version: 1.17.6-r8
 
   - id: CVE-2023-39325
     aliases:


### PR DESCRIPTION
This package was withdrawn here: https://github.com/wolfi-dev/os/pull/9933