### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for clusterctl

### DIFF
--- a/clusterctl.advisories.yaml
+++ b/clusterctl.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: clusterctl
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T08:23:23Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: clusterctl
+            componentID: 9148e59450f52159
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.3
+            componentType: go-module
+            componentLocation: /usr/bin/clusterctl
+            scanner: grype
+
   - id: CVE-2023-45288
     aliases:
       - GHSA-4v7x-pqxf-cx7m


### PR DESCRIPTION
```
$ wolfictl scan -r clusterctl
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-clusterctl-1.7.1-r0-1649847483.apk"
└── 📄 /usr/bin/clusterctl
        📦 k8s.io/apimachinery v0.29.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-clusterctl-1.7.1-r0-2128751401.apk"
└── 📄 /usr/bin/clusterctl
        📦 k8s.io/apimachinery v0.29.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```