### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for k8ssandra-operator

### DIFF
--- a/k8ssandra-operator.advisories.yaml
+++ b/k8ssandra-operator.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: k8ssandra-operator
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:20:41Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: k8ssandra-operator
+            componentID: 9f275ca7b10107db
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.26.4
+            componentType: go-module
+            componentLocation: /usr/bin/manager
+            scanner: grype
+
   - id: CVE-2023-45288
     aliases:
       - GHSA-4v7x-pqxf-cx7m


### PR DESCRIPTION
```
$ wolfictl scan -r k8ssandra-operator
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-k8ssandra-operator-1.15.0-r0-2176934059.apk"
└── 📄 /usr/bin/manager
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.26.4 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-k8ssandra-operator-1.15.0-r0-4274115517.apk"
└── 📄 /usr/bin/manager
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.26.4 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```