### PR TITLE
gitness :: fix: GHSA-mw99-9chc-xw7r

### DIFF
--- a/gitness.advisories.yaml
+++ b/gitness.advisories.yaml
@@ -103,6 +103,15 @@ advisories:
         data:
           fixed-version: 3.0.0_beta2-r2
 
+  - id: CVE-2023-49568
+    aliases:
+      - GHSA-mw99-9chc-xw7r
+    events:
+      - timestamp: 2024-01-02T09:27:26Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability requires upstream changes in one of the dependencies 'code.gitea.io' to support a latest version of 'github.com/go-git/go-git/v5' that fixes the vulnerability.
+
   - id: GHSA-7ww5-4wqc-m92c
     events:
       - timestamp: 2023-12-22T10:05:06Z


### PR DESCRIPTION
This vulnerability needs upstream changes in one of the dependencies 'code.gitea.io' to support a latest version of 'github.com/go-git/go-git/v5' due to the following error:

```
 .cache/go/pkg/mod/code.gitea.io/gitea@v1.21.3/modules/git/repo_commitgraph_gogit.go:28:44: cannot use index (variable of type "github.com/go-git/go-git/v5/plumbing/format/commitgraph".Index) as v2.Index value in argument to cgobject.NewGraphCommitNodeIndex: "github.com/go-git/go-git/v5/plumbing/format/commitgraph".Index does not implement v2.Index (missing method Close)
 ```