### PR TITLE
CVE-2024-24806: fixed advisory for libuv at v1.48.0

### DIFF
--- a/libuv.advisories.yaml
+++ b/libuv.advisories.yaml
@@ -18,3 +18,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-02-16T16:01:34Z
+        type: fixed
+        data:
+          fixed-version: 1.48.0-r0


### PR DESCRIPTION
We picked up v1.48.0 on February 7th, but the detection only happened recently!