### PR TITLE
fix(expat): validation failure after package withdrawal

### DIFF
--- a/expat.advisories.yaml
+++ b/expat.advisories.yaml
@@ -8,16 +8,18 @@ advisories:
     aliases:
       - GHSA-2vq2-xc55-3j5m
     events:
-      - timestamp: 2022-09-21T16:05:50Z
-        type: fixed
+      - timestamp: 2024-02-07T01:44:13Z
+        type: false-positive-determination
         data:
-          fixed-version: 2.4.9-r0
+          type: vulnerable-code-version-not-used
+          note: This was fixed in a now withdrawn 2.4.9-r0 APK package.
 
   - id: CVE-2022-43680
     aliases:
       - GHSA-4hjv-8mmr-jxwv
     events:
-      - timestamp: 2024-01-24T12:55:48Z
-        type: fixed
+      - timestamp: 2024-02-07T01:45:16Z
+        type: false-positive-determination
         data:
-          fixed-version: 2.5.0-r4
+          type: vulnerable-code-version-not-used
+          note: All non-fixed versions (prior to 2.5.0-r4) have been withdrawn.


### PR DESCRIPTION
See https://github.com/wolfi-dev/os/pull/12564/.

Expected validation failures (required to fix other longer-lasting failures):

```
invalid change(s) in diff:
    expat:
        CVE-2022-40674:
            one or more events were modified or removed
        CVE-2022-43680:
            one or more events were modified or removed
```

cc: @jonjohnsonjr @ajayk 