### PR TITLE
Adding Fixed Advisory GHSA-33c5-9fx5-fvjm for falcoctl

### DIFF
--- a/falcoctl.advisories.yaml
+++ b/falcoctl.advisories.yaml
@@ -4,6 +4,15 @@ package:
   name: falcoctl
 
 advisories:
+  - id: CVE-2020-8559
+    aliases:
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-26T09:08:24Z
+        type: fixed
+        data:
+          fixed-version: 0.7.3-r8
+
   - id: CVE-2023-39325
     aliases:
       - GHSA-4374-p667-p6c8


### PR DESCRIPTION
```
$ wolfictl scan -r falcoctl
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-falcoctl-0.7.3-r8-1089334878.apk"
✅ No vulnerabilities found
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-falcoctl-0.7.3-r8-273857540.apk"
✅ No vulnerabilities found

```