### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for coredns

### DIFF
--- a/coredns.advisories.yaml
+++ b/coredns.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: coredns
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T08:15:10Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: coredns
+            componentID: 52da9f83307d01c5
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.27.4
+            componentType: go-module
+            componentLocation: /usr/bin/coredns
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r coredns
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-coredns-1.11.1-r13-3590154897.apk"
└── 📄 /usr/bin/coredns
        📦 github.com/coredns/coredns v0.0.0-20230815193032-ae2bbc29be1a (go-module)
            Medium CVE-2022-2835 GHSA-ch7v-37xg-75ph
            Medium GHSA-gv9j-4w24-q7vx fixed in 1.6.6
            Medium CVE-2022-2837 GHSA-h828-v5pv-33qx
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.27.4 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-coredns-1.11.1-r13-2910254855.apk"
└── 📄 /usr/bin/coredns
        📦 github.com/coredns/coredns v0.0.0-20230815193032-ae2bbc29be1a (go-module)
            Medium CVE-2022-2835 GHSA-ch7v-37xg-75ph
            Medium GHSA-gv9j-4w24-q7vx fixed in 1.6.6
            Medium CVE-2022-2837 GHSA-h828-v5pv-33qx
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.27.4 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```