### PR TITLE
Adv cluster autoscaler 1.25 1.25.3 r12

### DIFF
--- a/cluster-autoscaler-1.25.advisories.yaml
+++ b/cluster-autoscaler-1.25.advisories.yaml
@@ -235,3 +235,20 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.25.3-r11
+
+  - id: CVE-2024-3177
+    aliases:
+      - GHSA-pxhw-596r-rwq5
+    events:
+      - timestamp: 2024-04-25T08:24:07Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: cluster-autoscaler-1.25
+            componentID: 4f9b3b55fa199167
+            componentName: k8s.io/kubernetes
+            componentVersion: v1.25.16
+            componentType: go-module
+            componentLocation: /usr/bin/cluster-autoscaler
+            scanner: grype


### PR DESCRIPTION
```
$ wolfictl scan -r cluster-autoscaler-1.25
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-cluster-autoscaler-1.25-1.25.3-r12-2362645333.apk"
└── 📄 /usr/bin/cluster-autoscaler
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.25.12 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
        📦 k8s.io/kubernetes v1.25.16 (go-module)
            Low CVE-2021-25743 GHSA-f9jg-8p32-2f55 fixed in 1.26.0-alpha.3
            Low CVE-2024-3177 GHSA-pxhw-596r-rwq5 fixed in 1.27.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-cluster-autoscaler-1.25-1.25.3-r12-2074768026.apk"
└── 📄 /usr/bin/cluster-autoscaler
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.25.12 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
        📦 k8s.io/kubernetes v1.25.16 (go-module)
            Low CVE-2021-25743 GHSA-f9jg-8p32-2f55 fixed in 1.26.0-alpha.3
            Low CVE-2024-3177 GHSA-pxhw-596r-rwq5 fixed in 1.27.13

```