### PR TITLE
Deleting a duplicated event entry for argo-cd-2.10

### DIFF
--- a/argo-cd-2.10.advisories.yaml
+++ b/argo-cd-2.10.advisories.yaml
@@ -96,10 +96,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: Any upgrade on the Kubernetes dependencies causes conflicts due to a strict dependency on github.com/argoproj/gitops-engine which supports Kubernetes v1.23 while the non-vulnerable code is on Kubernetes v1.27.13.
-      - timestamp: 2024-05-16T15:27:54Z
-        type: pending-upstream-fix
-        data:
-          note: Any upgrade on the Kubernetes dependencies causes conflicts due to a strict dependency on github.com/argoproj/gitops-engine which supports Kubernetes v1.23 while the non-vulnerable code is on Kubernetes v1.27.13.
 
   - id: CVE-2024-31990
     aliases:


### PR DESCRIPTION
By mistake, we added a duplicated event for the same CVE and type.