### PR TITLE
Add neuvector advisory data about a false-positive

### DIFF
--- a/neuvector-scanner.advisories.yaml
+++ b/neuvector-scanner.advisories.yaml
@@ -23,8 +23,8 @@ advisories:
       - timestamp: 2024-04-23T16:21:15Z
         type: false-positive-determination
         data:
-          type: vulnerable-code-not-included-in-package
-          note: The current version of the module v0.0.0-20240411013726-6a6b32c3e597 does not include the vulnerable code
+          type: vulnerable-code-version-not-used
+          note: neuvector-scanner is using a non vulnerable version of neuvector module which has been released after the affected versions.
 
   - id: CVE-2023-45288
     aliases:

--- a/neuvector-scanner.advisories.yaml
+++ b/neuvector-scanner.advisories.yaml
@@ -20,6 +20,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/neuvector-scanner
             scanner: grype
+      - timestamp: 2024-04-23T16:21:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The current version of the module v0.0.0-20240411013726-6a6b32c3e597 does not include the vulnerable code
 
   - id: CVE-2023-45288
     aliases:


### PR DESCRIPTION
```
wolfictl scan \
🔎 Scanning "/tmp/artifacts-1/packages/x86_64/neuvector-scanner-0_git20240417-r1.apk"
└── 📄 /usr/bin/neuvector-scanner
        📦 github.com/neuvector/neuvector v0.0.0-2024041[10](https://github.com/wolfi-dev/os/actions/runs/8799174875/job/24147872819#step:9:11)13726-6a6b32c3e597 (go-module)
            Critical GHSA-622h-h2p8-743x fixed in 5.2.2
```