### PR TITLE
keycloak: Advisories for bouncycastle CVEs

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -405,6 +405,33 @@ advisories:
         data:
           fixed-version: 24.0.2-r1
 
+  - id: CVE-2024-29857
+    aliases:
+      - GHSA-8xfc-gm6g-vgpv
+    events:
+      - timestamp: 2024-05-22T04:50:41Z
+        type: pending-upstream-fix
+        data:
+          note: org.bouncycastle packages cannot be upgraded without code changes from the upstream project. A number of packages and symbols have been refactored in the version that includes the CVE fixes (1.78).
+
+  - id: CVE-2024-30171
+    aliases:
+      - GHSA-v435-xc8x-wvr9
+    events:
+      - timestamp: 2024-05-22T04:50:16Z
+        type: pending-upstream-fix
+        data:
+          note: org.bouncycastle packages cannot be upgraded without code changes from the upstream project. A number of packages and symbols have been refactored in the version that includes the CVE fixes (1.78).
+
+  - id: CVE-2024-30172
+    aliases:
+      - GHSA-m44j-cfrm-g8qc
+    events:
+      - timestamp: 2024-05-22T04:50:28Z
+        type: pending-upstream-fix
+        data:
+          note: org.bouncycastle packages cannot be upgraded without code changes from the upstream project. A number of packages and symbols have been refactored in the version that includes the CVE fixes (1.78).
+
   - id: CVE-2024-34447
     aliases:
       - GHSA-4h8f-2wvx-gg5w
@@ -421,6 +448,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/keycloak/bin/client/lib/bcprov-jdk18on-1.77.jar
             scanner: grype
+      - timestamp: 2024-05-22T04:48:55Z
+        type: pending-upstream-fix
+        data:
+          note: org.bouncycastle packages cannot be upgraded without code changes from the upstream project. A number of packages and symbols have been refactored in the version that includes the CVE fixes (1.78).
 
   - id: GHSA-9vm7-v8wj-3fqw
     events:


### PR DESCRIPTION
Unfortunately, it's quite difficult to upgrade the library to version 1.78 since a large number of files have been moved in the provider. The upstream project (keycloak) will have to introduce code changes to make the upgrade possible