### PR TITLE
update advisory to pending-upstream-fix

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -379,6 +379,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 24.0.3-r1
+      - timestamp: 2024-05-01T14:55:00Z
+        type: pending-upstream-fix
+        data:
+          note: quarkus > v3.8.3 is affected by this vulnerability. Bumping this version to v3.8.4 or v3.9.x caused runtime issues. Waiting for upstream to fix in a future release.
 
   - id: CVE-2024-29025
     aliases:


### PR DESCRIPTION
See:
https://github.com/chainguard-dev/image-release-stats/issues/108

