### PR TITLE
fix: missing adv data openssl

### DIFF
--- a/openssl.advisories.yaml
+++ b/openssl.advisories.yaml
@@ -240,6 +240,13 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: This vulnerability is specific to PowerPC, which is an unsupported architecture at this time.
 
+  - id: CVE-2023-6237
+    events:
+      - timestamp: 2024-04-23T13:02:37Z
+        type: fixed
+        data:
+          fixed-version: 3.3.0-r5
+
   - id: CVE-2024-0727
     aliases:
       - GHSA-9v9h-cgj8-h64p
@@ -248,3 +255,12 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.2.1-r0
+
+  - id: CVE-2024-2511
+    aliases:
+      - GHSA-299c-jvhc-gxj8
+    events:
+      - timestamp: 2024-04-23T13:02:22Z
+        type: fixed
+        data:
+          fixed-version: 3.3.0-r5


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/libcrypto3-3.3.0-r5.apk
🔎 Scanning "packages/aarch64/libcrypto3-3.3.0-r5.apk"
✅ No vulnerabilities found
```