### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for crossplane

### DIFF
--- a/crossplane.advisories.yaml
+++ b/crossplane.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: crossplane
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T08:36:54Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: crossplane
+            componentID: 3a770525d9efdc2c
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.1
+            componentType: go-module
+            componentLocation: /usr/bin/crossplane
+            scanner: grype
+
   - id: CVE-2023-45283
     aliases:
       - GHSA-vvjp-q62m-2vph


### PR DESCRIPTION
```
$ wolfictl scan -r crossplane
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-crossplane-1.15.2-r0-2879565366.apk"
└── 📄 /usr/bin/crossplane
        📦 github.com/crossplane/crossplane v0.0.0-20240409140320-432e1637f677 (go-module)
            Low CVE-2023-37900 GHSA-68p4-95xf-7gx8 fixed in 1.11.5
            High CVE-2023-38495 GHSA-pj4x-2xr5-w87m fixed in 1.11.5
            Medium CVE-2023-27484 GHSA-v829-x6hh-cqfq fixed in 1.9.2
        📦 k8s.io/apimachinery v0.29.1 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-crossplane-1.15.2-r0-462427353.apk"
└── 📄 /usr/bin/crossplane
        📦 github.com/crossplane/crossplane v0.0.0-20240409140320-432e1637f677 (go-module)
            Low CVE-2023-37900 GHSA-68p4-95xf-7gx8 fixed in 1.11.5
            High CVE-2023-38495 GHSA-pj4x-2xr5-w87m fixed in 1.11.5
            Medium CVE-2023-27484 GHSA-v829-x6hh-cqfq fixed in 1.9.2
        📦 k8s.io/apimachinery v0.29.1 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```