### PR TITLE
Adding fixed CVEs for pulumi-kubernetes-operator

### DIFF
--- a/pulumi-kubernetes-operator.advisories.yaml
+++ b/pulumi-kubernetes-operator.advisories.yaml
@@ -77,3 +77,10 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: This vulnerability is only present on Windows.
+
+  - id: GHSA-9763-4f94-gfch
+    events:
+      - timestamp: 2024-01-25T07:13:34Z
+        type: fixed
+        data:
+          fixed-version: 1.14.0-r5


### PR DESCRIPTION
Adding Fixed Advisory GHSA-9763-4f94-gfch for pulumi-kubernetes-operator 