### PR TITLE
skaffold: pending-upstream-fix

### DIFF
--- a/skaffold.advisories.yaml
+++ b/skaffold.advisories.yaml
@@ -102,7 +102,7 @@ advisories:
             componentLocation: /usr/bin/skaffold
             scanner: grype
       - timestamp: 2024-02-11T12:48:47Z
-        type: fix-not-planned
+        type: pending-upstream-fix
         data:
           note: Upgrading runc to a non-vulnerable version creates conflicts with other old dependencies required by skaffold such as go.opentelemetry.io/otel which is using v1.15.0.
 
@@ -174,7 +174,7 @@ advisories:
             componentLocation: /usr/bin/skaffold
             scanner: grype
       - timestamp: 2024-02-11T12:50:32Z
-        type: fix-not-planned
+        type: pending-upstream-fix
         data:
           note: Upgrading buildkit to a non-vulnerable version requires to bump github.com/docker/docker to v25.0.3 (currently using v24.0.7) and as a consequence needs multiple code changes to adapt the source code to this new version.
 

--- a/skaffold.advisories.yaml
+++ b/skaffold.advisories.yaml
@@ -101,6 +101,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/skaffold
             scanner: grype
+      - timestamp: 2024-02-11T12:48:47Z
+        type: fix-not-planned
+        data:
+          note: Upgrading runc to a non-vulnerable version creates conflicts with other old dependencies required by skaffold such as go.opentelemetry.io/otel which is using v1.15.0.
 
   - id: CVE-2024-23650
     aliases:
@@ -169,6 +173,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/skaffold
             scanner: grype
+      - timestamp: 2024-02-11T12:50:32Z
+        type: fix-not-planned
+        data:
+          note: Upgrading buildkit to a non-vulnerable version requires to bump github.com/docker/docker to v25.0.3 (currently using v24.0.7) and as a consequence needs multiple code changes to adapt the source code to this new version.
 
   - id: GHSA-7ww5-4wqc-m92c
     events:


### PR DESCRIPTION
We decided to mark these two vulnerabilities as `pending-upstream-fix` due to how behind upstream skaffold is at the moment.

Happy to add more details if you think it isn't enough.