### PR TITLE
More triaging w/ `wolfictl adv triage`

### DIFF
--- a/calico.advisories.yaml
+++ b/calico.advisories.yaml
@@ -57,6 +57,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/calico-filecheck
             scanner: grype
+      - timestamp: 2024-05-06T00:09:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/projectcalico/calico" at the following location(s): /usr/bin/calicoctl. In all cases, the installed version of the module (git commit 638464f946657417dd4900724112eb844ce5be03) corresponds to a version tag (v3.27.3) that is later than the fixed version (3.20.5).'
 
   - id: CVE-2023-2727
     aliases:
@@ -101,6 +106,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/calico-apiserver
             scanner: grype
+      - timestamp: 2024-05-06T00:09:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "github.com/projectcalico/calico" at the following location(s): /usr/bin/calicoctl. In all cases, the installed version of the module (git commit 638464f946657417dd4900724112eb844ce5be03) corresponds to a version tag (v3.27.3) that is later than the fixed version (3.26.3).'
 
   - id: CVE-2023-44487
     aliases:

--- a/ingress-nginx-controller.advisories.yaml
+++ b/ingress-nginx-controller.advisories.yaml
@@ -54,6 +54,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/nginx-ingress-controller
             scanner: grype
+      - timestamp: 2024-05-06T00:32:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "k8s.io/ingress-nginx" at the following location(s): /usr/bin/nginx-dbg, /usr/bin/nginx-ingress-controller, /usr/bin/waitshutdown. In all cases, the fixed version of the module (git commit 6d9a39eda7b180f27b34726d7a7a96d73808ce75) is an ancestor of the installed version commit (51847ac1b537c547cdb7bfb06d14e6d3d8476a73).'
 
   - id: CVE-2021-25748
     aliases:
@@ -71,6 +76,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/waitshutdown
             scanner: grype
+      - timestamp: 2024-05-06T00:32:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "k8s.io/ingress-nginx" at the following location(s): /usr/bin/nginx-dbg, /usr/bin/nginx-ingress-controller, /usr/bin/waitshutdown. In all cases, the fixed version of the module (git commit c32f9a43279425920c41ba2e54dfcb1a54c0daf7) is an ancestor of the installed version commit (51847ac1b537c547cdb7bfb06d14e6d3d8476a73).'
 
   - id: CVE-2022-41741
     aliases:

--- a/istio-cni-1.21.advisories.yaml
+++ b/istio-cni-1.21.advisories.yaml
@@ -20,6 +20,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/istio-cni
             scanner: grype
+      - timestamp: 2024-05-06T00:43:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/istio-cni. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.1.13).'
 
   - id: CVE-2021-39155
     aliases:
@@ -37,6 +42,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/istio-cni
             scanner: grype
+      - timestamp: 2024-05-06T00:43:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/istio-cni. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.9.8).'
 
   - id: CVE-2021-39156
     aliases:
@@ -54,6 +64,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/istio-cni
             scanner: grype
+      - timestamp: 2024-05-06T00:43:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/istio-cni. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.9.8).'
 
   - id: CVE-2022-23635
     aliases:
@@ -71,6 +86,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/istio-cni
             scanner: grype
+      - timestamp: 2024-05-06T00:43:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/istio-cni. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.11.7).'
 
   - id: CVE-2022-31045
     aliases:

--- a/istio-operator-1.21.advisories.yaml
+++ b/istio-operator-1.21.advisories.yaml
@@ -20,6 +20,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/operator
             scanner: grype
+      - timestamp: 2024-05-06T00:48:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/operator. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.1.13).'
 
   - id: CVE-2019-25210
     aliases:
@@ -76,6 +81,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/operator
             scanner: grype
+      - timestamp: 2024-05-06T00:48:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/operator. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.9.8).'
 
   - id: CVE-2021-39156
     aliases:
@@ -93,6 +103,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/operator
             scanner: grype
+      - timestamp: 2024-05-06T00:48:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/operator. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.9.8).'
 
   - id: CVE-2022-23635
     aliases:
@@ -110,6 +125,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/operator
             scanner: grype
+      - timestamp: 2024-05-06T00:48:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/operator. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.11.7).'
 
   - id: CVE-2022-31045
     aliases:

--- a/istio-pilot-agent-1.21.advisories.yaml
+++ b/istio-pilot-agent-1.21.advisories.yaml
@@ -20,6 +20,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pilot-agent
             scanner: grype
