### PR TITLE
pulumi-kubernetes-operator: add info about GHSA-449p-3h89-pw88

### DIFF
--- a/pulumi-kubernetes-operator.advisories.yaml
+++ b/pulumi-kubernetes-operator.advisories.yaml
@@ -87,6 +87,13 @@ advisories:
             componentLocation: /usr/bin/pulumi-kubernetes-operator
             scanner: grype
 
+  - id: GHSA-449p-3h89-pw88
+    events:
+      - timestamp: 2024-01-29T16:01:39Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability requires to replace gopkg.in/src-d/go-git.v4 by github.com/go-git/go-git/v5 which requires to modify the source code.
+
   - id: GHSA-6xv5-86q9-7xr8
     events:
       - timestamp: 2023-09-09T15:18:19Z


### PR DESCRIPTION
GHSA-449p-3h89-pw88 for pulumi-kubernetes-operator requires switching from `gopkg.in/src-d/go-git.v4` which has been archived now with `github.com/go-git/go-git/v5` that fixed the detected vulnerability.