### PR TITLE
Add true-positive-determination for GHSA-5jpm-x58v-624v in logstash

### DIFF
--- a/logstash.advisories.yaml
+++ b/logstash.advisories.yaml
@@ -130,8 +130,8 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/logstash-input-http-3.8.0-java/vendor/jar-dependencies/io/netty/netty-codec-http/4.1.100.Final/netty-codec-http-4.1.100.Final.jar
             scanner: grype
-      - timestamp: 2024-04-11T18:43:49Z
-        type: true-positive-determination
+      - timestamp: 2024-04-11T19:10:22Z
+        type: pending-upstream-fix
         data:
           note: It is a vendor dependency that includes the vulnerable version. awaiting upstream release that includes the fix from https://github.com/logstash-plugins/logstash-input-http/pull/172
 

--- a/logstash.advisories.yaml
+++ b/logstash.advisories.yaml
@@ -130,6 +130,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/logstash-input-http-3.8.0-java/vendor/jar-dependencies/io/netty/netty-codec-http/4.1.100.Final/netty-codec-http-4.1.100.Final.jar
             scanner: grype
+      - timestamp: 2024-04-11T18:43:49Z
+        type: true-positive-determination
+        data:
+          note: It is a vendor dependency that includes the vulnerable version. awaiting upstream release that includes the fix from https://github.com/logstash-plugins/logstash-input-http/pull/172
 
   - id: GHSA-xc9x-jj77-9p9j
     events:


### PR DESCRIPTION
Opened a pull request to upstream https://github.com/logstash-plugins/logstash-input-http/pull/172 from where the cve is coming