### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for containerd

### DIFF
--- a/containerd.advisories.yaml
+++ b/containerd.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: containerd
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T08:12:31Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: containerd
+            componentID: a6ae6fbcecb34ecd
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.26.2
+            componentType: go-module
+            componentLocation: /usr/bin/containerd
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r containerd
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-containerd-1.7.15-r1-612931296.apk"
└── 📄 /usr/bin/containerd
        📦 k8s.io/apimachinery v0.26.2 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-containerd-1.7.15-r1-3687701292.apk"
└── 📄 /usr/bin/containerd
        📦 k8s.io/apimachinery v0.26.2 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```