### PR TITLE
python-3.*: Advisories for CVE-2023-6597 and CVE-2024-0450

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -73,12 +73,20 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.10.14-r0
+      - timestamp: 2024-03-27T17:42:06Z
+        type: fixed
+        data:
+          fixed-version: 3.10.14-r0
 
   - id: CVE-2024-0450
     aliases:
       - GHSA-jm46-725r-hh9v
     events:
       - timestamp: 2024-03-26T12:39:09Z
+        type: fixed
+        data:
+          fixed-version: 3.10.14-r0
+      - timestamp: 2024-03-27T17:42:39Z
         type: fixed
         data:
           fixed-version: 3.10.14-r0

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -64,3 +64,21 @@ advisories:
         data:
           type: vulnerability-record-analysis-contested
           note: The vendor's perspective is that this is neither a vulnerability nor a bug.
+
+  - id: CVE-2023-6597
+    aliases:
+      - GHSA-797f-63wg-8chv
+    events:
+      - timestamp: 2024-03-27T17:40:42Z
+        type: fixed
+        data:
+          fixed-version: 3.11.8-r0
+
+  - id: CVE-2024-0450
+    aliases:
+      - GHSA-jm46-725r-hh9v
+    events:
+      - timestamp: 2024-03-27T17:40:15Z
+        type: fixed
+        data:
+          fixed-version: 3.11.8-r0

--- a/python-3.12.advisories.yaml
+++ b/python-3.12.advisories.yaml
@@ -69,6 +69,10 @@ advisories:
             componentType: binary
             componentLocation: /usr/bin/python3.12, /usr/lib/libpython3.12.so.1.0
             scanner: grype
+      - timestamp: 2024-03-27T17:44:06Z
+        type: fixed
+        data:
+          fixed-version: 3.12.2-r0
 
   - id: CVE-2024-0450
     aliases:
@@ -86,3 +90,7 @@ advisories:
             componentType: binary
             componentLocation: /usr/bin/python3.12, /usr/lib/libpython3.12.so.1.0
             scanner: grype
+      - timestamp: 2024-03-27T17:43:49Z
+        type: fixed
+        data:
+          fixed-version: 3.12.2-r0


### PR DESCRIPTION
The CVE description has incorrect version ranges. As an example, here are the fixes for 3.12.2:

* CVE-2023-6597: https://github.com/python/cpython/pull/113912
* CVE-2024-0450: https://github.com/python/cpython/pull/112838