### PR TITLE
Adding Fixed Advisory GHSA-2mm7-x5h6-5pvq for ctop

### DIFF
--- a/ctop.advisories.yaml
+++ b/ctop.advisories.yaml
@@ -167,6 +167,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/ctop
             scanner: grype
+      - timestamp: 2024-04-23T19:21:17Z
+        type: fixed
+        data:
+          fixed-version: 0.7.7-r13
 
   - id: CVE-2022-29162
     aliases:


### PR DESCRIPTION
```
$ wolfictl scan ~/Downloads/os_x86_64_ctop-0.7.7-r13.apk
🔎 Scanning "/Users/cpanato/Downloads/os_x86_64_ctop-0.7.7-r13.apk"
✅ No vulnerabilities found
```