### PR TITLE
add lifecycle-automation-advisory sts

### DIFF
--- a/.github/chainguard/lifecycle-automation-advisory.sts.yaml
+++ b/.github/chainguard/lifecycle-automation-advisory.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://accounts.google.com
+
+# staging-images: not in use
+# prod-images: insights-publisher-sa@prod-images-c6e5.iam.gserviceaccount.com
+subject: "101826719708554282120"
+
+permissions:
+  contents: read


### PR DESCRIPTION
add missing policy for the `cve_advisory` cloud run service