### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for secrets-store-csi-driver-provider-gcp

### DIFF
--- a/secrets-store-csi-driver-provider-gcp.advisories.yaml
+++ b/secrets-store-csi-driver-provider-gcp.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: secrets-store-csi-driver-provider-gcp
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T08:30:12Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: secrets-store-csi-driver-provider-gcp
+            componentID: ce93d8da3baf0e77
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.1
+            componentType: go-module
+            componentLocation: /usr/bin/secrets-store-csi-driver-provider-gcp
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r secrets-store-csi-driver-provider-gcp
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-secrets-store-csi-driver-provider-gcp-1.5.0-r4-728290553.apk"
└── 📄 /usr/bin/secrets-store-csi-driver-provider-gcp
        📦 k8s.io/apimachinery v0.29.1 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-secrets-store-csi-driver-provider-gcp-1.5.0-r4-1075182616.apk"
└── 📄 /usr/bin/secrets-store-csi-driver-provider-gcp
        📦 k8s.io/apimachinery v0.29.1 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```