### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for doppler-kubernetes-operator

### DIFF
--- a/doppler-kubernetes-operator.advisories.yaml
+++ b/doppler-kubernetes-operator.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: doppler-kubernetes-operator
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T08:24:50Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: doppler-kubernetes-operator
+            componentID: a75509e6bf3965d5
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.20.2
+            componentType: go-module
+            componentLocation: /usr/bin/manager
+            scanner: grype
+
   - id: CVE-2023-45288
     aliases:
       - GHSA-4v7x-pqxf-cx7m


### PR DESCRIPTION
```
$ wolfictl scan -r doppler-kubernetes-operator
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-doppler-kubernetes-operator-1.5.0-r3-23611981.apk"
└── 📄 /usr/bin/manager
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.20.2 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-doppler-kubernetes-operator-1.5.0-r3-1450275998.apk"
└── 📄 /usr/bin/manager
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.20.2 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```