### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for bank-vaults

### DIFF
--- a/bank-vaults.advisories.yaml
+++ b/bank-vaults.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: bank-vaults
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:36:36Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: bank-vaults
+            componentID: aa5405a21368b6df
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.27.4
+            componentType: go-module
+            componentLocation: /usr/bin/bank-vaults
+            scanner: grype
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r bank-vaults
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-bank-vaults-1.20.4-r11-3919235192.apk"
└── 📄 /usr/bin/bank-vaults
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.27.4 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-bank-vaults-1.20.4-r11-2993982602.apk"
└── 📄 /usr/bin/bank-vaults
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.27.4 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13
```