### PR TITLE
Adding CVEs for kube-apiserver-1.27

### DIFF
--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -64,6 +64,23 @@ advisories:
           type: vulnerable-code-version-not-used
           note: Fixed in Kubernetes 1.21
 
+  - id: CVE-2023-45142
+    aliases:
+      - GHSA-rcjv-mgp8-qvmr
+    events:
+      - timestamp: 2024-01-11T07:09:52Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kube-apiserver-1.27
+            componentID: 649a8394b2e67a25
+            componentName: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+            componentVersion: v0.35.1
+            componentType: go-module
+            componentLocation: /usr/bin/kube-apiserver-1.27
+            scanner: grype
+
   - id: CVE-2023-45283
     aliases:
       - GHSA-vvjp-q62m-2vph

--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: 2.0.1
+schema-version: 2.0.2
 
 package:
   name: kubernetes-1.27
@@ -83,3 +83,20 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
+
+  - id: CVE-2023-48795
+    aliases:
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2024-01-11T07:09:50Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kube-apiserver-1.27
+            componentID: 3b55c02a923283b5
+            componentName: golang.org/x/crypto
+            componentVersion: v0.14.0
+            componentType: go-module
+            componentLocation: /usr/bin/kube-apiserver-1.27
+            scanner: grype

--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -84,6 +84,23 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
 
+  - id: CVE-2023-47108
+    aliases:
+      - GHSA-8pgv-569h-w5rw
+    events:
+      - timestamp: 2024-01-11T07:09:51Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kube-apiserver-1.27
+            componentID: 0fffc3f966a1268a
+            componentName: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
+            componentVersion: v0.35.0
+            componentType: go-module
+            componentLocation: /usr/bin/kube-apiserver-1.27
+            scanner: grype
+
   - id: CVE-2023-48795
     aliases:
       - GHSA-45x7-px36-x8w8


### PR DESCRIPTION
Adding Advisory GHSA-45x7-px36-x8w8 for kube-apiserver-1.27 
Adding Advisory GHSA-8pgv-569h-w5rw for kube-apiserver-1.27 
Adding Advisory GHSA-rcjv-mgp8-qvmr for kube-apiserver-1.27 