### PR TITLE
Clean up some excess permissions.

### DIFF
--- a/.github/workflows/bigquery-ingestion.yaml
+++ b/.github/workflows/bigquery-ingestion.yaml
@@ -14,7 +14,6 @@ jobs:
 
     permissions:
       id-token: write
-      packages: write
       contents: read
 
     steps:

--- a/.github/workflows/build-and-publish-secdb.yaml
+++ b/.github/workflows/build-and-publish-secdb.yaml
@@ -14,7 +14,6 @@ jobs:
 
     permissions:
       id-token: write
-      packages: write
       contents: read
 
     steps:

--- a/.github/workflows/build-and-publish-yaml.yaml
+++ b/.github/workflows/build-and-publish-yaml.yaml
@@ -14,7 +14,6 @@ jobs:
 
     permissions:
       id-token: write
-      packages: write
       contents: read
 
     steps:

--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -11,10 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
-      actions: write
+      contents: read # needed to checkout, but then we rely on the PAT.
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
I believe the digestabot one is leftover from before we used the PAT, and I don't believe we actually need `packages: write` for the other workflows, but I'm confirming that.