### PR TITLE
go: Advisories for EOL packages

### DIFF
--- a/c-ares.advisories.yaml
+++ b/c-ares.advisories.yaml
@@ -1,4 +1,4 @@
-schema-version: "2"
+schema-version: 2.0.2
 
 package:
   name: c-ares
@@ -31,3 +31,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.19.1-r0
+
+  - id: CVE-2024-25629
+    events:
+      - timestamp: 2024-04-11T00:07:01Z
+        type: fixed
+        data:
+          fixed-version: 1.27.0-r0

--- a/go-1.19.advisories.yaml
+++ b/go-1.19.advisories.yaml
@@ -243,6 +243,15 @@ advisories:
         data:
           note: Go 1.19 is no longer supported upstream.
 
+  - id: CVE-2023-45288
+    aliases:
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-10T23:20:32Z
+        type: fix-not-planned
+        data:
+          note: Go 1.19 is no longer supported upstream.
+
   - id: CVE-2023-45289
     aliases:
       - GHSA-32ch-6x54-q4h9

--- a/go-1.20.advisories.yaml
+++ b/go-1.20.advisories.yaml
@@ -163,6 +163,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-04-10T23:21:17Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.
 
   - id: CVE-2023-45289
     aliases:

--- a/go-fips-1.20.advisories.yaml
+++ b/go-fips-1.20.advisories.yaml
@@ -111,6 +111,15 @@ advisories:
         data:
           fixed-version: 1.20.4-r0
 
+  - id: CVE-2023-45288
+    aliases:
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-10T23:21:51Z
+        type: fix-not-planned
+        data:
+          note: Go 1.20 is no longer supported upstream.
+
   - id: CVE-2023-45289
     aliases:
       - GHSA-32ch-6x54-q4h9

--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -96,6 +96,15 @@ advisories:
         data:
           fixed-version: 18.17.1-r0
 
+  - id: CVE-2023-38552
+    aliases:
+      - GHSA-x39v-frq9-5hh8
+    events:
+      - timestamp: 2024-04-10T23:17:49Z
+        type: fixed
+        data:
+          fixed-version: 18.18.2-r0
+
   - id: CVE-2023-39331
     aliases:
       - GHSA-7xrv-q25v-f95m


### PR DESCRIPTION
Also adds a missing nodejs-18 + c-ares advisory