### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for aws-load-balancer-controller

### DIFF
--- a/aws-load-balancer-controller.advisories.yaml
+++ b/aws-load-balancer-controller.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: aws-load-balancer-controller
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:15:21Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: aws-load-balancer-controller
+            componentID: 1c53cc73bd938a40
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.26.5
+            componentType: go-module
+            componentLocation: /usr/bin/controller
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r aws-load-balancer-controller
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-aws-load-balancer-controller-2.7.2-r1-3833661651.apk"
└── 📄 /usr/bin/controller
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.26.5 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-aws-load-balancer-controller-2.7.2-r1-4016497909.apk"
└── 📄 /usr/bin/controller
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.26.5 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

```