### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for flux-helm-controller

### DIFF
--- a/flux-helm-controller.advisories.yaml
+++ b/flux-helm-controller.advisories.yaml
@@ -36,6 +36,23 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Go vulndb has marked this code NOT_IMPORTABLE.
 
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:03:02Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: flux-helm-controller
+            componentID: d90149653a4eb3bd
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.0
+            componentType: go-module
+            componentLocation: /usr/bin/helm-controller
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r flux-helm-controller
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-flux-helm-controller-0.37.4-r6-2312192083.apk"
└── 📄 /usr/bin/helm-controller
        📦 golang.org/x/net v0.20.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 helm.sh/helm/v3 v3.14.2 (go-module)
            Medium CVE-2019-25210 GHSA-jw44-4f3j-q396
        📦 k8s.io/apimachinery v0.29.0 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-flux-helm-controller-0.37.4-r6-3403016204.apk"
└── 📄 /usr/bin/helm-controller
        📦 golang.org/x/net v0.20.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 helm.sh/helm/v3 v3.14.2 (go-module)
            Medium CVE-2019-25210 GHSA-jw44-4f3j-q396
        📦 k8s.io/apimachinery v0.29.0 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```