### PR TITLE
ci: enable debug logging for validation

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -41,6 +41,7 @@ jobs:
         echo "fork point will be $fork_point"
 
         wolfictl adv validate \
+          -vv \
           --skip-alias \
           --no-distro-detection \
           --advisories-repo-dir . \


### PR DESCRIPTION
To help identify issue w/ inconsistent fixed-version validation.