### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for apko

### DIFF
--- a/apko.advisories.yaml
+++ b/apko.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: apko
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:35:22Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: apko
+            componentID: 12fb944ecfe01557
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.28.3
+            componentType: go-module
+            componentLocation: /usr/bin/apko
+            scanner: grype
+
   - id: CVE-2023-28840
     aliases:
       - GHSA-232p-vwff-86mp


### PR DESCRIPTION
```
$ wolfictl scan -r apko
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-apko-0.14.0-r7-2470667130.apk"
└── 📄 /usr/bin/apko
        📦 k8s.io/apimachinery v0.28.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-apko-0.14.0-r7-198214890.apk"
└── 📄 /usr/bin/apko
        📦 k8s.io/apimachinery v0.28.3 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```