### PR TITLE
add automated pr reviews

### DIFF
--- a/.github/chainguard/enable-auto-merge.sts.yaml
+++ b/.github/chainguard/enable-auto-merge.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:wolfi-dev/advisories:ref:refs/heads/main
+claim_pattern:
+  workflow_ref: wolfi-dev/advisories/.github/workflows/auto-review-merge.yaml@refs/heads/main
+
+# enable auto merge
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/auto-review-merge.yaml
+++ b/.github/workflows/auto-review-merge.yaml
@@ -1,0 +1,46 @@
+name: automated-pr-review
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '42 * * * *'
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write # needed for Octo STS federation
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - uses: chainguard-dev/octo-sts-action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: wolfi-dev/advisories
+          identity: enable-auto-merge
+
+      - run: |
+          ./scripts/enable-auto-merge.sh ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+
+  review-pr:
+    runs-on: ubuntu-latest
+
+    needs: enable-auto-merge
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - run: |
+          ./scripts/review-prs.sh ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/enable-auto-merge.sh
+++ b/scripts/enable-auto-merge.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo=$1
+
+get_prs() {
+    gh search prs --repo="${repo}" --author="octo-sts[bot]" --review=none --state=open --limit=50 --head=adv --json number --jq '.[].number'
+}
+
+readarray -t PRS < <(get_prs)
+for pr in "${PRS[@]}"; do
+  echo ">>> Enabling auto merge PR: ${pr}"
+
+  # Attempt to enable auto merge PR
+  GITHUB_TOKEN="${GH_TOKEN}" gh pr merge --squash --auto \
+  --repo="${repo}" "${pr}"
+
+done

--- a/scripts/enable-auto-merge.sh
+++ b/scripts/enable-auto-merge.sh
@@ -7,7 +7,7 @@ set -o pipefail
 repo=$1
 
 get_prs() {
-    gh search prs --repo="${repo}" --author="octo-sts[bot]" --review=none --state=open --limit=50 --head=adv --json number --jq '.[].number'
+    gh search prs --repo="${repo}" --author="octo-sts[bot]" --review=none --state=open --limit=50 --head=adv --sort=created --order=asc --json number --jq '.[].number'
 }
 
 readarray -t PRS < <(get_prs)

--- a/scripts/review-prs.sh
+++ b/scripts/review-prs.sh
@@ -7,7 +7,7 @@ set -o pipefail
 repo=$1
 
 get_prs() {
-    gh search prs --repo="${repo}" --author="octo-sts[bot]" --review=none --state=open --head=adv --limit=50 --json number --jq '.[].number'
+    gh search prs --repo="${repo}" --author="octo-sts[bot]" --review=none --state=open --head=adv --limit=50 --sort=created --order=asc --json number --jq '.[].number'
 }
 
 readarray -t PRS < <(get_prs)

--- a/scripts/review-prs.sh
+++ b/scripts/review-prs.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo=$1
+
+get_prs() {
+    gh search prs --repo="${repo}" --author="octo-sts[bot]" --review=none --state=open --head=adv --limit=50 --json number --jq '.[].number'
+}
+
+readarray -t PRS < <(get_prs)
+for pr in "${PRS[@]}"; do
+  echo ">>> Reviewing PR: ${pr}"
+
+  # Approve PR
+  curl \
+  -o review_output.json \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  https://api.github.com/repos/"${repo}"/pulls/"${pr}"/reviews
+
+  echo "review: "
+  cat review_output.json
+
+  REVIEW_ID=$(jq -r '.id' review_output.json)
+  GITHUB_TOKEN="${GH_TOKEN}" gh api \
+  --method POST \
+  -H "Accept: application/vnd.github+json" \
+  /repos/"${repo}"/pulls/"${pr}"/reviews/"${REVIEW_ID}"/events \
+  -f event='APPROVE'
+
+done


### PR DESCRIPTION
This PR add a job that can run manually or in a cron tab (every ~42 min)

It uses the Octo sts to enable the auto-merge and the GitHub CI User to approve the PR.
If the required CI checks are green and have the approval, the PR will get in the merge queue, and if it succeeds, that will be merged.

This automated job will only approve and enable auto-merge for the automated PRs created by the lifecycle automation.
For other PRs, like those created by DependaBot or humans that will not touch.
