### PR TITLE
Adding CVEs for kube-apiserver-1.29

### DIFF
--- a/kubernetes-1.29.advisories.yaml
+++ b/kubernetes-1.29.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: kubernetes-1.29
 
 advisories:
+  - id: CVE-2023-47108
+    aliases:
+      - GHSA-8pgv-569h-w5rw
+    events:
+      - timestamp: 2024-01-11T07:06:15Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kube-apiserver-1.29
+            componentID: ecb9afe52b707738
+            componentName: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
+            componentVersion: v0.42.0
+            componentType: go-module
+            componentLocation: /usr/bin/kube-apiserver-1.29
+            scanner: grype
+
   - id: CVE-2023-48795
     aliases:
       - GHSA-45x7-px36-x8w8


### PR DESCRIPTION
Adding Advisory GHSA-8pgv-569h-w5rw for kube-apiserver-1.29
