### PR TITLE
gradle-8: New advisories

### DIFF
--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -112,6 +112,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/gradle/lib/commons-compress-1.21.jar
             scanner: grype
+      - timestamp: 2024-03-05T18:09:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'The upstream project is planning a fix (https://github.com/gradle/gradle/pull/27666/files#diff-46a9cba02b57c005bb1da344ce6c71d7611894853c2a72272e4681c3158c202e). Chainguard won''t provide a fix ahead of upstream due to the following notice: "This change may affect the checksums of the produced jars, zips, and other archive types because the metadata of the produced artifacts may differ."'
 
   - id: CVE-2024-26308
     aliases:
@@ -129,3 +133,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/gradle/lib/commons-compress-1.21.jar
             scanner: grype
+      - timestamp: 2024-03-05T18:09:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'The upstream project is planning a fix (https://github.com/gradle/gradle/pull/27666/files#diff-46a9cba02b57c005bb1da344ce6c71d7611894853c2a72272e4681c3158c202e). Chainguard won''t provide a fix ahead of upstream due to the following notice: "This change may affect the checksums of the produced jars, zips, and other archive types because the metadata of the produced artifacts may differ."'


### PR DESCRIPTION
The upgrade of `commons-compress` is fairly complex, but also it may affect the checksum of JARs.