### PR TITLE
Adding CVEs for kubernetes-1.27

### DIFF
--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -101,6 +101,23 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
 
+  - id: CVE-2023-47108
+    aliases:
+      - GHSA-8pgv-569h-w5rw
+    events:
+      - timestamp: 2024-01-12T07:25:24Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.27
+            componentID: 84e8bc5fbda868ae
+            componentName: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
+            componentVersion: v0.35.0
+            componentType: go-module
+            componentLocation: /usr/bin/kube-apiserver
+            scanner: grype
+
   - id: CVE-2023-48795
     aliases:
       - GHSA-45x7-px36-x8w8

--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -64,6 +64,23 @@ advisories:
           type: vulnerable-code-version-not-used
           note: Fixed in Kubernetes 1.21
 
+  - id: CVE-2021-25740
+    aliases:
+      - GHSA-vw47-mr44-3jf9
+    events:
+      - timestamp: 2024-01-12T07:25:23Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.27
+            componentID: 6deefa15ecd700f3
+            componentName: kubernetes-1.27
+            componentVersion: 1.27.9-r0
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
   - id: CVE-2023-45283
     aliases:
       - GHSA-vvjp-q62m-2vph

--- a/kubernetes-1.27.advisories.yaml
+++ b/kubernetes-1.27.advisories.yaml
@@ -81,6 +81,23 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
+  - id: CVE-2023-45142
+    aliases:
+      - GHSA-rcjv-mgp8-qvmr
+    events:
+      - timestamp: 2024-01-12T07:25:25Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-1.27
+            componentID: 752884691da835ba
+            componentName: go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful
+            componentVersion: v0.35.0
+            componentType: go-module
+            componentLocation: /usr/bin/kubelet
+            scanner: grype
+
   - id: CVE-2023-45283
     aliases:
       - GHSA-vvjp-q62m-2vph


### PR DESCRIPTION
Adding Advisory CVE-2021-25740 for kubernetes-1.27 
Adding Advisory GHSA-8pgv-569h-w5rw for kubernetes-1.27 
Adding Advisory GHSA-rcjv-mgp8-qvmr for kubernetes-1.27 