### PR TITLE
Adding Advisory GHSA-4v7x-pqxf-cx7m for nfs-subdir-external-provisioner

### DIFF
--- a/nfs-subdir-external-provisioner.advisories.yaml
+++ b/nfs-subdir-external-provisioner.advisories.yaml
@@ -42,6 +42,23 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
 
+  - id: CVE-2023-45288
+    aliases:
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-26T09:12:18Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: nfs-subdir-external-provisioner
+            componentID: 04a90eb0cbd571b3
+            componentName: golang.org/x/net
+            componentVersion: v0.17.0
+            componentType: go-module
+            componentLocation: /usr/bin/nfs-subdir-external-provisioner
+            scanner: grype
+
   - id: CVE-2023-45289
     aliases:
       - GHSA-32ch-6x54-q4h9


### PR DESCRIPTION
removing the fix which is not correct and adding the detection for that