### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for cass-operator

### DIFF
--- a/cass-operator.advisories.yaml
+++ b/cass-operator.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: cass-operator
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:29:54Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: cass-operator
+            componentID: ffb3e6770c476933
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.26.4
+            componentType: go-module
+            componentLocation: /usr/bin/manager
+            scanner: grype
+
   - id: CVE-2023-39326
     aliases:
       - GHSA-9f76-wg39-x86h


### PR DESCRIPTION
```
$ wolfictl scan -r cass-operator
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-cass-operator-1.19.1-r2-246054125.apk"
└── 📄 /usr/bin/manager
        📦 k8s.io/apimachinery v0.26.4 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-cass-operator-1.19.1-r2-669460404.apk"
└── 📄 /usr/bin/manager
        📦 k8s.io/apimachinery v0.26.4 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```