### PR TITLE
Nack CVE-2023-42282 in npm and related packages.

### DIFF
--- a/lerna.advisories.yaml
+++ b/lerna.advisories.yaml
@@ -29,3 +29,8 @@ advisories:
             componentType: npm
             componentLocation: /usr/local/lib/node_modules/lerna/node_modules/ip/package.json
             scanner: grype
+      - timestamp: 2024-02-18T15:59:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability is only present in versions of ip before v1.1.8, but we have version 2.0.0. The metadata is wrong in the NVD.

--- a/node-gyp.advisories.yaml
+++ b/node-gyp.advisories.yaml
@@ -20,3 +20,8 @@ advisories:
             componentType: npm
             componentLocation: /usr/lib/node_modules/node-gyp/node_modules/ip/package.json
             scanner: grype
+      - timestamp: 2024-02-18T15:59:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability is only present in versions of ip before v1.1.8, but we have version 2.0.0. The metadata is wrong in the NVD.

--- a/npm.advisories.yaml
+++ b/npm.advisories.yaml
@@ -24,3 +24,8 @@ advisories:
         type: pending-upstream-fix
         data:
           note: Upstream fixes are actively being attempted, such as in https://github.com/indutny/node-ip/pull/138, and once a solution is accepted we should incorporate that into this package.
+      - timestamp: 2024-02-18T15:58:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability is only present in versions of ip before v1.1.8, but we have version 2.0.0. The metadata is wrong in the NVD.

--- a/pnpm-stage0.advisories.yaml
+++ b/pnpm-stage0.advisories.yaml
@@ -20,3 +20,8 @@ advisories:
             componentType: npm
             componentLocation: /usr/lib/node_modules/pnpm/dist/node_modules/ip/package.json
             scanner: grype
+      - timestamp: 2024-02-18T15:59:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability is only present in versions of ip before v1.1.8, but we have version 2.0.0. The metadata is wrong in the NVD.

--- a/renovate.advisories.yaml
+++ b/renovate.advisories.yaml
@@ -24,3 +24,8 @@ advisories:
         type: fixed
         data:
           fixed-version: 37.186.1-r0
+      - timestamp: 2024-02-18T16:00:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability is only present in versions of ip before v1.1.8, but we have version 2.0.0. The metadata is wrong in the NVD.

--- a/sqlpad.advisories.yaml
+++ b/sqlpad.advisories.yaml
@@ -20,3 +20,8 @@ advisories:
             componentType: npm
             componentLocation: /usr/bin/sqlpad-server/node_modules/ip/package.json
             scanner: grype
+      - timestamp: 2024-02-18T16:00:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability is only present in versions of ip before v1.1.8, but we have version 2.0.0. The metadata is wrong in the NVD.


### PR DESCRIPTION
The CVE description says it's only in versions prior to 1.1.8 but the CPE is incorrect, causing this to be flagged incorrectly.