### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for flux-source-controller

### DIFF
--- a/flux-source-controller.advisories.yaml
+++ b/flux-source-controller.advisories.yaml
@@ -26,6 +26,23 @@ advisories:
           type: vulnerability-record-analysis-contested
           note: 'This is not a vulnerability. Learn more about the response from Helm: https://helm.sh/blog/response-cve-2019-25210'
 
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T08:23:00Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: flux-source-controller
+            componentID: 95eec55ae7869bcd
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.0
+            componentType: go-module
+            componentLocation: /usr/bin/source-controller
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r flux-source-controller
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-flux-source-controller-1.2.5-r2-3257284211.apk"
└── 📄 /usr/bin/source-controller
        📦 helm.sh/helm/v3 v3.14.2 (go-module)
            Medium CVE-2019-25210 GHSA-jw44-4f3j-q396
        📦 k8s.io/apimachinery v0.29.0 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-flux-source-controller-1.2.5-r2-3687237687.apk"
└── 📄 /usr/bin/source-controller
        📦 helm.sh/helm/v3 v3.14.2 (go-module)
            Medium CVE-2019-25210 GHSA-jw44-4f3j-q396
        📦 k8s.io/apimachinery v0.29.0 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

```