### PR TITLE
keda-2.10: EOL Advisories

### DIFF
--- a/keda-2.10.advisories.yaml
+++ b/keda-2.10.advisories.yaml
@@ -86,6 +86,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/keda-adapter
             scanner: grype
+      - timestamp: 2024-03-30T16:09:26Z
+        type: fix-not-planned
+        data:
+          note: Keda 2.10 is longer supported. Security Support ended on 2023-09-28.
 
   - id: CVE-2023-45290
     aliases:
@@ -103,6 +107,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/keda-adapter
             scanner: grype
+      - timestamp: 2024-03-30T16:09:26Z
+        type: fix-not-planned
+        data:
+          note: Keda 2.10 is longer supported. Security Support ended on 2023-09-28.
 
   - id: CVE-2023-47108
     aliases:
@@ -129,6 +137,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/keda-adapter
             scanner: grype
+      - timestamp: 2024-03-30T16:09:26Z
+        type: fix-not-planned
+        data:
+          note: Keda 2.10 is longer supported. Security Support ended on 2023-09-28.
 
   - id: CVE-2024-24784
     aliases:
@@ -146,6 +158,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/keda-adapter
             scanner: grype
+      - timestamp: 2024-03-30T16:09:26Z
+        type: fix-not-planned
+        data:
+          note: Keda 2.10 is longer supported. Security Support ended on 2023-09-28.
 
   - id: CVE-2024-24785
     aliases:
@@ -163,3 +179,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/keda-adapter
             scanner: grype
+      - timestamp: 2024-03-30T16:09:26Z
+        type: fix-not-planned
+        data:
+          note: Keda 2.10 is longer supported. Security Support ended on 2023-09-28.


### PR DESCRIPTION
Security Support ended on 2023-09-28 - we no longer have this package build definition.