### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for cosign

### DIFF
--- a/cosign.advisories.yaml
+++ b/cosign.advisories.yaml
@@ -14,6 +14,23 @@ advisories:
           type: component-vulnerability-mismatch
           note: The vulnerability is in an ancient CGI script of the same name
 
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:11:39Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: cosign
+            componentID: a086132d3e268cf6
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.28.3
+            componentType: go-module
+            componentLocation: /usr/bin/cosign
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r cosign
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-cosign-2.2.4-r0-1634545444.apk"
└── 📄 /usr/bin/cosign
        📦 golang.org/x/net v0.22.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.28.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-cosign-2.2.4-r0-465845925.apk"
└── 📄 /usr/bin/cosign
        📦 golang.org/x/net v0.22.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.28.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```