### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for cert-exporter

### DIFF
--- a/cert-exporter.advisories.yaml
+++ b/cert-exporter.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: cert-exporter
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:18:55Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: cert-exporter
+            componentID: 2903f2804a8c3935
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.28.3
+            componentType: go-module
+            componentLocation: /usr/bin/cert-exporter
+            scanner: grype
+
   - id: CVE-2023-45288
     aliases:
       - GHSA-4v7x-pqxf-cx7m


### PR DESCRIPTION
```
$ wolfictl scan -r cert-exporter
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-cert-exporter-2.12.0-r4-1639070215.apk"
└── 📄 /usr/bin/cert-exporter
        📦 k8s.io/apimachinery v0.28.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-cert-exporter-2.12.0-r4-2295496711.apk"
└── 📄 /usr/bin/cert-exporter
        📦 k8s.io/apimachinery v0.28.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```