### PR TITLE
Adding CVEs for falco

### DIFF
--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -67,3 +67,18 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/falcoctl
             scanner: grype
+
+  - id: GHSA-m425-mq94-257g
+    events:
+      - timestamp: 2024-01-08T00:26:29Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: c4fcd5ef2f06c5d9
+            componentName: google.golang.org/grpc
+            componentVersion: v1.57.0
+            componentType: go-module
+            componentLocation: /usr/bin/falcoctl
+            scanner: grype

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -378,6 +378,23 @@ advisories:
             componentLocation: /usr/bin/falcoctl
             scanner: grype
 
+  - id: CVE-2023-39326
+    aliases:
+      - GHSA-9f76-wg39-x86h
+    events:
+      - timestamp: 2024-01-08T00:27:08Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 87ec632f41320113
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libk8saudit.so
+            scanner: grype
+
   - id: CVE-2023-44487
     aliases:
       - GHSA-qppj-fm5r-hxr3

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -106,6 +106,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libjson.so
             scanner: grype
 
+  - id: CVE-2023-24536
+    aliases:
+      - GHSA-9f7g-gqwh-jpf5
+    events:
+      - timestamp: 2024-01-08T00:26:37Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -157,6 +157,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libcloudtrail.so
             scanner: grype
 
+  - id: CVE-2023-24539
+    aliases:
+      - GHSA-3q6h-q44p-xw88
+    events:
+      - timestamp: 2024-01-08T00:26:42Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 87ec632f41320113
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libk8saudit.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: falco
 
 advisories:
+  - id: CVE-2022-41722
+    aliases:
+      - GHSA-fp44-cj2j-3jhx
+    events:
+      - timestamp: 2024-01-08T00:26:31Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 81a876bd99f6718c
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libcloudtrail.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -38,6 +38,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libjson.so
             scanner: grype
 
+  - id: CVE-2022-41724
+    aliases:
+      - GHSA-89mw-w342-mqrr
+    events:
+      - timestamp: 2024-01-08T00:26:33Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -293,6 +293,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libjson.so
             scanner: grype
 
+  - id: CVE-2023-29409
+    aliases:
+      - GHSA-xc82-5m89-g4jv
+    events:
+      - timestamp: 2024-01-08T00:26:58Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 87ec632f41320113
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libk8saudit.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -1,0 +1,20 @@
+schema-version: 2.0.2
+
+package:
+  name: falco
+
+advisories:
+  - id: GHSA-2c7c-3mj9-8fqh
+    events:
+      - timestamp: 2024-01-08T00:26:27Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: bd9e978696d3eb85
+            componentName: github.com/go-jose/go-jose/v3
+            componentVersion: v3.0.0
+            componentType: go-module
+            componentLocation: /usr/bin/falcoctl
+            scanner: grype

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -72,6 +72,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libcloudtrail.so
             scanner: grype
 
+  - id: CVE-2023-24532
+    aliases:
+      - GHSA-x2w5-7wp4-5qff
+    events:
+      - timestamp: 2024-01-08T00:26:35Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 87ec632f41320113
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libk8saudit.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -21,6 +21,23 @@ advisories:
             componentLocation: /usr/bin/falcoctl
             scanner: grype
 
+  - id: CVE-2023-48795
+    aliases:
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2024-01-08T00:26:28Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 6abf5c943280da20
+            componentName: golang.org/x/crypto
+            componentVersion: v0.12.0
+            componentType: go-module
+            componentLocation: /usr/bin/falcoctl
+            scanner: grype
+
   - id: GHSA-2c7c-3mj9-8fqh
     events:
       - timestamp: 2024-01-08T00:26:27Z

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -123,6 +123,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libjson.so
             scanner: grype
 
+  - id: CVE-2023-24537
+    aliases:
+      - GHSA-fp86-2355-v99r
+    events:
+      - timestamp: 2024-01-08T00:26:39Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 81a876bd99f6718c
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libcloudtrail.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -191,6 +191,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libcloudtrail.so
             scanner: grype
 
+  - id: CVE-2023-29400
+    aliases:
+      - GHSA-c9hr-fvm9-7c49
+    events:
+      - timestamp: 2024-01-08T00:26:45Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -55,6 +55,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libjson.so
             scanner: grype
 
