### PR TITLE
opensearch-2: advisory entry for bouncycastle CVEs

### DIFF
--- a/opensearch-2.advisories.yaml
+++ b/opensearch-2.advisories.yaml
@@ -162,6 +162,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/opensearch/lib/tools/plugin-cli/bc-fips-1.0.2.4.jar
             scanner: grype
+      - timestamp: 2024-05-30T23:00:31Z
+        type: pending-upstream-fix
+        data:
+          note: The subpackage opensearch-performance-analyzer compilation hardcodes the cloning a specific branch of opensearch-performance-analyzer-rca repository with the vulnerable libraries. This requires upstream changes to opensearch-performance-analyzer-rca repository.
 
   - id: CGA-35r6-m6p6-xc93
     aliases:
@@ -180,6 +184,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/opensearch/plugins/opensearch-identity-shiro/bcprov-jdk18on-1.77.jar
             scanner: grype
+      - timestamp: 2024-05-30T23:00:31Z
+        type: pending-upstream-fix
+        data:
+          note: The subpackage opensearch-performance-analyzer compilation hardcodes the cloning a specific branch of opensearch-performance-analyzer-rca repository with the vulnerable libraries. This requires upstream changes to opensearch-performance-analyzer-rca repository.
 
   - id: CGA-h94h-f38q-chh8
     aliases:
@@ -198,6 +206,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/opensearch/plugins/opensearch-identity-shiro/bcprov-jdk18on-1.77.jar
             scanner: grype
+      - timestamp: 2024-05-30T23:00:31Z
+        type: pending-upstream-fix
+        data:
+          note: The subpackage opensearch-performance-analyzer compilation hardcodes the cloning a specific branch of opensearch-performance-analyzer-rca repository with the vulnerable libraries. This requires upstream changes to opensearch-performance-analyzer-rca repository.
 
   - id: CGA-2wgv-29fq-xg2j
     aliases:
@@ -216,3 +228,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/opensearch/plugins/opensearch-identity-shiro/bcprov-jdk18on-1.77.jar
             scanner: grype
+      - timestamp: 2024-05-30T23:00:31Z
+        type: pending-upstream-fix
+        data:
+          note: The subpackage opensearch-performance-analyzer compilation hardcodes the cloning a specific branch of opensearch-performance-analyzer-rca repository with the vulnerable libraries. This requires upstream changes to opensearch-performance-analyzer-rca repository.


### PR DESCRIPTION
opensearch-2 compilation scripts clone a specific branch of `performance-analyzer-rca repo`  in https://github.com/opensearch-project/performance-analyzer/blob/2.14.0.0/build.gradle#L84 repository with the vulnerable code. That repository needs to upgrade these vulnerable versions.