### PR TITLE
docs: initial import of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,7 @@ Each package advisories file in this repository has a list of one or more adviso
 
 ### Event Types
 
-Here are the types of events found in an advisory and what they mean:
-
-`detection`: The maintainers are aware that the package is potentially affected by the vulnerability, but more investigation is needed in order to reach a conclusion.
-
-`true-positive-determination`: The package is believed to be affected by the vulnerability.
-
-`false-positive-determination`: The package is not believed to be affected by the vulnerability. Where possible, further explanation about why this match is a false positive is included in the event data's `type` and `note` fields.
-
-`fixed`: There was one or more versions of the package affected by the vulnerability, but as of the `fixed-version`, the vulnerability has been mitigated.
+For a detailed look at the current event types, see the [Event Types](./docs/event_types.md) document.
 
 ## Using the data
 

--- a/docs/event_types.md
+++ b/docs/event_types.md
@@ -1,0 +1,27 @@
+# Event Types
+
+Advisories include a list of ordered, timestamped "events". Each event has a designated "type". Each type has a specific meaning, and it indicates the structure of the data contained in the event.
+
+## detection
+
+This indicates that we've detected a potential vulnerability match for the distro package. This event doesn't imply the vulnerability match is a true positive or that any remediation is planned, it just puts the vulnerability on our radar of issues to look further into.
+
+## true-positive-determination
+
+This indicates that we've determined that a given vulnerability match is a true positive, i.e. that the package is affected by the vulnerability.
+
+## false-positive-determination
+
+This indicates that we've determined that a given vulnerability does not affect the package. This information will be propagated to vulnerability scanners. Not all scanners will respect Chainguard's false positive determinations.
+
+## fixed
+
+This indicates that the vulnerabiblity had affected a version of our package but has been fixed as of the specified "fixed version" of our package.
+
+## fix-not-planned
+
+This indicates that we're aware of the vulnerability match, but we don't plan on issuing a fix. This type of event **should never be used on supported software**. We generally only use this event type on packages that have reached end-of-life.
+
+## pending-upstream-fix
+
+This indicates that we've been unable to resolve a vulnerability without introducing breaking changes to a package. This is an event type that we use as a last resort when there are very specific reasons preventing a fix to a vulnerability. This is especially relevant when trying to bump a language level dependency. The need for code changes isn't enough to justify using the `pending-upstream-fix` type. We should ensure alignment with the [CVE Philosophy](../philosophy/) before using this event type.

--- a/docs/examples/false-positive-determination.md
+++ b/docs/examples/false-positive-determination.md
@@ -1,0 +1,11 @@
+# False positive determination
+
+### trino: [GHSA-2cqf-6xv9-f22w](https://github.com/advisories/GHSA-2cqf-6xv9-f22w)
+
+This is an example where resolving the CVE was not possible. We attempted to contribute a patch upstream: https://github.com/trinodb/trino/pull/19983
+
+However, the upstream tests helped to identify an incompatibility in newer versions of the `elasticsearch` dependency. Specifically, newer versions of `elasticsearch` are not compatible with OpenSearch since new validation was added to the client. This prevents a medium-difficulty bump of the dependency.
+
+After inspecting the code further, we determined the CVE was a false positive. This is not an ideal scenario since the CVE still shows up in scan results, but provides a good example of when the complexity reaches a upper threshold: https://github.com/wolfi-dev/advisories/pull/513
+
+<!-- TODO: Provide a better example of an analysis that surfaced evidence that a vulnerability match was a false positive. Ideally, show examples for each of the different types of false positives we enumerate in our advisory data format. -->

--- a/docs/examples/fix-cherry-pick.md
+++ b/docs/examples/fix-cherry-pick.md
@@ -1,0 +1,9 @@
+# Fix: cherry-pick
+
+### tiff patch for [CVE-2023-6277](https://github.com/advisories/GHSA-fq8g-55cp-756j)
+
+In this case, a patch for the reported CVE is available:
+
+- https://gitlab.com/libtiff/libtiff/-/merge_requests/545
+
+The patch was merged upstream, but not yet released as an released upstream version. The patch was applied to our package: https://github.com/wolfi-dev/os/pull/9662 as we wait for the upstream project to cut a new release.

