### PR TITLE
jenkins: Advisories for bouncycastle CVEs

### DIFF
--- a/jenkins.advisories.yaml
+++ b/jenkins.advisories.yaml
@@ -236,6 +236,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/jenkins/jenkins.war
             scanner: grype
+      - timestamp: 2024-05-27T04:50:45Z
+        type: pending-upstream-fix
+        data:
+          note: 'Bouncycastle cannot be upgraded directly in jenkins. The upstream project needs to upgrade the API plugin first: https://github.com/jenkinsci/bouncycastle-api-plugin'
 
   - id: CVE-2024-30171
     aliases:
@@ -253,6 +257,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/jenkins/jenkins.war
             scanner: grype
+      - timestamp: 2024-05-27T04:51:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'Bouncycastle cannot be upgraded directly in jenkins. The upstream project needs to upgrade the API plugin first: https://github.com/jenkinsci/bouncycastle-api-plugin'
 
   - id: CVE-2024-30172
     aliases:
@@ -270,6 +278,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/jenkins/jenkins.war
             scanner: grype
+      - timestamp: 2024-05-27T04:50:53Z
+        type: pending-upstream-fix
+        data:
+          note: 'Bouncycastle cannot be upgraded directly in jenkins. The upstream project needs to upgrade the API plugin first: https://github.com/jenkinsci/bouncycastle-api-plugin'
 
   - id: CVE-2024-34144
     aliases:
@@ -329,6 +341,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/jenkins/jenkins.war
             scanner: grype
+      - timestamp: 2024-05-27T04:50:31Z
+        type: pending-upstream-fix
+        data:
+          note: 'Bouncycastle cannot be upgraded directly in jenkins. The upstream project needs to upgrade the API plugin first: https://github.com/jenkinsci/bouncycastle-api-plugin'
 
   - id: GHSA-58qw-p7qm-5rvh
     events:


### PR DESCRIPTION
Upgrading bouncycastle from jenkins directly isn't working.