### PR TITLE
Adding CVEs for kubernetes-1.26

### DIFF
--- a/kubernetes-1.26.advisories.yaml
+++ b/kubernetes-1.26.advisories.yaml
@@ -64,6 +64,23 @@ advisories:
           type: vulnerable-code-version-not-used
           note: Fixed in Kubernetes 1.21
 
+  - id: CVE-2021-25740
+    aliases:
+      - GHSA-vw47-mr44-3jf9
+    events:
+      - timestamp: 2024-01-12T07:10:36Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.26
+            componentID: 505cefcbaa2a8bf3
+            componentName: kubernetes-1.26
+            componentVersion: 1.26.12-r0
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
   - id: CVE-2023-45142
     aliases:
       - GHSA-rcjv-mgp8-qvmr


### PR DESCRIPTION
Adding Advisory CVE-2021-25740 for kubernetes-1.26 