### PR TITLE
update advise bluez-CVE-2020-24490

### DIFF
--- a/bluez.advisories.yaml
+++ b/bluez.advisories.yaml
@@ -18,3 +18,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-04-02T10:30:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The vulnerable code is in the linux kernel, Wolfi doesn't ship a kernel. The Kernel fix for this CVE can be found here https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git/commit/?id=a2ec905d1e160a33b2e210e45ad30445ef26ce0e


### PR DESCRIPTION
Adding update of the bluez-CVE-2020-24490 advisory.