### PR TITLE
freerdp: add advisory entries

### DIFF
--- a/freerdp.advisories.yaml
+++ b/freerdp.advisories.yaml
@@ -25,6 +25,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-05-16T11:54:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The package is using v2.11.7 which includes a patch to fix this vulnerability in commit (2b9f30a2fa4b13559a367f7cbe158e1bafe0f482).
 
   - id: CVE-2024-32659
     events:
@@ -40,6 +45,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-05-16T11:53:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The package is using v2.11.7 which includes a patch to fix this vulnerability in commit (8b9ad6cf80a2233de22b3b5100d642d876ef9a6e).
 
   - id: CVE-2024-32660
     events:
@@ -55,6 +65,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-05-16T11:45:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The package is using v2.11.7 which includes a patch to fix this vulnerability in commit (0381b3bef6e09b17576445186d26a07ec3772b1a).
 
   - id: CVE-2024-32661
     events:
@@ -70,6 +85,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-05-16T11:50:16Z
+        type: pending-upstream-fix
+        data:
+          note: This package is locked to its v2 version while the patches for this vulnerability are only available for v3 version.
 
   - id: CVE-2024-32662
     events:
@@ -85,3 +104,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-05-16T11:52:13Z
+        type: pending-upstream-fix
+        data:
+          note: This package is locked to its v2 version while the patches for this vulnerability are only available for v3 version.


### PR DESCRIPTION
The following list of CVEs are found on the current package locked to a v2 version:

```
            Critical CVE-2024-32658
            Critical CVE-20[24](https://github.com/wolfi-dev/os/actions/runs/9071157066/job/24924415629#step:9:25)-32659
            High CVE-2024-32660
            High CVE-2024-3[26](https://github.com/wolfi-dev/os/actions/runs/9071157066/job/24924415629#step:9:27)61
            High CVE-2024-32662
```