### PR TITLE
go: File advisories for EOL packages

### DIFF
--- a/go-1.19.advisories.yaml
+++ b/go-1.19.advisories.yaml
@@ -259,6 +259,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.19 is no longer supported upstream.
 
   - id: CVE-2023-45290
     aliases:
@@ -276,6 +280,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.19 is no longer supported upstream.
 
   - id: CVE-2024-24783
     aliases:
@@ -293,6 +301,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.19 is no longer supported upstream.
 
   - id: CVE-2024-24784
     aliases:
@@ -310,6 +322,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.19 is no longer supported upstream.
 
   - id: CVE-2024-24785
     aliases:
@@ -327,3 +343,7 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.19 is no longer supported upstream.

--- a/go-1.20.advisories.yaml
+++ b/go-1.20.advisories.yaml
@@ -163,6 +163,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.
 
   - id: CVE-2023-45290
     aliases:
@@ -180,6 +184,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.
 
   - id: CVE-2024-24783
     aliases:
@@ -197,6 +205,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.
 
   - id: CVE-2024-24784
     aliases:
@@ -214,6 +226,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.
 
   - id: CVE-2024-24785
     aliases:
@@ -231,3 +247,7 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.

--- a/go-fips-1.20.advisories.yaml
+++ b/go-fips-1.20.advisories.yaml
@@ -127,6 +127,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.
 
   - id: CVE-2023-45290
     aliases:
@@ -144,6 +148,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.
 
   - id: CVE-2024-24783
     aliases:
@@ -161,6 +169,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.
 
   - id: CVE-2024-24784
     aliases:
@@ -178,6 +190,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.
 
   - id: CVE-2024-24785
     aliases:
@@ -195,3 +211,7 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/go/bin/go
             scanner: grype
+      - timestamp: 2024-03-20T23:17:34Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.


### PR DESCRIPTION
These packages are no longer supported by the Go team, and there are no fixes available from upstream: https://groups.google.com/g/golang-announce/c/5pwGVUPoMbg