### PR TITLE
Backfill aliases, add prometheus advisories

### DIFF
--- a/byobu.advisories.yaml
+++ b/byobu.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: byobu
 
 advisories:
   - id: CVE-2019-7306
+    aliases:
+      - GHSA-2rpx-jj49-wf29
     events:
       - timestamp: 2023-11-22T16:36:03Z
         type: false-positive-determination

--- a/certificate-transparency.advisories.yaml
+++ b/certificate-transparency.advisories.yaml
@@ -1,9 +1,19 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: certificate-transparency
 
 advisories:
+  - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-12-17T17:35:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
+
   - id: CVE-2023-44487
     aliases:
       - GHSA-qppj-fm5r-hxr3

--- a/cloud-sql-proxy.advisories.yaml
+++ b/cloud-sql-proxy.advisories.yaml
@@ -1,9 +1,19 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: cloud-sql-proxy
 
 advisories:
+  - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-12-17T17:35:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/gatekeeper-3.12.advisories.yaml
+++ b/gatekeeper-3.12.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: gatekeeper-3.12
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-08-30T19:52:44Z
         type: false-positive-determination

--- a/gatekeeper-3.13.advisories.yaml
+++ b/gatekeeper-3.13.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: gatekeeper-3.13
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-08-30T19:53:46Z
         type: false-positive-determination

--- a/gatekeeper-3.14.advisories.yaml
+++ b/gatekeeper-3.14.advisories.yaml
@@ -1,9 +1,19 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: gatekeeper-3.14
 
 advisories:
+  - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-12-17T17:35:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
+
   - id: CVE-2023-44487
     aliases:
       - GHSA-m425-mq94-257g

--- a/istio-operator-1.19.advisories.yaml
+++ b/istio-operator-1.19.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: istio-operator-1.19
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-09-25T20:27:23Z
         type: false-positive-determination

--- a/istio-operator-1.20.advisories.yaml
+++ b/istio-operator-1.20.advisories.yaml
@@ -1,22 +1,15 @@
 schema-version: 2.0.2
 
 package:
-  name: istio-pilot-discovery-1.20
+  name: istio-operator-1.20
 
 advisories:
   - id: CVE-2019-3826
     aliases:
       - GHSA-3m87-5598-2v4f
     events:
-      - timestamp: 2023-12-17T17:36:05Z
+      - timestamp: 2023-12-17T17:35:54Z
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used
           note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
-
-  - id: GHSA-2c7c-3mj9-8fqh
-    events:
-      - timestamp: 2023-12-08T19:38:41Z
-        type: fixed
-        data:
-          fixed-version: 1.20.0-r2

--- a/istio-pilot-agent-1.18.advisories.yaml
+++ b/istio-pilot-agent-1.18.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: istio-pilot-agent-1.18
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-09-15T13:54:14Z
         type: false-positive-determination

--- a/istio-pilot-agent-1.19.advisories.yaml
+++ b/istio-pilot-agent-1.19.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: istio-pilot-agent-1.19
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-10-01T16:44:14Z
         type: false-positive-determination

--- a/istio-pilot-agent-1.20.advisories.yaml
+++ b/istio-pilot-agent-1.20.advisories.yaml
@@ -1,22 +1,15 @@
 schema-version: 2.0.2
 
 package:
-  name: istio-pilot-discovery-1.20
+  name: istio-pilot-agent-1.20
 
 advisories:
   - id: CVE-2019-3826
     aliases:
       - GHSA-3m87-5598-2v4f
     events:
-      - timestamp: 2023-12-17T17:36:05Z
+      - timestamp: 2023-12-17T17:35:59Z
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used
           note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
-
-  - id: GHSA-2c7c-3mj9-8fqh
-    events:
-      - timestamp: 2023-12-08T19:38:41Z
-        type: fixed
-        data:
-          fixed-version: 1.20.0-r2

--- a/istio-pilot-discovery-1.19.advisories.yaml
+++ b/istio-pilot-discovery-1.19.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: istio-pilot-discovery-1.19
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-09-15T13:54:14Z
         type: false-positive-determination

