### PR TITLE
octo-sts advisory update

### DIFF
--- a/octo-sts.advisories.yaml
+++ b/octo-sts.advisories.yaml
@@ -21,3 +21,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/octo-sts
             scanner: grype
+      - timestamp: 2024-06-03T19:24:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: vulnerable version is v<0.1.0 and wolfi uses 0.2.0


### PR DESCRIPTION
[GHSA-75r6-6jg8-pfcq](https://github.com/advisories/GHSA-75r6-6jg8-pfcq) is not an issue for octo-sts, as Wolfi uses v0.2.0 and the vulnerability is only present in v<0.1.0. 