+      - timestamp: 2024-05-06T00:49:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/pilot-agent. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.1.13).'
 
   - id: CVE-2021-39155
     aliases:
@@ -37,6 +42,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pilot-agent
             scanner: grype
+      - timestamp: 2024-05-06T00:49:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/pilot-agent. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.9.8).'
 
   - id: CVE-2021-39156
     aliases:
@@ -54,6 +64,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pilot-agent
             scanner: grype
+      - timestamp: 2024-05-06T00:49:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/pilot-agent. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.9.8).'
 
   - id: CVE-2022-23635
     aliases:
@@ -71,6 +86,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pilot-agent
             scanner: grype
+      - timestamp: 2024-05-06T00:49:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/pilot-agent. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.11.7).'
 
   - id: CVE-2022-31045
     aliases:

--- a/istio-pilot-discovery-1.21.advisories.yaml
+++ b/istio-pilot-discovery-1.21.advisories.yaml
@@ -20,6 +20,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pilot-discovery
             scanner: grype
+      - timestamp: 2024-05-06T00:50:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/pilot-discovery. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.1.13).'
 
   - id: CVE-2021-39155
     aliases:
@@ -37,6 +42,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pilot-discovery
             scanner: grype
+      - timestamp: 2024-05-06T00:50:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/pilot-discovery. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.9.8).'
 
   - id: CVE-2021-39156
     aliases:
@@ -54,6 +64,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pilot-discovery
             scanner: grype
+      - timestamp: 2024-05-06T00:50:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/pilot-discovery. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.9.8).'
 
   - id: CVE-2022-23635
     aliases:
@@ -71,6 +86,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pilot-discovery
             scanner: grype
+      - timestamp: 2024-05-06T00:50:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/pilot-discovery. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.11.7).'
 
   - id: CVE-2022-31045
     aliases:


### PR DESCRIPTION
```
~ document "calico"
  ~ advisory "CVE-2022-28224"
    + event "false-positive-determination" @ 2024-05-06T00:09:48Z
  ~ advisory "CVE-2023-41378"
    + event "false-positive-determination" @ 2024-05-06T00:09:48Z
~ document "ingress-nginx-controller"
  ~ advisory "CVE-2021-25745"
    + event "false-positive-determination" @ 2024-05-06T00:32:04Z
  ~ advisory "CVE-2021-25748"
    + event "false-positive-determination" @ 2024-05-06T00:32:04Z
~ document "istio-cni-1.21"
  ~ advisory "CVE-2019-14993"
    + event "false-positive-determination" @ 2024-05-06T00:43:42Z
  ~ advisory "CVE-2021-39155"
    + event "false-positive-determination" @ 2024-05-06T00:43:42Z
  ~ advisory "CVE-2021-39156"
    + event "false-positive-determination" @ 2024-05-06T00:43:42Z
  ~ advisory "CVE-2022-23635"
    + event "false-positive-determination" @ 2024-05-06T00:43:42Z
~ document "istio-operator-1.21"
  ~ advisory "CVE-2019-14993"
    + event "false-positive-determination" @ 2024-05-06T00:48:49Z
  ~ advisory "CVE-2021-39155"
    + event "false-positive-determination" @ 2024-05-06T00:48:48Z
  ~ advisory "CVE-2021-39156"
    + event "false-positive-determination" @ 2024-05-06T00:48:48Z
  ~ advisory "CVE-2022-23635"
    + event "false-positive-determination" @ 2024-05-06T00:48:48Z
~ document "istio-pilot-agent-1.21"
  ~ advisory "CVE-2019-14993"
    + event "false-positive-determination" @ 2024-05-06T00:49:53Z
  ~ advisory "CVE-2021-39155"
    + event "false-positive-determination" @ 2024-05-06T00:49:52Z
  ~ advisory "CVE-2021-39156"
    + event "false-positive-determination" @ 2024-05-06T00:49:52Z
  ~ advisory "CVE-2022-23635"
    + event "false-positive-determination" @ 2024-05-06T00:49:52Z
~ document "istio-pilot-discovery-1.21"
  ~ advisory "CVE-2019-14993"
    + event "false-positive-determination" @ 2024-05-06T00:50:29Z
  ~ advisory "CVE-2021-39155"
    + event "false-positive-determination" @ 2024-05-06T00:50:28Z
  ~ advisory "CVE-2021-39156"
    + event "false-positive-determination" @ 2024-05-06T00:50:28Z
  ~ advisory "CVE-2022-23635"
    + event "false-positive-determination" @ 2024-05-06T00:50:28Z
```