### PR TITLE
Adding CVEs for kubernetes-1.29

### DIFF
--- a/kubernetes-1.29.advisories.yaml
+++ b/kubernetes-1.29.advisories.yaml
@@ -89,6 +89,23 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
+  - id: CVE-2021-25740
+    aliases:
+      - GHSA-vw47-mr44-3jf9
+    events:
+      - timestamp: 2024-01-12T10:23:24Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.29
+            componentID: 399d8bd741b2abc6
+            componentName: kubernetes-1.29
+            componentVersion: 1.29.0-r0
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
   - id: CVE-2023-47108
     aliases:
       - GHSA-8pgv-569h-w5rw

--- a/kubernetes-1.29.advisories.yaml
+++ b/kubernetes-1.29.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: kubernetes-1.29
 
 advisories:
+  - id: CVE-2015-7561
+    aliases:
+      - GHSA-2h9c-34v6-3qmr
+    events:
+      - timestamp: 2024-01-12T10:17:20Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.29
+            componentID: 399d8bd741b2abc6
+            componentName: kubernetes-1.29
+            componentVersion: 1.29.0-r0
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
   - id: CVE-2023-47108
     aliases:
       - GHSA-8pgv-569h-w5rw

--- a/kubernetes-1.29.advisories.yaml
+++ b/kubernetes-1.29.advisories.yaml
@@ -106,6 +106,23 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
+  - id: CVE-2023-45142
+    aliases:
+      - GHSA-rcjv-mgp8-qvmr
+    events:
+      - timestamp: 2024-01-11T07:06:32Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.29
+            componentID: 90328936dfd806a8
+            componentName: go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful
+            componentVersion: v0.42.0
+            componentType: go-module
+            componentLocation: /usr/bin/kubelet
+            scanner: grype
+
   - id: CVE-2023-47108
     aliases:
       - GHSA-8pgv-569h-w5rw

--- a/kubernetes-1.29.advisories.yaml
+++ b/kubernetes-1.29.advisories.yaml
@@ -21,6 +21,23 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
+  - id: CVE-2016-1905
+    aliases:
+      - GHSA-xx8c-m748-xr4j
+    events:
+      - timestamp: 2024-01-12T10:18:42Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.29
+            componentID: 399d8bd741b2abc6
+            componentName: kubernetes-1.29
+            componentVersion: 1.29.0-r0
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
   - id: CVE-2023-47108
     aliases:
       - GHSA-8pgv-569h-w5rw

--- a/kubernetes-1.29.advisories.yaml
+++ b/kubernetes-1.29.advisories.yaml
@@ -72,6 +72,23 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
+  - id: CVE-2020-8554
+    aliases:
+      - GHSA-j9wf-vvm6-4r9w
+    events:
+      - timestamp: 2024-01-12T10:22:00Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.29
+            componentID: 399d8bd741b2abc6
+            componentName: kubernetes-1.29
+            componentVersion: 1.29.0-r0
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
   - id: CVE-2023-47108
     aliases:
       - GHSA-8pgv-569h-w5rw

--- a/kubernetes-1.29.advisories.yaml
+++ b/kubernetes-1.29.advisories.yaml
@@ -55,6 +55,23 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
+  - id: CVE-2016-7075
+    aliases:
+      - GHSA-7w66-j2r2-vm3p
+    events:
+      - timestamp: 2024-01-12T10:21:01Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.29
+            componentID: 399d8bd741b2abc6
+            componentName: kubernetes-1.29
+            componentVersion: 1.29.0-r0
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
   - id: CVE-2023-47108
     aliases:
       - GHSA-8pgv-569h-w5rw

--- a/kubernetes-1.29.advisories.yaml
+++ b/kubernetes-1.29.advisories.yaml
@@ -38,6 +38,23 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
+  - id: CVE-2016-1906
+    aliases:
+      - GHSA-m3fm-h5jp-q79p
+    events:
+      - timestamp: 2024-01-12T10:19:38Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.29
+            componentID: 399d8bd741b2abc6
+            componentName: kubernetes-1.29
+            componentVersion: 1.29.0-r0
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
   - id: CVE-2023-47108
     aliases:
       - GHSA-8pgv-569h-w5rw


### PR DESCRIPTION
Adding Advisory CVE-2015-7561 for kubernetes-1.29 
Adding Advisory CVE-2016-1905 for kubernetes-1.29 
Adding Advisory CVE-2016-1906 for kubernetes-1.29 
Adding Advisory CVE-2016-7075 for kubernetes-1.29 
Adding Advisory CVE-2020-8554 for kubernetes-1.29 
Adding Advisory CVE-2021-25740 for kubernetes-1.29 
Adding Advisory GHSA-rcjv-mgp8-qvmr for kubernetes-1.29 