### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for flux-notification-controller

### DIFF
--- a/flux-notification-controller.advisories.yaml
+++ b/flux-notification-controller.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: flux-notification-controller
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T08:31:05Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: flux-notification-controller
+            componentID: 387192be3fabceeb
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.28.6
+            componentType: go-module
+            componentLocation: /usr/bin/notification-controller
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r flux-notification-controller
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-flux-notification-controller-1.2.4-r4-3586782911.apk"
└── 📄 /usr/bin/notification-controller
        📦 k8s.io/apimachinery v0.28.6 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-flux-notification-controller-1.2.4-r4-1358073243.apk"
└── 📄 /usr/bin/notification-controller
        📦 k8s.io/apimachinery v0.28.6 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```