### PR TITLE
Switch to the dedicated action

### DIFF
--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-    - uses: chainguard-dev/actions/octo-sts@main
+    - uses: chainguard-dev/octo-sts-action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
       id: octo-sts
       with:
         scope: ${{ github.repository }}


### PR DESCRIPTION
This uses the JS version, which tags releases and revokes the token upon workflow completion.