### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for aactl

### DIFF
--- a/aactl.advisories.yaml
+++ b/aactl.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: aactl
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:05:08Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: aactl
+            componentID: ca5bef0266c640f9
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.28.3
+            componentType: go-module
+            componentLocation: /usr/bin/aactl
+            scanner: grype
+
   - id: CVE-2023-1732
     aliases:
       - GHSA-2q89-485c-9j2x


### PR DESCRIPTION
```
$ wolfictl scan -r aactl
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-aactl-0.4.12-r11-648050918.apk"
└── 📄 /usr/bin/aactl
        📦 k8s.io/apimachinery v0.28.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-aactl-0.4.12-r11-2384341189.apk"
└── 📄 /usr/bin/aactl
        📦 k8s.io/apimachinery v0.28.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```