### PR TITLE
Adding Fixed Advisory GHSA-ppf8-hhpp-f5hj for hugo-extended

### DIFF
--- a/hugo-extended.advisories.yaml
+++ b/hugo-extended.advisories.yaml
@@ -53,3 +53,12 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.125.0-r0
+
+  - id: CVE-2024-32875
+    aliases:
+      - GHSA-ppf8-hhpp-f5hj
+    events:
+      - timestamp: 2024-04-25T07:24:19Z
+        type: fixed
+        data:
+          fixed-version: 0.125.3-r0


### PR DESCRIPTION
```
$ wolfictl scan -r hugo-extended
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-hugo-extended-0.125.4-r0-2755827429.apk"
✅ No vulnerabilities found
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-hugo-extended-0.125.4-r0-2694449955.apk"
✅ No vulnerabilities found
```