### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for cilium-cli

### DIFF
--- a/cilium-cli.advisories.yaml
+++ b/cilium-cli.advisories.yaml
@@ -25,6 +25,23 @@ advisories:
         data:
           fixed-version: 0.16.2-r0
 
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T07:36:43Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: cilium-cli
+            componentID: 00e8fb82f5e61cc3
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.2
+            componentType: go-module
+            componentLocation: /usr/bin/cilium
+            scanner: grype
+
   - id: CVE-2023-45283
     aliases:
       - GHSA-vvjp-q62m-2vph


### PR DESCRIPTION
```
$ wolfictl scan -r cilium-cli
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-cilium-cli-0.16.4-r2-1672560164.apk"
└── 📄 /usr/bin/cilium
        📦 k8s.io/apimachinery v0.29.2 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-cilium-cli-0.16.4-r2-1639477063.apk"
└── 📄 /usr/bin/cilium
        📦 k8s.io/apimachinery v0.29.2 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```