### PR TITLE
chromium: Fixed advisories per Chrome

### DIFF
--- a/chromium.advisories.yaml
+++ b/chromium.advisories.yaml
@@ -284,6 +284,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-04-02T15:19:40Z
+        type: fixed
+        data:
+          fixed-version: 122.0.6261.128-r0
 
   - id: CVE-2024-2174
     aliases:
@@ -301,6 +305,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-04-02T15:20:23Z
+        type: fixed
+        data:
+          fixed-version: 122.0.6261.128-r0
 
   - id: CVE-2024-2176
     aliases:
@@ -318,3 +326,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-04-02T15:20:53Z
+        type: fixed
+        data:
+          fixed-version: 122.0.6261.128-r0


### PR DESCRIPTION
Per https://chromereleases.googleblog.com/2024/03/stable-channel-update-for-desktop.html

Associated our fixed version to the version we have past 122.0.6261.111