### PR TITLE
vault-1.13: Publish advisory for CVE-2024-2048

### DIFF
--- a/vault-1.13.advisories.yaml
+++ b/vault-1.13.advisories.yaml
@@ -85,6 +85,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/vault
             scanner: grype
+      - timestamp: 2024-03-15T23:41:05Z
+        type: fix-not-planned
+        data:
+          note: 'HashiCorp Vault is not publishing a fix for this vulnerability for version 1.13. To fix this vulnerability, upgrade to version 1.14+. Learn more: https://discuss.hashicorp.com/t/hcsec-2024-05-vault-cert-auth-method-did-not-correctly-validate-non-ca-certificates/63382'
 
   - id: CVE-2024-24786
     aliases:


### PR DESCRIPTION
vault-1.13 is no longer supported and will exit Wolfi ~soon. This advisory provides information in the meantime.