### PR TITLE
Adding Fixed Advisory GHSA-9m6p-x4h2-6frq for argo-cd-2.10

### DIFF
--- a/argo-cd-2.10.advisories.yaml
+++ b/argo-cd-2.10.advisories.yaml
@@ -101,3 +101,12 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.10.7-r0
+
+  - id: CVE-2024-32476
+    aliases:
+      - GHSA-9m6p-x4h2-6frq
+    events:
+      - timestamp: 2024-04-27T09:02:19Z
+        type: fixed
+        data:
+          fixed-version: 2.10.8-r0


### PR DESCRIPTION
```
$ wolfictl scan -r argo-cd-2.10
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-argo-cd-2.10-2.10.8-r0-3432775502.apk"
└── 📄 /usr/bin/argocd
        📦 k8s.io/kubernetes v1.26.11 (go-module)
            Low CVE-2024-3177 GHSA-pxhw-596r-rwq5 fixed in 1.27.13

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-argo-cd-2.10-2.10.8-r0-3566933269.apk"
└── 📄 /usr/bin/argocd
        📦 k8s.io/kubernetes v1.26.11 (go-module)
            Low CVE-2024-3177 GHSA-pxhw-596r-rwq5 fixed in 1.27.13
```