### PR TITLE
Adding fixed CVEs for crossplane-crank

### DIFF
--- a/crossplane.advisories.yaml
+++ b/crossplane.advisories.yaml
@@ -47,3 +47,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/crank
             scanner: grype
+      - timestamp: 2024-01-25T07:07:08Z
+        type: fixed
+        data:
+          fixed-version: 1.14.5-r2


### PR DESCRIPTION
Adding Fixed Advisory GHSA-9763-4f94-gfch for crossplane-crank 