### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for addon-resizer

### DIFF
--- a/addon-resizer.advisories.yaml
+++ b/addon-resizer.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: addon-resizer
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:06:24Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: addon-resizer
+            componentID: 45970c295c0b09dc
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.21.1
+            componentType: go-module
+            componentLocation: /usr/bin/pod_nanny
+            scanner: grype
+
   - id: CVE-2023-45288
     aliases:
       - GHSA-4v7x-pqxf-cx7m


### PR DESCRIPTION
```
$ wolfictl scan -r addon-resizer
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-addon-resizer-1.8.20-r1-3275553570.apk"
└── 📄 /usr/bin/pod_nanny
        📦 k8s.io/apimachinery v0.21.1 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-addon-resizer-1.8.20-r1-3395113819.apk"
└── 📄 /usr/bin/pod_nanny
        📦 k8s.io/apimachinery v0.21.1 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```