### PR TITLE
Adding Advisory GHSA-33c5-9fx5-fvjm for gke-gcloud-auth-plugin

### DIFF
--- a/gke-gcloud-auth-plugin.advisories.yaml
+++ b/gke-gcloud-auth-plugin.advisories.yaml
@@ -4,6 +4,23 @@ package:
   name: gke-gcloud-auth-plugin
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T09:37:34Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: gke-gcloud-auth-plugin
+            componentID: 6746c3a096f271b8
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.26.0
+            componentType: go-module
+            componentLocation: /usr/bin/gke-gcloud-auth-plugin
+            scanner: grype
+
   - id: CVE-2022-41723
     aliases:
       - GHSA-vvpx-j8f3-3w6h


### PR DESCRIPTION
```
$ wolfictl scan -r gke-gcloud-auth-plugin
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-gke-gcloud-auth-plugin-0.0.2-r8-4123038378.apk"
└── 📄 /usr/bin/gke-gcloud-auth-plugin
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.26.0 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-gke-gcloud-auth-plugin-0.0.2-r8-3969548003.apk"
└── 📄 /usr/bin/gke-gcloud-auth-plugin
        📦 golang.org/x/net v0.17.0 (go-module)
            Medium CVE-2023-45288 GHSA-4v7x-pqxf-cx7m fixed in 0.23.0
        📦 k8s.io/apimachinery v0.26.0 (go-module)
            Medium CVE-2020-8559 GHSA-33c5-9fx5-fvjm fixed in 1.16.13

```