### PR TITLE
Adding CVEs for openjdk-8-jre

### DIFF
--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -89,6 +89,23 @@ advisories:
             componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
             scanner: grype
 
+  - id: CVE-2023-21967
+    aliases:
+      - GHSA-wg7x-fvjp-r3fx
+    events:
+      - timestamp: 2024-01-11T07:10:56Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype
+
   - id: CVE-2023-21968
     aliases:
       - GHSA-r6j2-4r52-mpg7

--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -21,6 +21,23 @@ advisories:
             componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
             scanner: grype
 
+  - id: CVE-2023-21937
+    aliases:
+      - GHSA-vr26-5f5w-r829
+    events:
+      - timestamp: 2024-01-11T07:10:54Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype
+
   - id: CVE-2023-21968
     aliases:
       - GHSA-r6j2-4r52-mpg7

--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -1,9 +1,26 @@
-schema-version: "2"
+schema-version: 2.0.2
 
 package:
   name: openjdk-8
 
 advisories:
+  - id: CVE-2023-21930
+    aliases:
+      - GHSA-4j35-7cr4-3mc8
+    events:
+      - timestamp: 2024-01-11T07:10:53Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype
+
   - id: CVE-2023-21968
     aliases:
       - GHSA-r6j2-4r52-mpg7

--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -38,6 +38,23 @@ advisories:
             componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
             scanner: grype
 
+  - id: CVE-2023-21938
+    aliases:
+      - GHSA-9pqg-44mx-r5gr
+    events:
+      - timestamp: 2024-01-11T07:10:54Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype
+
   - id: CVE-2023-21968
     aliases:
       - GHSA-r6j2-4r52-mpg7

--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -55,6 +55,23 @@ advisories:
             componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
             scanner: grype
 
+  - id: CVE-2023-21939
+    aliases:
+      - GHSA-xfrf-5cgw-f964
+    events:
+      - timestamp: 2024-01-11T07:10:54Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype
+
   - id: CVE-2023-21968
     aliases:
       - GHSA-r6j2-4r52-mpg7

--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -72,6 +72,23 @@ advisories:
             componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
             scanner: grype
 
+  - id: CVE-2023-21954
+    aliases:
+      - GHSA-8x3h-4f64-v6v6
+    events:
+      - timestamp: 2024-01-11T07:10:55Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype
+
   - id: CVE-2023-21968
     aliases:
       - GHSA-r6j2-4r52-mpg7


### PR DESCRIPTION
Adding Advisory CVE-2023-21930 for openjdk-8-jre 
Adding Advisory CVE-2023-21937 for openjdk-8-jre 
Adding Advisory CVE-2023-21938 for openjdk-8-jre 
Adding Advisory CVE-2023-21939 for openjdk-8-jre 
Adding Advisory CVE-2023-21954 for openjdk-8-jre 
Adding Advisory CVE-2023-21967 for openjdk-8-jre 