### PR TITLE
Adding fixed events for ruby3.2-puma

### DIFF
--- a/ruby3.2-puma.advisories.yaml
+++ b/ruby3.2-puma.advisories.yaml
@@ -20,3 +20,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-02-05T07:14:13Z
+        type: fixed
+        data:
+          fixed-version: 6.4.2-r0


### PR DESCRIPTION
Adding Fixed Advisory GHSA-c2f4-cvqm-65w2 for ruby3.2-puma 