### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for flux

### DIFF
--- a/flux.advisories.yaml
+++ b/flux.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: flux
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T08:43:36Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: flux
+            componentID: 1eb55c2e4625069c
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.28.6
+            componentType: go-module
+            componentLocation: /usr/bin/flux
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r flux
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-flux-2.2.3-r5-3674699394.apk"
└── 📄 /usr/bin/flux
        📦 k8s.io/apimachinery v0.28.6 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-flux-2.2.3-r5-3880113523.apk"
└── 📄 /usr/bin/flux
        📦 k8s.io/apimachinery v0.28.6 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```