+  - id: CVE-2022-41725
+    aliases:
+      - GHSA-w4h2-22wh-m6jx
+    events:
+      - timestamp: 2024-01-08T00:26:34Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 81a876bd99f6718c
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libcloudtrail.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -174,6 +174,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libk8saudit.so
             scanner: grype
 
+  - id: CVE-2023-24540
+    aliases:
+      - GHSA-7qhm-5mxq-x7vp
+    events:
+      - timestamp: 2024-01-08T00:26:43Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 81a876bd99f6718c
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libcloudtrail.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -140,6 +140,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libcloudtrail.so
             scanner: grype
 
+  - id: CVE-2023-24538
+    aliases:
+      - GHSA-v4m2-x4rp-hv22
+    events:
+      - timestamp: 2024-01-08T00:26:40Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 81a876bd99f6718c
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libcloudtrail.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -310,6 +310,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libk8saudit.so
             scanner: grype
 
+  - id: CVE-2023-39318
+    aliases:
+      - GHSA-vq7j-gx56-rxjh
+    events:
+      - timestamp: 2024-01-08T00:27:00Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 87ec632f41320113
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libk8saudit.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -52,3 +52,18 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/falcoctl
             scanner: grype
+
+  - id: GHSA-jq35-85cj-fj4p
+    events:
+      - timestamp: 2024-01-08T00:26:28Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 217b6447efbbab3d
+            componentName: github.com/docker/docker
+            componentVersion: v24.0.5+incompatible
+            componentType: go-module
+            componentLocation: /usr/bin/falcoctl
+            scanner: grype

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -242,6 +242,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libjson.so
             scanner: grype
 
+  - id: CVE-2023-29404
+    aliases:
+      - GHSA-888h-rm2r-vrc7
+    events:
+      - timestamp: 2024-01-08T00:26:51Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 87ec632f41320113
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libk8saudit.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -412,6 +412,23 @@ advisories:
             componentLocation: /usr/bin/falcoctl
             scanner: grype
 
+  - id: CVE-2023-45285
+    aliases:
+      - GHSA-5f94-vhjq-rpg8
+    events:
+      - timestamp: 2024-01-08T00:27:11Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-46737
     aliases:
       - GHSA-vfp6-jrw2-99g9

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -38,6 +38,23 @@ advisories:
             componentLocation: /usr/bin/falcoctl
             scanner: grype
 
+  - id: CVE-2023-46737
+    aliases:
+      - GHSA-vfp6-jrw2-99g9
+    events:
+      - timestamp: 2024-01-08T00:26:30Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 6683a70c005d7a6d
+            componentName: github.com/sigstore/cosign/v2
+            componentVersion: v2.1.1
+            componentType: go-module
+            componentLocation: /usr/bin/falcoctl
+            scanner: grype
+
   - id: CVE-2023-48795
     aliases:
       - GHSA-45x7-px36-x8w8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -259,6 +259,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libk8saudit.so
             scanner: grype
 
+  - id: CVE-2023-29405
+    aliases:
+      - GHSA-68g3-2p3g-w9pq
+    events:
+      - timestamp: 2024-01-08T00:26:53Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -429,6 +429,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libjson.so
             scanner: grype
 
+  - id: CVE-2023-45287
+    aliases:
+      - GHSA-33qr-2xwr-95pw
+    events:
+      - timestamp: 2024-01-08T00:27:14Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-46737
     aliases:
       - GHSA-vfp6-jrw2-99g9

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -208,6 +208,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libjson.so
             scanner: grype
 
+  - id: CVE-2023-29402
+    aliases:
+      - GHSA-f2cj-5636-4j38
+    events:
+      - timestamp: 2024-01-08T00:26:47Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -276,6 +276,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libjson.so
             scanner: grype
 
+  - id: CVE-2023-29406
+    aliases:
+      - GHSA-f8f7-69v5-w4vx
+    events:
+      - timestamp: 2024-01-08T00:26:55Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -225,6 +225,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libjson.so
             scanner: grype
 
+  - id: CVE-2023-29403
+    aliases:
+      - GHSA-rxx3-4978-3cc9
+    events:
+      - timestamp: 2024-01-08T00:26:49Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -327,6 +327,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libk8saudit.so
             scanner: grype
 
