### PR TITLE
Adding Fixed Advisory GHSA-f4w6-3rh6-6q4q for kubernetes-csi-external-provisioner

### DIFF
--- a/kubernetes-csi-external-provisioner.advisories.yaml
+++ b/kubernetes-csi-external-provisioner.advisories.yaml
@@ -4,6 +4,15 @@ package:
   name: kubernetes-csi-external-provisioner
 
 advisories:
+  - id: CVE-2019-11255
+    aliases:
+      - GHSA-f4w6-3rh6-6q4q
+    events:
+      - timestamp: 2024-04-26T09:42:56Z
+        type: fixed
+        data:
+          fixed-version: 4.0.1-r1
+
   - id: CVE-2020-8552
     aliases:
       - GHSA-82hx-w2r5-c2wq


### PR DESCRIPTION
```
$ wolfictl scan -r kubernetes-csi-external-provisioner
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-kubernetes-csi-external-provisioner-4.0.1-r1-410585242.apk"
✅ No vulnerabilities found
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-kubernetes-csi-external-provisioner-4.0.1-r1-1665945901.apk"
✅ No vulnerabilities found
```