### PR TITLE
CVE-2024-3094: Advisories for `openssh` and `xz`

### DIFF
--- a/openssh.advisories.yaml
+++ b/openssh.advisories.yaml
@@ -30,3 +30,13 @@ advisories:
         type: fixed
         data:
           fixed-version: 9.6_p1-r0
+
+  - id: CVE-2024-3094
+    aliases:
+      - GHSA-rxwq-x6h5-x525
+    events:
+      - timestamp: 2024-03-29T23:36:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'Chainguard''s analysis of this vulnerability indicates that our packaging of openssh isn''t vulnerable to this backdoor. Learn more: https://www.chainguard.dev/unchained/chainguards-response-to-cve-2024-3094-aka-the-backdoor-in-xz-library'

--- a/xz.advisories.yaml
+++ b/xz.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: 2.0.2
+
+package:
+  name: xz
+
+advisories:
+  - id: CVE-2024-3094
+    aliases:
+      - GHSA-rxwq-x6h5-x525
+    events:
+      - timestamp: 2024-03-29T23:38:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'Chainguard''s analysis indicates that our build configuration of liblzma doesn''t include the malicious code due to not being Debian/RPM based. Out of an abundance of caution, versions 5.6.0 and 5.6.1 have been withdrawn from the distro. We are closely monitoring the situation and will provide updates as necessary: https://www.chainguard.dev/unchained/chainguards-response-to-cve-2024-3094-aka-the-backdoor-in-xz-library'


### PR DESCRIPTION
Scanners will likely flag these packages regarding the backdoor in `xz`. Over the weekend, we'll follow developments around the `xz` package to determine whether further advisories need to be issued.

Details here: https://www.chainguard.dev/unchained/chainguards-response-to-cve-2024-3094-aka-the-backdoor-in-xz-library