### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for ghaudit

### DIFF
--- a/ghaudit.advisories.yaml
+++ b/ghaudit.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: ghaudit
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T08:25:47Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: ghaudit
+            componentID: 8faace228495454c
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.3
+            componentType: go-module
+            componentLocation: /usr/bin/ghaudit
+            scanner: grype
+
   - id: CVE-2023-45288
     aliases:
       - GHSA-4v7x-pqxf-cx7m


### PR DESCRIPTION
```
$ wolfictl scan -r ghaudit
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-ghaudit-0.4.0-r1-2258578417.apk"
└── 📄 /usr/bin/ghaudit
        📦 k8s.io/apimachinery v0.29.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-ghaudit-0.4.0-r1-2886285368.apk"
└── 📄 /usr/bin/ghaudit
        📦 k8s.io/apimachinery v0.29.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```