### PR TITLE
gitness ::: fix: GHSA-9w9f-6mg8-jp7w

### DIFF
--- a/gitness.advisories.yaml
+++ b/gitness.advisories.yaml
@@ -49,6 +49,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gitness
             scanner: grype
+      - timestamp: 2024-01-08T22:51:58Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability requires upstream changes to stop using ''github.com/blevesearch/bleve/v2'' which contains the vulnerable code. '
 
   - id: CVE-2023-3515
     aliases:


### PR DESCRIPTION
gitness beta5 is affected by the following CVE which doesn't have any available fixed version on the affected dependency.