### PR TITLE
Adding Advisory GHSA-pxhw-596r-rwq5 for sig-storage-local-static-provisioner

### DIFF
--- a/sig-storage-local-static-provisioner.advisories.yaml
+++ b/sig-storage-local-static-provisioner.advisories.yaml
@@ -24,3 +24,20 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.7.0-r1
+
+  - id: CVE-2024-3177
+    aliases:
+      - GHSA-pxhw-596r-rwq5
+    events:
+      - timestamp: 2024-04-24T07:27:21Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: sig-storage-local-static-provisioner
+            componentID: 88259a54a68dce3b
+            componentName: k8s.io/kubernetes
+            componentVersion: v1.27.8
+            componentType: go-module
+            componentLocation: /usr/bin/local-provisioner
+            scanner: grype


### PR DESCRIPTION
```
$ wolfictl scan -r sig-storage-local-static-provisioner
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-sig-storage-local-static-provisioner-2.7.0-r1-2945973484.apk"
└── 📄 /usr/bin/local-provisioner
        📦 k8s.io/kubernetes v1.27.8 (go-module)
            Low CVE-2024-3177 GHSA-pxhw-596r-rwq5 fixed in 1.27.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-sig-storage-local-static-provisioner-2.7.0-r1-480488250.apk"
└── 📄 /usr/bin/local-provisioner
        📦 k8s.io/kubernetes v1.27.8 (go-module)
            Low CVE-2024-3177 GHSA-pxhw-596r-rwq5 fixed in 1.27.13
```