### PR TITLE
ci: tone down validation log verbosity

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -39,7 +39,7 @@ jobs:
         echo "fork point will be $fork_point"
 
         wolfictl adv validate \
-          -vv \
+          -v \
           --skip-alias \
           --no-distro-detection \
           --advisories-repo-dir . \


### PR DESCRIPTION
We increased verbosity on CI validation to pinpoint the cause of an issue. That issue was fixed, so now changing level from `DEBUG` to `INFO`.