### PR TITLE
Adding CVEs for imagemagick-static

### DIFF
--- a/imagemagick.advisories.yaml
+++ b/imagemagick.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: imagemagick
@@ -693,3 +693,20 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: Vulnerability was resolved upstream prior to Wolfi packaging.
+
+  - id: CVE-2023-5341
+    aliases:
+      - GHSA-gp6r-24h3-qcjv
+    events:
+      - timestamp: 2024-01-07T18:50:04Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: imagemagick-static
+            componentID: 67e4f796fc6b7f18
+            componentName: imagemagick-static
+            componentVersion: 7.1.1.25-r0
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype


### PR DESCRIPTION
Adding Advisory CVE-2023-5341 for imagemagick-static 