### PR TITLE
More triaging w/ `wolfictl adv triage`

### DIFF
--- a/cilium-1.15.advisories.yaml
+++ b/cilium-1.15.advisories.yaml
@@ -20,6 +20,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-dbg
             scanner: grype
+      - timestamp: 2024-05-05T14:39:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.9.16).'
 
   - id: CVE-2022-29179
     aliases:
@@ -37,6 +42,11 @@ advisories:
             componentType: go-module
             componentLocation: /opt/cni/bin/cilium-cni
             scanner: grype
+      - timestamp: 2024-05-05T14:39:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.9.16).'
 
   - id: CVE-2023-27593
     aliases:
@@ -54,6 +64,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-sysctlfix
             scanner: grype
+      - timestamp: 2024-05-05T14:39:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.11.15).'
 
   - id: CVE-2023-27594
     aliases:
@@ -71,6 +86,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-sysctlfix
             scanner: grype
+      - timestamp: 2024-05-05T14:39:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.11.15).'
 
   - id: CVE-2023-30851
     aliases:
@@ -88,6 +108,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-bugtool
             scanner: grype
+      - timestamp: 2024-05-05T14:39:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.11.16).'
 
   - id: CVE-2023-39347
     aliases:
@@ -105,6 +130,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-health
             scanner: grype
+      - timestamp: 2024-05-05T14:39:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.12.14).'
 
   - id: CVE-2023-41332
     aliases:
@@ -122,6 +152,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-mount
             scanner: grype
+      - timestamp: 2024-05-05T14:39:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.12.14).'
 
   - id: CVE-2023-41333
     aliases:
@@ -139,6 +174,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-health-responder
             scanner: grype
+      - timestamp: 2024-05-05T14:39:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.12.14).'
 
   - id: CVE-2023-45288
     aliases:
@@ -198,6 +238,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-health-responder
             scanner: grype
+      - timestamp: 2024-05-05T14:39:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.14.7).'
 
   - id: CVE-2024-25631
     aliases:
@@ -215,6 +260,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-sysctlfix
             scanner: grype
+      - timestamp: 2024-05-05T14:39:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.14.7).'
 
   - id: CVE-2024-28180
     aliases:
@@ -273,6 +323,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-health-responder
             scanner: grype
+      - timestamp: 2024-05-05T14:39:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.10.14).'
 
   - id: GHSA-wc5v-r48v-g4vh
     events:
@@ -288,3 +343,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cilium-health-responder
             scanner: grype
+      - timestamp: 2024-05-05T14:39:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/cilium/cilium" at the following location(s): /opt/cni/bin/cilium-cni, /usr/bin/cilium-agent, /usr/bin/cilium-bugtool, /usr/bin/cilium-dbg, /usr/bin/cilium-health, /usr/bin/cilium-health-responder, /usr/bin/cilium-mount, /usr/bin/cilium-sysctlfix. In all cases, the installed version of the module (git commit 9b3f9a8c0d71bf70bc0fd3fbc256bacc67fe6c32) corresponds to a version tag (1.15.4) that is later than the fixed version (1.10.13).'

--- a/coredns.advisories.yaml
+++ b/coredns.advisories.yaml
@@ -262,3 +262,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/coredns
             scanner: grype
+      - timestamp: 2024-05-05T15:17:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/coredns/coredns" at the following location(s): /usr/bin/coredns. In all cases, the fixed version of the module (git commit 6a7a75e0cc14159177e604d0157836cc32add343) is an ancestor of the installed version commit (a7ed346585e30b99317d36e4d007b7b19a228ea5).'

--- a/crossplane.advisories.yaml
+++ b/crossplane.advisories.yaml
@@ -20,6 +20,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/crossplane
             scanner: grype
+      - timestamp: 2024-05-05T14:56:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/crossplane/crossplane" at the following location(s): /usr/bin/crossplane. In all cases, the installed version of the module (git commit 432e1637f677bf46e3fa5b84211bc903141409bb) corresponds to a version tag (v1.15.2) that is later than the fixed version (1.9.2).'
 
   - id: CVE-2023-37900
     aliases:
@@ -37,6 +42,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/crossplane
             scanner: grype
+      - timestamp: 2024-05-05T14:56:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/crossplane/crossplane" at the following location(s): /usr/bin/crossplane. In all cases, the installed version of the module (git commit 432e1637f677bf46e3fa5b84211bc903141409bb) corresponds to a version tag (v1.15.2) that is later than the fixed version (1.11.5).'
 
   - id: CVE-2023-38495
     aliases:
@@ -54,6 +64,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/crossplane
             scanner: grype
+      - timestamp: 2024-05-05T14:56:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/crossplane/crossplane" at the following location(s): /usr/bin/crossplane. In all cases, the installed version of the module (git commit 432e1637f677bf46e3fa5b84211bc903141409bb) corresponds to a version tag (v1.15.2) that is later than the fixed version (1.11.5).'
 
   - id: CVE-2023-45283
     aliases:

--- a/hugo.advisories.yaml
+++ b/hugo.advisories.yaml
@@ -20,6 +20,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/hugo
             scanner: grype