--- a/loki.advisories.yaml
+++ b/loki.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: loki
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-09-02T01:06:18Z
         type: false-positive-determination

--- a/nodejs-16.advisories.yaml
+++ b/nodejs-16.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: nodejs-16
 
 advisories:
   - id: CVE-2023-30581
+    aliases:
+      - GHSA-86v4-9wq7-fx97
     events:
       - timestamp: 2023-06-20T17:11:00Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 16.20.1-r0
 
   - id: CVE-2023-30585
+    aliases:
+      - GHSA-4r2r-cf85-vmc7
     events:
       - timestamp: 2023-06-20T17:11:00Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 16.20.1-r0
 
   - id: CVE-2023-30588
+    aliases:
+      - GHSA-g526-x7vj-cfv6
     events:
       - timestamp: 2023-06-20T17:11:00Z
         type: fixed
@@ -35,6 +41,8 @@ advisories:
           fixed-version: 16.20.1-r0
 
   - id: CVE-2023-30590
+    aliases:
+      - GHSA-v63h-9gvh-2x49
     events:
       - timestamp: 2023-06-20T17:11:00Z
         type: fixed

--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: nodejs-18
 
 advisories:
   - id: CVE-2023-30581
+    aliases:
+      - GHSA-86v4-9wq7-fx97
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed
@@ -12,6 +14,8 @@ advisories:
           fixed-version: 18.16.1-r0
 
   - id: CVE-2023-30585
+    aliases:
+      - GHSA-4r2r-cf85-vmc7
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed
@@ -19,6 +23,8 @@ advisories:
           fixed-version: 18.16.1-r0
 
   - id: CVE-2023-30588
+    aliases:
+      - GHSA-g526-x7vj-cfv6
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed
@@ -35,6 +41,8 @@ advisories:
           fixed-version: 18.16.1-r0
 
   - id: CVE-2023-30590
+    aliases:
+      - GHSA-v63h-9gvh-2x49
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed

--- a/nodejs-20.advisories.yaml
+++ b/nodejs-20.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: nodejs-20
 
 advisories:
   - id: CVE-2023-30581
+    aliases:
+      - GHSA-86v4-9wq7-fx97
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed
@@ -33,6 +35,8 @@ advisories:
           fixed-version: 20.3.1-r0
 
   - id: CVE-2023-30585
+    aliases:
+      - GHSA-4r2r-cf85-vmc7
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed
@@ -56,6 +60,8 @@ advisories:
           fixed-version: 20.3.1-r0
 
   - id: CVE-2023-30588
+    aliases:
+      - GHSA-g526-x7vj-cfv6
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed
@@ -72,6 +78,8 @@ advisories:
           fixed-version: 20.3.1-r0
 
   - id: CVE-2023-30590
+    aliases:
+      - GHSA-v63h-9gvh-2x49
     events:
       - timestamp: 2023-06-20T19:07:00Z
         type: fixed

--- a/postgresql-11.advisories.yaml
+++ b/postgresql-11.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: postgresql-11
@@ -15,6 +15,8 @@ advisories:
           note: This CVE appears to impact only Debian/Ubuntu.
 
   - id: CVE-2023-5868
+    aliases:
+      - GHSA-3f9w-7983-qcmq
     events:
       - timestamp: 2023-11-09T14:51:03Z
         type: fixed
@@ -22,6 +24,8 @@ advisories:
           fixed-version: 11.22-r0
 
   - id: CVE-2023-5869
+    aliases:
+      - GHSA-9625-p7pg-3cxg
     events:
       - timestamp: 2023-11-09T14:54:14Z
         type: fixed
@@ -29,6 +33,8 @@ advisories:
           fixed-version: 11.22-r0
 
   - id: CVE-2023-5870
+    aliases:
+      - GHSA-5gp7-j4r7-g66f
     events:
       - timestamp: 2023-11-09T14:59:29Z
         type: fixed

