### PR TITLE
Adding CVEs for argo-cd-2.9

### DIFF
--- a/argo-cd-2.9.advisories.yaml
+++ b/argo-cd-2.9.advisories.yaml
@@ -66,3 +66,18 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.9.2-r1
+
+  - id: GHSA-9763-4f94-gfch
+    events:
+      - timestamp: 2024-01-12T07:23:12Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: argo-cd-2.9
+            componentID: e7a3d85fdb2480cf
+            componentName: github.com/cloudflare/circl
+            componentVersion: v1.3.3
+            componentType: go-module
+            componentLocation: /usr/bin/argocd
+            scanner: grype


### PR DESCRIPTION
Adding Advisory GHSA-9763-4f94-gfch for argo-cd-2.9 