### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for cluster-proportional-autoscaler

### DIFF
--- a/cluster-proportional-autoscaler.advisories.yaml
+++ b/cluster-proportional-autoscaler.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: cluster-proportional-autoscaler
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:01:09Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: cluster-proportional-autoscaler
+            componentID: 262b2e3995e02f61
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.1
+            componentType: go-module
+            componentLocation: /usr/bin/cluster-proportional-autoscaler
+            scanner: grype
+
   - id: CVE-2023-45283
     aliases:
       - GHSA-vvjp-q62m-2vph


### PR DESCRIPTION
```
$ wolfictl scan -r cluster-proportional-autoscaler
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-cluster-proportional-autoscaler-1.8.11-r4-3883344324.apk"
└── 📄 /usr/bin/cluster-proportional-autoscaler
        📦 k8s.io/apimachinery v0.29.1 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-cluster-proportional-autoscaler-1.8.11-r4-3077228728.apk"
└── 📄 /usr/bin/cluster-proportional-autoscaler
        📦 k8s.io/apimachinery v0.29.1 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13```