### PR TITLE
fix(ci): use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,7 +1,7 @@
 name: Validate
 
 on:
-  pull_request_target:
+  pull_request:
     branches: ['main']
   push:
     branches:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -34,8 +34,6 @@ jobs:
     - name: Validate advisory data
       id: validate
       working-directory: ./wolfi-advisories
-      env:
-        GITHUB_TOKEN: ${{ secrets.WOLFI_BOT_PAT_ADVISORIES }}
       run: |
         fork_point=$(git merge-base --fork-point refs/remotes/origin/${{ github.base_ref }} HEAD || git rev-parse HEAD)
         echo "fork point will be $fork_point"


### PR DESCRIPTION
This appears to be connected to the faulty validation in CI, because of the git references used in the pipeline when `pull_request_target` is used, which seems to result in CI validating the `main` branch.

For more information, see: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

cc: @jonjohnsonjr @cpanato 