### PR TITLE
Adding Fixed Advisory GHSA-25w4-hfqg-4r52 for keycloak

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -253,6 +253,15 @@ advisories:
             netty-handler is a dependency of Quarkus, which is used by Keycloak. For more detail:
             https://github.com/netty/netty/issues/8537
 
+  - id: CVE-2023-5675
+    aliases:
+      - GHSA-25w4-hfqg-4r52
+    events:
+      - timestamp: 2024-04-26T12:17:00Z
+        type: fixed
+        data:
+          fixed-version: 24.0.3-r1
+
   - id: CVE-2023-6544
     aliases:
       - GHSA-46c8-635v-68r2


### PR DESCRIPTION
```
$ wolfictl scan -r keycloak
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-keycloak-24.0.3-r1-812883173.apk"
✅ No vulnerabilities found
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-keycloak-24.0.3-r1-1878639905.apk"
✅ No vulnerabilities found
```