### PR TITLE
npm: anticipating an upstream fix

### DIFF
--- a/npm.advisories.yaml
+++ b/npm.advisories.yaml
@@ -20,3 +20,7 @@ advisories:
             componentType: npm
             componentLocation: /usr/lib/node_modules/npm/node_modules/ip/package.json
             scanner: grype
+      - timestamp: 2024-02-16T11:02:53Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream fixes are actively being attempted, such as in https://github.com/indutny/node-ip/pull/138, and once a solution is accepted we should incorporate that into this package.


### PR DESCRIPTION
We've been tracking this situation upstream for a few days now. In the meantime, let's update the advisory data to reflect that, and hopefully we can apply a fix shortly.