### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for kubernetes-csi-driver-hostpath

### DIFF
--- a/kubernetes-csi-driver-hostpath.advisories.yaml
+++ b/kubernetes-csi-driver-hostpath.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: kubernetes-csi-driver-hostpath
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T07:13:53Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: kubernetes-csi-driver-hostpath
+            componentID: 99cde908a2d72c6f
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.0
+            componentType: go-module
+            componentLocation: /usr/bin/hostpathplugin
+            scanner: grype
+
   - id: CVE-2023-45288
     aliases:
       - GHSA-4v7x-pqxf-cx7m


### PR DESCRIPTION
```
$ wolfictl scan -r kubernetes-csi-driver-hostpath
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-kubernetes-csi-driver-hostpath-1.13.0-r3-2124324488.apk"
└── 📄 /usr/bin/hostpathplugin
        📦 k8s.io/apimachinery v0.29.0 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-kubernetes-csi-driver-hostpath-1.13.0-r3-2433738398.apk"
└── 📄 /usr/bin/hostpathplugin
        📦 k8s.io/apimachinery v0.29.0 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```