+      - timestamp: 2024-05-05T15:18:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/gohugoio/hugo" at the following location(s): /usr/bin/hugo. In all cases, the installed version of the module (git commit c8b9f9f81c375f5b391e61bae711ee63fc76c1fd) corresponds to a version tag (v0.125.5) that is later than the fixed version (0.79.1).'
 
   - id: CVE-2023-39325
     aliases:

--- a/kyverno.advisories.yaml
+++ b/kyverno.advisories.yaml
@@ -75,6 +75,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kyverno
             scanner: grype
+      - timestamp: 2024-05-05T15:27:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/kyverno/kyverno" at the following location(s): /usr/bin/kyverno. In all cases, the installed version of the module (git commit 84fba8e2448df1ee306d33379f4fb831e8f1381e) corresponds to a version tag (v1.12.1) that is later than the fixed version (1.10.0).'
 
   - id: CVE-2023-39325
     aliases:
@@ -178,6 +183,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kyverno
             scanner: grype
+      - timestamp: 2024-05-05T15:27:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/kyverno/kyverno" at the following location(s): /usr/bin/kyverno. In all cases, the installed version of the module (git commit 84fba8e2448df1ee306d33379f4fb831e8f1381e) corresponds to a version tag (v1.12.1) that is later than the fixed version (1.10.5).'
 
   - id: CVE-2023-48795
     aliases:
@@ -306,6 +316,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kyverno
             scanner: grype
+      - timestamp: 2024-05-05T15:27:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'A govulncheck analysis found that none of the known affected symbols were present in the APK, after examining the following paths within the package: /usr/bin/kyverno.'
 
   - id: GHSA-2c7c-3mj9-8fqh
     events:
@@ -351,6 +366,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kyverno
             scanner: grype
+      - timestamp: 2024-05-05T15:27:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/kyverno/kyverno" at the following location(s): /usr/bin/kyverno. In all cases, the installed version of the module (git commit 84fba8e2448df1ee306d33379f4fb831e8f1381e) corresponds to a version tag (v1.12.1) that is later than the fixed version (1.9.5).'
 
   - id: GHSA-jq35-85cj-fj4p
     events:


### PR DESCRIPTION
```
( - removed / ~ modified / + added )

~ document "cilium-1.15"
  ~ advisory "CVE-2022-29178"
    + event "false-positive-determination" @ 2024-05-05T14:39:55Z
  ~ advisory "CVE-2022-29179"
    + event "false-positive-determination" @ 2024-05-05T14:39:56Z
  ~ advisory "CVE-2023-27593"
    + event "false-positive-determination" @ 2024-05-05T14:39:53Z
  ~ advisory "CVE-2023-27594"
    + event "false-positive-determination" @ 2024-05-05T14:39:56Z
  ~ advisory "CVE-2023-30851"
    + event "false-positive-determination" @ 2024-05-05T14:39:53Z
  ~ advisory "CVE-2023-39347"
    + event "false-positive-determination" @ 2024-05-05T14:39:56Z
  ~ advisory "CVE-2023-41332"
    + event "false-positive-determination" @ 2024-05-05T14:39:52Z
  ~ advisory "CVE-2023-41333"
    + event "false-positive-determination" @ 2024-05-05T14:39:54Z
  ~ advisory "CVE-2024-25630"
    + event "false-positive-determination" @ 2024-05-05T14:39:56Z
  ~ advisory "CVE-2024-25631"
    + event "false-positive-determination" @ 2024-05-05T14:39:57Z
  ~ advisory "GHSA-pfhr-pccp-hwmh"
    + event "false-positive-determination" @ 2024-05-05T14:39:56Z
  ~ advisory "GHSA-wc5v-r48v-g4vh"
    + event "false-positive-determination" @ 2024-05-05T14:39:57Z
~ document "coredns"
  ~ advisory "GHSA-gv9j-4w24-q7vx"
    + event "false-positive-determination" @ 2024-05-05T15:17:04Z
~ document "crossplane"
  ~ advisory "CVE-2023-27484"
    + event "false-positive-determination" @ 2024-05-05T14:56:57Z
  ~ advisory "CVE-2023-37900"
    + event "false-positive-determination" @ 2024-05-05T14:56:57Z
  ~ advisory "CVE-2023-38495"
    + event "false-positive-determination" @ 2024-05-05T14:56:57Z
~ document "hugo"
  ~ advisory "CVE-2020-26284"
    + event "false-positive-determination" @ 2024-05-05T15:18:07Z
~ document "kyverno"
  ~ advisory "CVE-2023-34091"
    + event "false-positive-determination" @ 2024-05-05T15:27:03Z
  ~ advisory "CVE-2023-47630"
    + event "false-positive-determination" @ 2024-05-05T15:27:02Z
  ~ advisory "CVE-2024-29018"
    + event "false-positive-determination" @ 2024-05-05T15:27:03Z
  ~ advisory "GHSA-hgv6-w7r3-w4qw"
    + event "false-positive-determination" @ 2024-05-05T15:27:02Z
```