### PR TITLE
Fix validation errors for new duplicate validation check

### DIFF
--- a/cluster-autoscaler-1.25.advisories.yaml
+++ b/cluster-autoscaler-1.25.advisories.yaml
@@ -79,10 +79,3 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.25.3-r5
-
-  - id: GHSA-f9jg-8p32-2f55
-    events:
-      - timestamp: 2024-01-15T17:04:16Z
-        type: fix-not-planned
-        data:
-          note: This package is end of life and will not receive more updates.

--- a/gitlab-shell.advisories.yaml
+++ b/gitlab-shell.advisories.yaml
@@ -42,7 +42,9 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
 
-  - id: GHSA-45x7-px36-x8w8
+  - id: CVE-2023-48795
+    aliases:
+      - GHSA-45x7-px36-x8w8
     events:
       - timestamp: 2023-12-29T21:35:56Z
         type: fixed

--- a/glibc.advisories.yaml
+++ b/glibc.advisories.yaml
@@ -110,6 +110,8 @@ advisories:
           fixed-version: 2.38-r3
 
   - id: CVE-2023-6246
+    aliases:
+      - GHSA-p6rw-gvvh-q8v4
     events:
       - timestamp: 2024-01-31T13:41:52Z
         type: fixed
@@ -117,6 +119,8 @@ advisories:
           fixed-version: 2.38-r11
 
   - id: CVE-2023-6779
+    aliases:
+      - GHSA-p5vr-h433-qhqr
     events:
       - timestamp: 2024-01-31T13:43:45Z
         type: fixed
@@ -124,6 +128,8 @@ advisories:
           fixed-version: 2.38-r11
 
   - id: CVE-2023-6780
+    aliases:
+      - GHSA-jjr8-97p7-vmmg
     events:
       - timestamp: 2024-01-31T13:44:33Z
         type: fixed

--- a/management-api-for-apache-cassandra.advisories.yaml
+++ b/management-api-for-apache-cassandra.advisories.yaml
@@ -11,7 +11,7 @@ advisories:
       - timestamp: 2024-01-14T18:15:03Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade 'swagger-jaxrs2' to '2.2.0' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade ''swagger-jaxrs2'' to ''2.2.0'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''
 
   - id: CVE-2021-46877
     aliases:
@@ -20,7 +20,7 @@ advisories:
       - timestamp: 2024-01-14T18:14:57Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade 'swagger-jaxrs2' to '2.2.0' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade ''swagger-jaxrs2'' to ''2.2.0'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''
 
   - id: CVE-2022-1471
     aliases:
@@ -29,7 +29,7 @@ advisories:
       - timestamp: 2024-01-14T18:25:44Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade 'swagger-jaxrs2' to '2.2.11' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade ''swagger-jaxrs2'' to ''2.2.11'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''
 
   - id: CVE-2022-25857
     aliases:
@@ -38,7 +38,7 @@ advisories:
       - timestamp: 2024-01-14T18:21:41Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade 'swagger-jaxrs2' to '2.2.10' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade ''swagger-jaxrs2'' to ''2.2.10'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''
 
   - id: CVE-2022-38749
     aliases:
@@ -47,7 +47,7 @@ advisories:
       - timestamp: 2024-01-14T18:22:30Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade 'swagger-jaxrs2' to '2.2.10' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade ''swagger-jaxrs2'' to ''2.2.10'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''
 
   - id: CVE-2022-38750
     aliases:
@@ -56,7 +56,7 @@ advisories:
       - timestamp: 2024-01-14T18:22:40Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade 'swagger-jaxrs2' to '2.2.10' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade ''swagger-jaxrs2'' to ''2.2.10'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''
 
   - id: CVE-2022-38751
     aliases:
@@ -65,7 +65,7 @@ advisories:
       - timestamp: 2024-01-14T18:22:10Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade 'swagger-jaxrs2' to '2.2.10' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade ''swagger-jaxrs2'' to ''2.2.10'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''
 
   - id: CVE-2022-38752
     aliases:
@@ -74,14 +74,16 @@ advisories:
       - timestamp: 2024-01-14T18:22:20Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade swagger-jaxrs2' to '2.2.10' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade swagger-jaxrs2'' to ''2.2.10'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''
 
   - id: CVE-2022-41854
+    aliases:
+      - GHSA-w37g-rhq8-7m4j
     events:
       - timestamp: 2024-01-14T18:26:02Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade 'swagger-jaxrs2' to '2.2.10' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade ''swagger-jaxrs2'' to ''2.2.10'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''
 
   - id: CVE-2022-42003
     aliases:
@@ -90,7 +92,7 @@ advisories:
       - timestamp: 2024-01-14T18:15:07Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade 'swagger-jaxrs2' to '2.2.0' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade ''swagger-jaxrs2'' to ''2.2.0'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''
 
   - id: CVE-2022-42004
     aliases:
@@ -99,4 +101,4 @@ advisories:
       - timestamp: 2024-01-14T18:15:11Z
         type: pending-upstream-fix
         data:
-          note: "To fix the CVE, we have to upgrade 'swagger-jaxrs2' to '2.2.0' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: 'src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'"
+          note: 'To fix the CVE, we have to upgrade ''swagger-jaxrs2'' to ''2.2.0'' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: ''src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java:[425,28] cannot access com.fasterxml.jackson.core.exc.StreamWriteException'''

--- a/py3-docker.advisories.yaml
+++ b/py3-docker.advisories.yaml
@@ -90,6 +90,8 @@ advisories:
             scanner: grype
 
   - id: CVE-2020-27534
+    aliases:
+      - GHSA-6hwg-w5jg-9c6x
     events:
       - timestamp: 2024-01-28T01:26:16Z
         type: detection
@@ -105,6 +107,8 @@ advisories:
             scanner: grype
 
   - id: CVE-2021-21284
+    aliases:
+      - GHSA-7452-xqpj-6rpc
     events:
       - timestamp: 2024-01-28T01:26:17Z
         type: detection
@@ -120,6 +124,8 @@ advisories:
             scanner: grype
 
   - id: CVE-2021-21285
+    aliases:
+      - GHSA-6fj5-m822-rqx8
     events:
       - timestamp: 2024-01-28T01:26:17Z
         type: detection


### PR DESCRIPTION
This incorporates fixes for the new duplicate advisory ID check in wolfictl: https://github.com/wolfi-dev/wolfictl/pull/617

This also catches up on alias discovery (which isn't checked in CI currently).

There are some necessary validation failures due to the nature of this fix. Here's what's expected:

```console
❌ advisory data is not valid.

invalid change(s) in diff:
    cluster-autoscaler-1.25:
        GHSA-f9jg-8p32-2f55:
            advisory was removed
    gitlab-shell:
        GHSA-45x7-px36-x8w8:
            advisory was removed
        CVE-2023-48795:
            event 1 (just added):
                event's timestamp (2023-12-29T21:35:56Z) set to more than 3 days ago; timestamps should accurately capture event creation time
            event 2 (just added):
                event's timestamp (2023-12-29T21:36:27Z) set to more than 3 days ago; timestamps should accurately capture event creation time
```
