### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for velero-plugin-for-aws

### DIFF
--- a/velero-plugin-for-aws.advisories.yaml
+++ b/velero-plugin-for-aws.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: velero-plugin-for-aws
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:03:26Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: velero-plugin-for-aws
+            componentID: 5a377fe37b6cad35
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.25.6
+            componentType: go-module
+            componentLocation: /usr/bin/velero-plugin-for-aws
+            scanner: grype
+
   - id: CVE-2023-45288
     aliases:
       - GHSA-4v7x-pqxf-cx7m


### PR DESCRIPTION
```
$ wolfictl scan -r velero-plugin-for-aws
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-velero-plugin-for-aws-1.9.2-r1-2422178295.apk"
└── 📄 /usr/bin/velero-plugin-for-aws
        📦 k8s.io/apimachinery v0.25.6 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-velero-plugin-for-aws-1.9.2-r1-939344516.apk"
└── 📄 /usr/bin/velero-plugin-for-aws
        📦 k8s.io/apimachinery v0.25.6 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```