### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for k9s

### DIFF
--- a/k9s.advisories.yaml
+++ b/k9s.advisories.yaml
@@ -25,6 +25,23 @@ advisories:
         data:
           fixed-version: 0.32.4-r0
 
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:04:34Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: k9s
+            componentID: 8298d50d5e8cbc1c
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.3
+            componentType: go-module
+            componentLocation: /usr/bin/k9s
+            scanner: grype
+
   - id: CVE-2023-45288
     aliases:
       - GHSA-4v7x-pqxf-cx7m


### PR DESCRIPTION
```
$ wolfictl scan -r k9s
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-k9s-0.32.4-r2-1383462069.apk"
└── 📄 /usr/bin/k9s
        📦 github.com/mholt/archiver/v3 v3.5.1 (go-module)
            Medium CVE-2024-0406 GHSA-rhh4-rh7c-7r5v
        📦 k8s.io/apimachinery v0.29.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-k9s-0.32.4-r2-2717141851.apk"
└── 📄 /usr/bin/k9s
        📦 github.com/mholt/archiver/v3 v3.5.1 (go-module)
            Medium CVE-2024-0406 GHSA-rhh4-rh7c-7r5v
        📦 k8s.io/apimachinery v0.29.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```