### PR TITLE
imagemagick: fixed CVE-2023-5341

### DIFF
--- a/imagemagick.advisories.yaml
+++ b/imagemagick.advisories.yaml
@@ -710,3 +710,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-01-18T16:54:39Z
+        type: fixed
+        data:
+          fixed-version: 7.1.1.25-r0


### PR DESCRIPTION
patch released upstream https://github.com/ImageMagick/ImageMagick/commit/aa673b2e4defc7cad5bec16c4fc8324f71e531f1