### PR TITLE
ffmpeg: Advisory for CVE-2010-3429

### DIFF
--- a/ffmpeg.advisories.yaml
+++ b/ffmpeg.advisories.yaml
@@ -1,9 +1,19 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: ffmpeg
 
 advisories:
+  - id: CVE-2010-3429
+    aliases:
+      - GHSA-v73j-5247-67hg
+    events:
+      - timestamp: 2023-12-28T19:09:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This vulnerability was fixed in versions > 0.6.0. The first version in Wolfi was 6.0.0.
+
   - id: CVE-2023-46407
     aliases:
       - GHSA-9j42-4j78-g4mh


### PR DESCRIPTION
This vulnerability was fixed back in 2010 - when ffmpeg was still using SVN, so it's even too old to prove a git commit is an ancestor 😆 