### PR TITLE
adds keycloak-operator advisory

### DIFF
--- a/keycloak-operator.advisories.yaml
+++ b/keycloak-operator.advisories.yaml
@@ -1,0 +1,14 @@
+schema-version: 2.0.2
+
+package:
+  name: keycloak-operator
+
+advisories:
+  - id: CVE-2024-2700
+    aliases:
+      - GHSA-f8h5-v2vg-46rr
+    events:
+      - timestamp: 2024-05-06T12:44:19Z
+        type: pending-upstream-fix
+        data:
+          note: quarkus > v3.8.3 is affected by this vulnerability. Bumping this version to v3.8.4 or v3.9.x caused runtime issues. Waiting for upstream to fix in a future release.


### PR DESCRIPTION
I think we already have a similar [CVE adv for keycloak](https://github.com/wolfi-dev/advisories/blob/ec6438d28576369664567a2bf5442691fb6d02b6/keycloak.advisories.yaml#L362), this one is also needed for the keycloak-operator as the upstream fix has still to be released 