+  - id: CVE-2023-39319
+    aliases:
+      - GHSA-vv9m-32rr-3g55
+    events:
+      - timestamp: 2024-01-08T00:27:03Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 87ec632f41320113
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libk8saudit.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -21,6 +21,23 @@ advisories:
             componentLocation: /usr/bin/falcoctl
             scanner: grype
 
+  - id: CVE-2023-44487
+    aliases:
+      - GHSA-qppj-fm5r-hxr3
+    events:
+      - timestamp: 2024-01-08T00:26:29Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 03b9d2575ca3c672
+            componentName: golang.org/x/net
+            componentVersion: v0.14.0
+            componentType: go-module
+            componentLocation: /usr/bin/falcoctl
+            scanner: grype
+
   - id: CVE-2023-48795
     aliases:
       - GHSA-45x7-px36-x8w8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -344,6 +344,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libk8saudit.so
             scanner: grype
 
+  - id: CVE-2023-39323
+    aliases:
+      - GHSA-679v-hh23-h5jh
+    events:
+      - timestamp: 2024-01-08T00:27:05Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 87ec632f41320113
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libk8saudit.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -21,6 +21,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libcloudtrail.so
             scanner: grype
 
+  - id: CVE-2022-41723
+    aliases:
+      - GHSA-vvpx-j8f3-3w6h
+    events:
+      - timestamp: 2024-01-08T00:26:32Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -89,6 +89,23 @@ advisories:
             componentLocation: /usr/share/falco/plugins/libk8saudit.so
             scanner: grype
 
+  - id: CVE-2023-24534
+    aliases:
+      - GHSA-8v5j-pwr7-w5f8
+    events:
+      - timestamp: 2024-01-08T00:26:36Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 41a6ded5ebfc54bf
+            componentName: stdlib
+            componentVersion: go1.18.10
+            componentType: go-module
+            componentLocation: /usr/share/falco/plugins/libjson.so
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8

--- a/falco.advisories.yaml
+++ b/falco.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: falco
 
 advisories:
+  - id: CVE-2023-39325
+    aliases:
+      - GHSA-4374-p667-p6c8
+    events:
+      - timestamp: 2024-01-08T00:26:28Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: falco
+            componentID: 03b9d2575ca3c672
+            componentName: golang.org/x/net
+            componentVersion: v0.14.0
+            componentType: go-module
+            componentLocation: /usr/bin/falcoctl
+            scanner: grype
+
   - id: GHSA-2c7c-3mj9-8fqh
     events:
       - timestamp: 2024-01-08T00:26:27Z


### PR DESCRIPTION
Adding Advisory GHSA-2c7c-3mj9-8fqh for falco 
Adding Advisory GHSA-4374-p667-p6c8 for falco 
Adding Advisory GHSA-45x7-px36-x8w8 for falco 
Adding Advisory GHSA-jq35-85cj-fj4p for falco 
Adding Advisory GHSA-m425-mq94-257g for falco 
Adding Advisory GHSA-qppj-fm5r-hxr3 for falco 
Adding Advisory GHSA-vfp6-jrw2-99g9 for falco 
Adding Advisory CVE-2022-41722 for falco 
Adding Advisory CVE-2022-41723 for falco 
Adding Advisory CVE-2022-41724 for falco 
Adding Advisory CVE-2022-41725 for falco 
Adding Advisory CVE-2023-24532 for falco 
Adding Advisory CVE-2023-24534 for falco 
Adding Advisory CVE-2023-24536 for falco 
Adding Advisory CVE-2023-24537 for falco 
Adding Advisory CVE-2023-24538 for falco 
Adding Advisory CVE-2023-24539 for falco 
Adding Advisory CVE-2023-24540 for falco 
Adding Advisory CVE-2023-29400 for falco 
Adding Advisory CVE-2023-29402 for falco 
Adding Advisory CVE-2023-29403 for falco 
Adding Advisory CVE-2023-29404 for falco 
Adding Advisory CVE-2023-29405 for falco 
Adding Advisory CVE-2023-29406 for falco 
Adding Advisory CVE-2023-29409 for falco 
Adding Advisory CVE-2023-39318 for falco 
Adding Advisory CVE-2023-39319 for falco 
Adding Advisory CVE-2023-39323 for falco 
Adding Advisory CVE-2023-39326 for falco 
Adding Advisory CVE-2023-45285 for falco 
Adding Advisory CVE-2023-45287 for falco 