### PR TITLE
Adding CVEs for ruby3.2-puma

### DIFF
--- a/ruby3.2-puma.advisories.yaml
+++ b/ruby3.2-puma.advisories.yaml
@@ -1,0 +1,22 @@
+schema-version: 2.0.2
+
+package:
+  name: ruby3.2-puma
+
+advisories:
+  - id: CVE-2024-21647
+    aliases:
+      - GHSA-c2f4-cvqm-65w2
+    events:
+      - timestamp: 2024-01-12T07:32:05Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: ruby3.2-puma
+            componentID: 311810fbf5d9f3c7
+            componentName: ruby3.2-puma
+            componentVersion: 6.4.1-r0
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype


### PR DESCRIPTION
Adding Advisory CVE-2024-21647 for ruby3.2-puma 