--- a/postgresql-12.advisories.yaml
+++ b/postgresql-12.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: postgresql-12
@@ -25,6 +25,8 @@ advisories:
           note: Sanity dictates (and the maintainers agree) that this is neither a vulnerability nor a bug. https://www.postgresql.org/about/news/cve-2020-21469-is-not-a-security-vulnerability-2701/
 
   - id: CVE-2023-5868
+    aliases:
+      - GHSA-3f9w-7983-qcmq
     events:
       - timestamp: 2023-11-09T14:52:27Z
         type: fixed
@@ -32,6 +34,8 @@ advisories:
           fixed-version: 12.17-r0
 
   - id: CVE-2023-5869
+    aliases:
+      - GHSA-9625-p7pg-3cxg
     events:
       - timestamp: 2023-11-09T14:58:31Z
         type: fixed
@@ -39,6 +43,8 @@ advisories:
           fixed-version: 12.17-r0
 
   - id: CVE-2023-5870
+    aliases:
+      - GHSA-5gp7-j4r7-g66f
     events:
       - timestamp: 2023-11-09T14:59:34Z
         type: fixed

--- a/postgresql-13.advisories.yaml
+++ b/postgresql-13.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: postgresql-13
@@ -15,6 +15,8 @@ advisories:
           note: This CVE appears to impact only Debian/Ubuntu.
 
   - id: CVE-2023-5868
+    aliases:
+      - GHSA-3f9w-7983-qcmq
     events:
       - timestamp: 2023-11-09T14:53:12Z
         type: fixed
@@ -22,6 +24,8 @@ advisories:
           fixed-version: 13.13-r0
 
   - id: CVE-2023-5869
+    aliases:
+      - GHSA-9625-p7pg-3cxg
     events:
       - timestamp: 2023-11-09T14:58:42Z
         type: fixed
@@ -29,6 +33,8 @@ advisories:
           fixed-version: 13.13-r0
 
   - id: CVE-2023-5870
+    aliases:
+      - GHSA-5gp7-j4r7-g66f
     events:
       - timestamp: 2023-11-09T14:59:40Z
         type: fixed

--- a/postgresql-14.advisories.yaml
+++ b/postgresql-14.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: postgresql-14
@@ -15,6 +15,8 @@ advisories:
           note: This CVE appears to impact only Debian/Ubuntu.
 
   - id: CVE-2023-5868
+    aliases:
+      - GHSA-3f9w-7983-qcmq
     events:
       - timestamp: 2023-11-09T14:53:24Z
         type: fixed
@@ -22,6 +24,8 @@ advisories:
           fixed-version: 14.10-r0
 
   - id: CVE-2023-5869
+    aliases:
+      - GHSA-9625-p7pg-3cxg
     events:
       - timestamp: 2023-11-09T14:58:54Z
         type: fixed
@@ -29,6 +33,8 @@ advisories:
           fixed-version: 14.10-r0
 
   - id: CVE-2023-5870
+    aliases:
+      - GHSA-5gp7-j4r7-g66f
     events:
       - timestamp: 2023-11-09T14:59:47Z
         type: fixed

--- a/postgresql-15.advisories.yaml
+++ b/postgresql-15.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: postgresql-15
@@ -24,6 +24,8 @@ advisories:
           fixed-version: 15.2-r0
 
   - id: CVE-2023-5868
+    aliases:
+      - GHSA-3f9w-7983-qcmq
     events:
       - timestamp: 2023-11-09T14:53:37Z
         type: fixed
@@ -31,6 +33,8 @@ advisories:
           fixed-version: 15.5-r0
 
   - id: CVE-2023-5869
+    aliases:
+      - GHSA-9625-p7pg-3cxg
     events:
       - timestamp: 2023-11-09T14:59:03Z
         type: fixed
@@ -38,6 +42,8 @@ advisories:
           fixed-version: 15.5-r0
 
   - id: CVE-2023-5870
+    aliases:
+      - GHSA-5gp7-j4r7-g66f
     events:
       - timestamp: 2023-11-09T14:59:53Z
         type: fixed

--- a/postgresql-16.advisories.yaml
+++ b/postgresql-16.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: postgresql-16
@@ -15,6 +15,8 @@ advisories:
           note: This CVE appears to impact only Debian/Ubuntu.
 
   - id: CVE-2023-5868
