### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for keda-2.13

### DIFF
--- a/keda-2.13.advisories.yaml
+++ b/keda-2.13.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: keda-2.13
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:25:35Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: keda-2.13
+            componentID: c36fbd3f538c4cac
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.28.5
+            componentType: go-module
+            componentLocation: /usr/bin/keda
+            scanner: grype
+
   - id: CVE-2023-45288
     aliases:
       - GHSA-4v7x-pqxf-cx7m


### PR DESCRIPTION
```
$ wolfictl scan -r keda-2.13
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-keda-2.13-2.13.1-r4-2808688871.apk"
└── 📄 /usr/bin/keda
        📦 k8s.io/apimachinery v0.28.5 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-keda-2.13-2.13.1-r4-3343034445.apk"
└── 📄 /usr/bin/keda
        📦 k8s.io/apimachinery v0.28.5 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```