--- a/docs/examples/fix-dependency-update.md
+++ b/docs/examples/fix-dependency-update.md
@@ -1,0 +1,21 @@
+# Fix: dependency update
+
+Dependency updates work differently depending on the language.
+
+## Java
+
+### trino [CVE-2023-6378](https://github.com/advisories/GHSA-vmq6-5m68-f53m)
+
+In this example, we introduce a patch to the Maven `pom.xml` file in order to bump a transitive dependency: https://github.com/wolfi-dev/os/pull/9669
+
+### cassandra [CVE-2023-6378](https://github.com/advisories/GHSA-vmq6-5m68-f53m)
+
+In this example, we introduce a patch to the antfile `build.xml` to build a dependency: https://github.com/wolfi-dev/os/pull/9676
+
+## Go
+
+### istio-pilot-discovery-1.20 [GHSA-2c7c-3mj9-8fqh](https://github.com/advisories/GHSA-2c7c-3mj9-8fqh)
+
+This is a very standard example for bumping an easy Go dependency: https://github.com/wolfi-dev/os/pull/9663
+
+<!-- TODO: Add a few complex otel examples -->

--- a/docs/examples/fix-net-new.md
+++ b/docs/examples/fix-net-new.md
@@ -1,0 +1,13 @@
+# Fix: net-new
+
+We should **almost never** develop net-new CVE fixes. However, there's always an exception to the rule.
+
+### Example: [CVE-2023-46402](https://github.com/advisories/GHSA-3f2q-6294-fmq5)
+
+This vulnerability has been reported on an abandoned repository. There are no fixes available and this is a fairly simple Go repository. Chainguard authored a patch and attempted to contribute back:
+
+- https://github.com/whilp/git-urls/pull/25
+
+Given the repo is abandoned, the PR didn't get merge and Chainguard choose to fork the repo to apply the net-new patch: https://github.com/chainguard-dev/git-urls
+
+This is providing us a way to replace the vulnerable repository with Chainguard's repository. This is **rare** and should not happen on a regular basis.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,37 @@
+# Philosophy
+
+## Our mission
+
+We endeavor to provide software with no security vulnerabilities. Along with this, we want our users' experience with vulnerability scanners to be positive — we want to enable accurate scanner to produce high quality results. We believe both of these goals intersect to enable vulnerability management workflows that minimize friction and risk for the consumers of our software.
+
+We solve this through a mixture of removing unnecessary components, high quality curation of vulnerability data, and actual patching of vulnerabilities. Upstream projects also play a role in this overall process, but at the end of the day, **users are relying on us to solve this problem for them**.
+
+## How
+
+First, we need to ensure we can always detect potential vulnerabilities in packages. Second, we need to figure out the best way to fix the vulnerability or to prevent a false positive from adding noise to users' scan results. There is a handful of options at our disposal, and in each case we have to choose which path to take.
+
+We should not shy away from fixing vulnerabilities unless there’s a real reason we can’t do it ourselves. Some approaches are harder than others, and some add more value to our users. For example, using a `pending-upstream-fix` event is relatively easy and gives us an advisory entry to point at, but in most cases, it doesn’t add value to our users.
+
+### Resolving Vulnerabilities
+
+#### a. (best) Update our package to a new upstream released version
+
+This is easy and the best case scenario. It allows us to match what upstream wants to ship as their tested and supportable version.
+
+#### b. (great) Update dependencies
+
+When the vulnerability is addressed in a newer version of an upstream dependency, we can update our build configuration to bump the dependency for our package. We need to be more careful with testing the change. This introduces some drift from what upstream (or other users elsewhere) have tested.
+
+For dependency changes that require code changes, we should contribute patches upstream, to provide a path toward removing the drift between our package and the upstream project once again.
+
+#### c. (okay) Cherry-picking a fix from upstream
+
+This is harder, but can provide a lot of value to our users. This involves manual work, research, and sometimes dealing with patch munging. We should use this as a temporary “bridge”, until such time as we’re able to merge in a new upstream released version, as described in (a).
+
+#### d. (almost never) Net-new development, where we create the actual fix ourselves
+
+This is by far the hardest work, and almost certainly impractical at scale. Crafting net-new patches for vulnerabilities would involve deep expertise in potentially dozens of different projects, written in different languages, every day (or week). However, there are a few edge cases where we may choose to develop a new patch to create value for our users.
+
+### Identifying false-positives
+
+We can “nack” vulnerabilities by marking the vulnerability as a `false-positive-determination`. For scanners that have [correctly implemented support for the distro](https://github.com/chainguard-dev/vulnerability-scanner-support/blob/main/docs/scanning_implementation.md), this has the effect of silencing the scanner for our users, in other cases it doesn’t. Over time we expect this to help more users in more cases, as scanners continue to work to support our distro and vulnerability feed.


### PR DESCRIPTION
This includes:

- consolidating our description of "event types"
- sharing our overall philosophy for handling vulnerabilities in the distro
- providing examples of responses to detected vulnerabilities in the distro

This is just a starting place, and more documentation should be added before long.