### PR TITLE
chromium: CVE fixes from the April 2nd stable channel update

### DIFF
--- a/chromium.advisories.yaml
+++ b/chromium.advisories.yaml
@@ -330,3 +330,30 @@ advisories:
         type: fixed
         data:
           fixed-version: 122.0.6261.128-r0
+
+  - id: CVE-2024-3156
+    aliases:
+      - GHSA-g47c-q844-rxj3
+    events:
+      - timestamp: 2024-04-11T00:17:15Z
+        type: fixed
+        data:
+          fixed-version: 123.0.6312.105-r0
+
+  - id: CVE-2024-3158
+    aliases:
+      - GHSA-r9g8-4h9q-3jfp
+    events:
+      - timestamp: 2024-04-11T00:17:54Z
+        type: fixed
+        data:
+          fixed-version: 123.0.6312.105-r0
+
+  - id: CVE-2024-3159
+    aliases:
+      - GHSA-mh2p-2x66-3hr4
+    events:
+      - timestamp: 2024-04-11T00:18:10Z
+        type: fixed
+        data:
+          fixed-version: 123.0.6312.105-r0


### PR DESCRIPTION
Fixed advisories, as per https://chromereleases.googleblog.com/2024/04/stable-channel-update-for-desktop.html