### PR TITLE
k3d: mark CVEs as pending-upstream-changes for the k3d-proxy

### DIFF
--- a/k3d.advisories.yaml
+++ b/k3d.advisories.yaml
@@ -37,6 +37,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/confd
             scanner: grype
+      - timestamp: 2024-04-01T10:11:03Z
+        type: pending-upstream-fix
+        data:
+          note: k3d-proxy is using an unmaintained repository since 2022 which requires multiple upstream code changes to fix this vulnerability.
 
   - id: CVE-2019-11840
     aliases:
@@ -241,6 +245,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/confd
             scanner: grype
+      - timestamp: 2024-04-01T10:13:09Z
+        type: pending-upstream-fix
+        data:
+          note: k3d-proxy is using an unmaintained repository since 2022 which requires multiple upstream code changes to fix this vulnerability.
 
   - id: CVE-2020-8912
     aliases:
@@ -581,6 +589,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/confd
             scanner: grype
+      - timestamp: 2024-04-01T10:15:03Z
+        type: pending-upstream-fix
+        data:
+          note: k3d-proxy is using an unmaintained repository since 2022 which requires multiple upstream code changes to fix this vulnerability.
 
   - id: CVE-2022-3064
     aliases:
@@ -615,6 +627,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/confd
             scanner: grype
+      - timestamp: 2024-04-01T10:16:25Z
+        type: pending-upstream-fix
+        data:
+          note: k3d-proxy is using an unmaintained repository since 2022 which requires multiple upstream code changes to fix this vulnerability.
 
   - id: CVE-2022-40716
     aliases:
@@ -717,6 +733,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/confd
             scanner: grype
+      - timestamp: 2024-04-01T10:14:29Z
+        type: pending-upstream-fix
+        data:
+          note: k3d-proxy is using an unmaintained repository since 2022 which requires multiple upstream code changes to fix this vulnerability.
 
   - id: CVE-2023-2121
     aliases:
@@ -857,6 +877,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 5.6.0-r6
+      - timestamp: 2024-04-01T10:15:51Z
+        type: pending-upstream-fix
+        data:
+          note: k3d-proxy is using an unmaintained repository since 2022 which requires multiple upstream code changes to fix this vulnerability.
 
   - id: CVE-2023-45283
     aliases:
@@ -976,6 +1000,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/confd
             scanner: grype
+      - timestamp: 2024-04-01T10:13:58Z
+        type: pending-upstream-fix
+        data:
+          note: k3d-proxy is using an unmaintained repository since 2022 which requires multiple upstream code changes to fix this vulnerability.
 
   - id: CVE-2024-21626
     aliases:


### PR DESCRIPTION
k3d proxy is using an unmaintained project (actually is a [fork](https://github.com/iwilltry42/confd)) since 2022, I tried to compile that fork but it requires many upstream changes. 

Initially I am gonna mark the k3d-proxy CVEs as pending-upstream-changes although I'd say they could also be considered as fix-not-planned.