+    aliases:
+      - GHSA-3f9w-7983-qcmq
     events:
       - timestamp: 2023-11-09T14:53:52Z
         type: fixed
@@ -22,6 +24,8 @@ advisories:
           fixed-version: 16.1-r0
 
   - id: CVE-2023-5869
+    aliases:
+      - GHSA-9625-p7pg-3cxg
     events:
       - timestamp: 2023-11-09T14:59:14Z
         type: fixed
@@ -29,6 +33,8 @@ advisories:
           fixed-version: 16.1-r0
 
   - id: CVE-2023-5870
+    aliases:
+      - GHSA-5gp7-j4r7-g66f
     events:
       - timestamp: 2023-11-09T15:00:02Z
         type: fixed

--- a/prometheus-operator.advisories.yaml
+++ b/prometheus-operator.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: prometheus-operator
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-08-11T21:13:07Z
         type: false-positive-determination

--- a/telegraf-1.26.advisories.yaml
+++ b/telegraf-1.26.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: telegraf-1.26
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-08-25T22:09:21Z
         type: false-positive-determination

--- a/telegraf-1.27.advisories.yaml
+++ b/telegraf-1.27.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: telegraf-1.27
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-08-25T22:09:52Z
         type: false-positive-determination

--- a/telegraf-1.29.advisories.yaml
+++ b/telegraf-1.29.advisories.yaml
@@ -1,22 +1,15 @@
 schema-version: 2.0.2
 
 package:
-  name: istio-pilot-discovery-1.20
+  name: telegraf-1.29
 
 advisories:
   - id: CVE-2019-3826
     aliases:
       - GHSA-3m87-5598-2v4f
     events:
-      - timestamp: 2023-12-17T17:36:05Z
+      - timestamp: 2023-12-17T17:36:20Z
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used
           note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
-
-  - id: GHSA-2c7c-3mj9-8fqh
-    events:
-      - timestamp: 2023-12-08T19:38:41Z
-        type: fixed
-        data:
-          fixed-version: 1.20.0-r2

--- a/thanos-0.31.advisories.yaml
+++ b/thanos-0.31.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: thanos-0.31
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-08-30T21:45:02Z
         type: false-positive-determination

--- a/thanos-0.32.advisories.yaml
+++ b/thanos-0.32.advisories.yaml
@@ -1,10 +1,12 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: thanos-0.32
 
 advisories:
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-08-30T21:45:02Z
         type: false-positive-determination

--- a/traefik.advisories.yaml
+++ b/traefik.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: traefik
@@ -79,6 +79,8 @@ advisories:
           note: Only affects Windows
 
   - id: CVE-2023-47106
+    aliases:
+      - GHSA-fvhj-4qfh-q2hm
     events:
       - timestamp: 2023-12-04T21:24:39Z
         type: fixed
@@ -86,6 +88,8 @@ advisories:
           fixed-version: 2.10.6-r0
 
   - id: CVE-2023-47124
+    aliases:
+      - GHSA-8g85-whqh-cr2f
     events:
       - timestamp: 2023-12-04T21:24:09Z
         type: fixed
@@ -93,6 +97,8 @@ advisories:
           fixed-version: 2.10.6-r0
 
   - id: CVE-2023-47633
+    aliases:
+      - GHSA-6fwg-jrfw-ff7p
     events:
       - timestamp: 2023-12-04T21:24:28Z
         type: fixed

--- a/trillian.advisories.yaml
+++ b/trillian.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: trillian
@@ -56,6 +56,8 @@ advisories:
           note: CVE refers to the instant messaging platform called 'Trillian'.
 
   - id: CVE-2019-3826
+    aliases:
+      - GHSA-3m87-5598-2v4f
     events:
       - timestamp: 2023-10-01T16:46:09Z
         type: false-positive-determination


### PR DESCRIPTION
- Backfill missing aliases 
- Add false positive advisories for CVE-2019-3826. We're still working to update the underlying data.
