### PR TITLE
openjdk-*: CVE-2024-20932 is a false positive

### DIFF
--- a/openjdk-10.advisories.yaml
+++ b/openjdk-10.advisories.yaml
@@ -4,127 +4,19 @@ package:
   name: openjdk-10
 
 advisories:
-  - id: CGA-x553-263x-w5r4
+  - id: CGA-3c74-2v6w-g9p4
     aliases:
-      - CVE-2023-21930
-      - GHSA-4j35-7cr4-3mc8
+      - CVE-2024-21085
+      - GHSA-273j-fjrx-gf2f
     events:
-      - timestamp: 2024-03-31T13:27:52Z
+      - timestamp: 2024-04-19T13:09:12Z
         type: detection
         data:
           type: scan/v1
           data:
-            subpackageName: openjdk-10-demos
-            componentID: 2817ff019ab111ef
-            componentName: openjdk-10-demos
-            componentVersion: 10.0.2-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-qgpm-xhx2-5pjp
-    aliases:
-      - CVE-2023-21937
-      - GHSA-vr26-5f5w-r829
-    events:
-      - timestamp: 2024-03-31T13:28:23Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-10-demos
-            componentID: 2817ff019ab111ef
-            componentName: openjdk-10-demos
-            componentVersion: 10.0.2-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-5x4h-8frw-6cx4
-    aliases:
-      - CVE-2023-21938
-      - GHSA-9pqg-44mx-r5gr
-    events:
-      - timestamp: 2024-03-31T13:29:33Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-10-demos
-            componentID: 2817ff019ab111ef
-            componentName: openjdk-10-demos
-            componentVersion: 10.0.2-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-653g-v393-grqx
-    aliases:
-      - CVE-2023-21939
-      - GHSA-xfrf-5cgw-f964
-    events:
-      - timestamp: 2024-03-31T13:31:28Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-10-demos
-            componentID: 2817ff019ab111ef
-            componentName: openjdk-10-demos
-            componentVersion: 10.0.2-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-qxm6-59qp-ccpf
-    aliases:
-      - CVE-2023-21954
-      - GHSA-8x3h-4f64-v6v6
-    events:
-      - timestamp: 2024-03-31T13:35:32Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-10-demos
-            componentID: 2817ff019ab111ef
-            componentName: openjdk-10-demos
-            componentVersion: 10.0.2-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-wfxh-c4fv-4383
-    aliases:
-      - CVE-2023-21967
-      - GHSA-wg7x-fvjp-r3fx
-    events:
-      - timestamp: 2024-03-31T13:38:54Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-10-demos
-            componentID: 2817ff019ab111ef
-            componentName: openjdk-10-demos
-            componentVersion: 10.0.2-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-j5qg-p276-q8fq
-    aliases:
-      - CVE-2023-21968
-      - GHSA-r6j2-4r52-mpg7
-    events:
-      - timestamp: 2024-03-31T13:41:30Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-10-demos
-            componentID: 2817ff019ab111ef
-            componentName: openjdk-10-demos
+            subpackageName: openjdk-10-doc
+            componentID: 1dcdbfaef83f18d0
+            componentName: openjdk-10-doc
             componentVersion: 10.0.2-r4
             componentType: apk
             componentLocation: /.PKGINFO
@@ -166,12 +58,66 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-phgm-jqj3-mcpq
+  - id: CGA-5r87-8qp7-jmrv
     aliases:
-      - CVE-2024-20918
-      - GHSA-45pc-2866-5hxx
+      - CVE-2024-21094
+      - GHSA-g3wm-f7gr-3fwh
     events:
-      - timestamp: 2024-04-13T07:42:28Z
+      - timestamp: 2024-04-19T13:09:14Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-10-doc
+            componentID: 1dcdbfaef83f18d0
+            componentName: openjdk-10-doc
+            componentVersion: 10.0.2-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-5x4h-8frw-6cx4
+    aliases:
+      - CVE-2023-21938
+      - GHSA-9pqg-44mx-r5gr
+    events:
+      - timestamp: 2024-03-31T13:29:33Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-10-demos
+            componentID: 2817ff019ab111ef
+            componentName: openjdk-10-demos
+            componentVersion: 10.0.2-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-653g-v393-grqx
+    aliases:
+      - CVE-2023-21939
+      - GHSA-xfrf-5cgw-f964
+    events:
+      - timestamp: 2024-03-31T13:31:28Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-10-demos
+            componentID: 2817ff019ab111ef
+            componentName: openjdk-10-demos
+            componentVersion: 10.0.2-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-85fg-mp4w-g52f
+    aliases:
+      - CVE-2024-20945
+      - GHSA-qj64-r5h2-w6f9
+    events:
+      - timestamp: 2024-04-13T07:42:34Z
         type: detection
         data:
           type: scan/v1
@@ -202,12 +148,12 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-qf4g-cwf8-2fh9
+  - id: CGA-hjgc-m4pq-g9mg
     aliases:
-      - CVE-2024-20921
-      - GHSA-hxqj-hr64-7vf7
+      - CVE-2024-20926
+      - GHSA-hjh6-9v4w-w32w
     events:
-      - timestamp: 2024-04-13T07:42:31Z
+      - timestamp: 2024-04-13T07:42:32Z
         type: detection
         data:
           type: scan/v1
@@ -220,12 +166,12 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-hjgc-m4pq-g9mg
+  - id: CGA-j5qg-p276-q8fq
     aliases:
-      - CVE-2024-20926
-      - GHSA-hjh6-9v4w-w32w
+      - CVE-2023-21968
+      - GHSA-r6j2-4r52-mpg7
     events:
-      - timestamp: 2024-04-13T07:42:32Z
+      - timestamp: 2024-03-31T13:41:30Z
         type: detection
         data:
           type: scan/v1
@@ -255,31 +201,18 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
-
-  - id: CGA-85fg-mp4w-g52f
-    aliases:
-      - CVE-2024-20945
-      - GHSA-qj64-r5h2-w6f9
-    events:
-      - timestamp: 2024-04-13T07:42:34Z
-        type: detection
+      - timestamp: 2024-06-05T12:27:37Z
+        type: false-positive-determination
         data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-10-demos
-            componentID: 2817ff019ab111ef
-            componentName: openjdk-10-demos
-            componentVersion: 10.0.2-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
+          type: vulnerable-code-version-not-used
+          note: NVD record says the affected version is 17.0.9, not a version range.
 
-  - id: CGA-v5hv-pv7q-6657
+  - id: CGA-phgm-jqj3-mcpq
     aliases:
-      - CVE-2024-20952
-      - GHSA-343v-9ccv-7535
+      - CVE-2024-20918
+      - GHSA-45pc-2866-5hxx
     events:
-      - timestamp: 2024-03-31T13:48:22Z
+      - timestamp: 2024-04-13T07:42:28Z
         type: detection
         data:
           type: scan/v1
@@ -310,19 +243,55 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-wcmw-97v5-xh38
+  - id: CGA-qf4g-cwf8-2fh9
     aliases:
-      - CVE-2024-21012
-      - GHSA-ccmh-gwpx-35xj
+      - CVE-2024-20921
+      - GHSA-hxqj-hr64-7vf7
     events:
-      - timestamp: 2024-04-19T13:09:07Z
+      - timestamp: 2024-04-13T07:42:31Z
         type: detection
         data:
           type: scan/v1
           data:
-            subpackageName: openjdk-10-doc
-            componentID: 1dcdbfaef83f18d0
-            componentName: openjdk-10-doc
+            subpackageName: openjdk-10-demos
+            componentID: 2817ff019ab111ef
+            componentName: openjdk-10-demos
+            componentVersion: 10.0.2-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-qgpm-xhx2-5pjp
+    aliases:
+      - CVE-2023-21937
+      - GHSA-vr26-5f5w-r829
+    events:
+      - timestamp: 2024-03-31T13:28:23Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-10-demos
+            componentID: 2817ff019ab111ef
+            componentName: openjdk-10-demos
+            componentVersion: 10.0.2-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-qxm6-59qp-ccpf
+    aliases:
+      - CVE-2023-21954
+      - GHSA-8x3h-4f64-v6v6
+    events:
+      - timestamp: 2024-03-31T13:35:32Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-10-demos
+            componentID: 2817ff019ab111ef
+            componentName: openjdk-10-demos
             componentVersion: 10.0.2-r4
             componentType: apk
             componentLocation: /.PKGINFO
@@ -346,12 +315,30 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-3c74-2v6w-g9p4
+  - id: CGA-v5hv-pv7q-6657
     aliases:
-      - CVE-2024-21085
-      - GHSA-273j-fjrx-gf2f
+      - CVE-2024-20952
+      - GHSA-343v-9ccv-7535
     events:
-      - timestamp: 2024-04-19T13:09:12Z
+      - timestamp: 2024-03-31T13:48:22Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-10-demos
+            componentID: 2817ff019ab111ef
+            componentName: openjdk-10-demos
+            componentVersion: 10.0.2-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-wcmw-97v5-xh38
+    aliases:
+      - CVE-2024-21012
+      - GHSA-ccmh-gwpx-35xj
+    events:
+      - timestamp: 2024-04-19T13:09:07Z
         type: detection
         data:
           type: scan/v1
@@ -364,19 +351,37 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-5r87-8qp7-jmrv
+  - id: CGA-wfxh-c4fv-4383
     aliases:
-      - CVE-2024-21094
-      - GHSA-g3wm-f7gr-3fwh
+      - CVE-2023-21967
+      - GHSA-wg7x-fvjp-r3fx
     events:
-      - timestamp: 2024-04-19T13:09:14Z
+      - timestamp: 2024-03-31T13:38:54Z
         type: detection
         data:
           type: scan/v1
           data:
-            subpackageName: openjdk-10-doc
-            componentID: 1dcdbfaef83f18d0
-            componentName: openjdk-10-doc
+            subpackageName: openjdk-10-demos
+            componentID: 2817ff019ab111ef
+            componentName: openjdk-10-demos
+            componentVersion: 10.0.2-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-x553-263x-w5r4
+    aliases:
+      - CVE-2023-21930
+      - GHSA-4j35-7cr4-3mc8
+    events:
+      - timestamp: 2024-03-31T13:27:52Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-10-demos
+            componentID: 2817ff019ab111ef
+            componentName: openjdk-10-demos
             componentVersion: 10.0.2-r4
             componentType: apk
             componentLocation: /.PKGINFO

--- a/openjdk-11.advisories.yaml
+++ b/openjdk-11.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-06-05T12:28:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: NVD record says the affected version is 17.0.9, not a version range.
 
   - id: CGA-4v82-53j9-9r9q
     aliases:
@@ -28,26 +33,6 @@ advisories:
       - GHSA-7qqv-8pwc-x4xc
     events:
       - timestamp: 2024-04-19T07:19:59Z
-        type: fixed
-        data:
-          fixed-version: 11.0.23-r0
-
-  - id: CGA-ffm4-8jj3-39xw
-    aliases:
-      - CVE-2024-21012
-      - GHSA-ccmh-gwpx-35xj
-    events:
-      - timestamp: 2024-04-19T07:20:00Z
-        type: fixed
-        data:
-          fixed-version: 11.0.23-r0
-
-  - id: CGA-v333-j54p-w387
-    aliases:
-      - CVE-2024-21068
-      - GHSA-q4c6-w389-xqq6
-    events:
-      - timestamp: 2024-04-19T07:20:01Z
         type: fixed
         data:
           fixed-version: 11.0.23-r0
@@ -68,6 +53,26 @@ advisories:
       - GHSA-g3wm-f7gr-3fwh
     events:
       - timestamp: 2024-04-19T07:20:02Z
+        type: fixed
+        data:
+          fixed-version: 11.0.23-r0
+
+  - id: CGA-ffm4-8jj3-39xw
+    aliases:
+      - CVE-2024-21012
+      - GHSA-ccmh-gwpx-35xj
+    events:
+      - timestamp: 2024-04-19T07:20:00Z
+        type: fixed
+        data:
+          fixed-version: 11.0.23-r0
+
+  - id: CGA-v333-j54p-w387
+    aliases:
+      - CVE-2024-21068
+      - GHSA-q4c6-w389-xqq6
+    events:
+      - timestamp: 2024-04-19T07:20:01Z
         type: fixed
         data:
           fixed-version: 11.0.23-r0

--- a/openjdk-12.advisories.yaml
+++ b/openjdk-12.advisories.yaml
@@ -4,60 +4,6 @@ package:
   name: openjdk-12
 
 advisories:
-  - id: CGA-mc5f-2r2g-664c
-    aliases:
-      - CVE-2023-21930
-      - GHSA-4j35-7cr4-3mc8
-    events:
-      - timestamp: 2024-04-05T07:42:44Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-12-default-jdk
-            componentID: b89c941d8c7fcaaf
-            componentName: openjdk-12-default-jdk
-            componentVersion: 12.0.2.10-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-8xcc-wj36-grc9
-    aliases:
-      - CVE-2023-21937
-      - GHSA-vr26-5f5w-r829
-    events:
-      - timestamp: 2024-04-05T07:43:35Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-12-default-jdk
-            componentID: b89c941d8c7fcaaf
-            componentName: openjdk-12-default-jdk
-            componentVersion: 12.0.2.10-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-vg74-c9p6-rch7
-    aliases:
-      - CVE-2023-21938
-      - GHSA-9pqg-44mx-r5gr
-    events:
-      - timestamp: 2024-04-05T07:43:45Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-12-default-jdk
-            componentID: b89c941d8c7fcaaf
-            componentName: openjdk-12-default-jdk
-            componentVersion: 12.0.2.10-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
   - id: CGA-4m7f-x5rf-7hp5
     aliases:
       - CVE-2023-21939
@@ -76,66 +22,12 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-m29x-f3qq-6884
+  - id: CGA-7f27-vg24-rjj5
     aliases:
-      - CVE-2023-21954
-      - GHSA-8x3h-4f64-v6v6
+      - CVE-2024-20952
+      - GHSA-343v-9ccv-7535
     events:
-      - timestamp: 2024-04-05T07:44:20Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-12-default-jdk
-            componentID: b89c941d8c7fcaaf
-            componentName: openjdk-12-default-jdk
-            componentVersion: 12.0.2.10-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-mwrv-7rw9-w5xq
-    aliases:
-      - CVE-2023-21967
-      - GHSA-wg7x-fvjp-r3fx
-    events:
-      - timestamp: 2024-04-05T07:44:46Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-12-default-jdk
-            componentID: b89c941d8c7fcaaf
-            componentName: openjdk-12-default-jdk
-            componentVersion: 12.0.2.10-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-v656-jrm7-545q
-    aliases:
-      - CVE-2023-21968
-      - GHSA-r6j2-4r52-mpg7
-    events:
-      - timestamp: 2024-04-05T07:45:15Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-12-default-jdk
-            componentID: b89c941d8c7fcaaf
-            componentName: openjdk-12-default-jdk
-            componentVersion: 12.0.2.10-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-ggj8-ghf7-hp38
-    aliases:
-      - CVE-2023-22041
-      - GHSA-rgxf-494f-377c
-    events:
-      - timestamp: 2024-04-05T07:45:51Z
+      - timestamp: 2024-04-05T07:48:33Z
         type: detection
         data:
           type: scan/v1
@@ -166,30 +58,12 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-pj65-xr32-978w
+  - id: CGA-8xcc-wj36-grc9
     aliases:
-      - CVE-2024-20932
-      - GHSA-ccwc-jrj7-h4v6
+      - CVE-2023-21937
+      - GHSA-vr26-5f5w-r829
     events:
-      - timestamp: 2024-05-24T08:26:57Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-12
-            componentID: 84e764f9b39511ca
-            componentName: openjdk-12
-            componentVersion: 12.0.2.10-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-7f27-vg24-rjj5
-    aliases:
-      - CVE-2024-20952
-      - GHSA-343v-9ccv-7535
-    events:
-      - timestamp: 2024-04-05T07:48:33Z
+      - timestamp: 2024-04-05T07:43:35Z
         type: detection
         data:
           type: scan/v1
@@ -218,4 +92,135 @@ advisories:
             componentVersion: 12.0.2-internal+0-wolfi-r2
             componentType: binary
             componentLocation: /usr/lib/jvm/java-12-openjdk/bin/java
+            scanner: grype
+
+  - id: CGA-ggj8-ghf7-hp38
+    aliases:
+      - CVE-2023-22041
+      - GHSA-rgxf-494f-377c
+    events:
+      - timestamp: 2024-04-05T07:45:51Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-12-default-jdk
+            componentID: b89c941d8c7fcaaf
+            componentName: openjdk-12-default-jdk
+            componentVersion: 12.0.2.10-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-m29x-f3qq-6884
+    aliases:
+      - CVE-2023-21954
+      - GHSA-8x3h-4f64-v6v6
+    events:
+      - timestamp: 2024-04-05T07:44:20Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-12-default-jdk
+            componentID: b89c941d8c7fcaaf
+            componentName: openjdk-12-default-jdk
+            componentVersion: 12.0.2.10-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-mc5f-2r2g-664c
+    aliases:
+      - CVE-2023-21930
+      - GHSA-4j35-7cr4-3mc8
+    events:
+      - timestamp: 2024-04-05T07:42:44Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-12-default-jdk
+            componentID: b89c941d8c7fcaaf
+            componentName: openjdk-12-default-jdk
+            componentVersion: 12.0.2.10-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-mwrv-7rw9-w5xq
+    aliases:
+      - CVE-2023-21967
+      - GHSA-wg7x-fvjp-r3fx
+    events:
+      - timestamp: 2024-04-05T07:44:46Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-12-default-jdk
+            componentID: b89c941d8c7fcaaf
+            componentName: openjdk-12-default-jdk
+            componentVersion: 12.0.2.10-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-pj65-xr32-978w
+    aliases:
+      - CVE-2024-20932
+      - GHSA-ccwc-jrj7-h4v6
+    events:
+      - timestamp: 2024-05-24T08:26:57Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-12
+            componentID: 84e764f9b39511ca
+            componentName: openjdk-12
+            componentVersion: 12.0.2.10-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-06-05T12:28:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: NVD record says the affected version is 17.0.9, not a version range.
+
+  - id: CGA-v656-jrm7-545q
+    aliases:
+      - CVE-2023-21968
+      - GHSA-r6j2-4r52-mpg7
+    events:
+      - timestamp: 2024-04-05T07:45:15Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-12-default-jdk
+            componentID: b89c941d8c7fcaaf
+            componentName: openjdk-12-default-jdk
+            componentVersion: 12.0.2.10-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-vg74-c9p6-rch7
+    aliases:
+      - CVE-2023-21938
+      - GHSA-9pqg-44mx-r5gr
+    events:
+      - timestamp: 2024-04-05T07:43:45Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-12-default-jdk
+            componentID: b89c941d8c7fcaaf
+            componentName: openjdk-12-default-jdk
+            componentVersion: 12.0.2.10-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
             scanner: grype

--- a/openjdk-13.advisories.yaml
+++ b/openjdk-13.advisories.yaml
@@ -4,12 +4,12 @@ package:
   name: openjdk-13
 
 advisories:
-  - id: CGA-x53f-gwvv-jqqq
+  - id: CGA-3chm-f6fp-3gj4
     aliases:
-      - CVE-2023-21930
-      - GHSA-4j35-7cr4-3mc8
+      - CVE-2024-20919
+      - GHSA-vgxv-38wx-r77w
     events:
-      - timestamp: 2024-04-13T07:34:54Z
+      - timestamp: 2024-04-13T07:35:03Z
         type: detection
         data:
           type: scan/v1
@@ -22,12 +22,66 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-p6r6-rgfw-wjfc
+  - id: CGA-3wmm-g5vr-38c5
     aliases:
-      - CVE-2023-21937
-      - GHSA-vr26-5f5w-r829
+      - CVE-2024-21011
+      - GHSA-7qqv-8pwc-x4xc
     events:
-      - timestamp: 2024-04-13T07:34:54Z
+      - timestamp: 2024-04-19T13:34:23Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-13-jmods
+            componentID: 18530d8060d34702
+            componentName: openjdk-13-jmods
+            componentVersion: 13.0.14.5-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-4cr9-hmr3-x33c
+    aliases:
+      - CVE-2024-20921
+      - GHSA-hxqj-hr64-7vf7
+    events:
+      - timestamp: 2024-04-13T07:35:05Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-13-default-jdk
+            componentID: c5a797af162c12af
+            componentName: openjdk-13-default-jdk
+            componentVersion: 13.0.14.5-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-4v29-q5gx-qqpf
+    aliases:
+      - CVE-2024-21012
+      - GHSA-ccmh-gwpx-35xj
+    events:
+      - timestamp: 2024-04-19T13:34:25Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-13-jmods
+            componentID: 18530d8060d34702
+            componentName: openjdk-13-jmods
+            componentVersion: 13.0.14.5-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-52fq-3hr9-8hh8
+    aliases:
+      - CVE-2023-21968
+      - GHSA-r6j2-4r52-mpg7
+    events:
+      - timestamp: 2024-04-13T07:34:58Z
         type: detection
         data:
           type: scan/v1
@@ -46,6 +100,114 @@ advisories:
       - GHSA-9pqg-44mx-r5gr
     events:
       - timestamp: 2024-04-13T07:34:55Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-13-default-jdk
+            componentID: c5a797af162c12af
+            componentName: openjdk-13-default-jdk
+            componentVersion: 13.0.14.5-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-82j8-jhp4-cxch
+    aliases:
+      - CVE-2024-20918
+      - GHSA-45pc-2866-5hxx
+    events:
+      - timestamp: 2024-04-13T07:35:02Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-13-default-jdk
+            componentID: c5a797af162c12af
+            componentName: openjdk-13-default-jdk
+            componentVersion: 13.0.14.5-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-8qvx-rpqp-4gpp
+    aliases:
+      - CVE-2023-25193
+      - GHSA-v8ff-vmc3-wr4m
+    events:
+      - timestamp: 2024-04-13T07:35:01Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-13-default-jdk
+            componentID: c5a797af162c12af
+            componentName: openjdk-13-default-jdk
+            componentVersion: 13.0.14.5-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-8vfw-fhww-7h6v
+    aliases:
+      - CVE-2024-21068
+      - GHSA-q4c6-w389-xqq6
+    events:
+      - timestamp: 2024-04-19T13:34:27Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-13-jmods
+            componentID: 18530d8060d34702
+            componentName: openjdk-13-jmods
+            componentVersion: 13.0.14.5-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-8x9c-jmcv-hcjm
+    aliases:
+      - CVE-2024-20945
+      - GHSA-qj64-r5h2-w6f9
+    events:
+      - timestamp: 2024-04-13T07:35:06Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-13-default-jdk
+            componentID: c5a797af162c12af
+            componentName: openjdk-13-default-jdk
+            componentVersion: 13.0.14.5-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-974q-c4v2-9rw6
+    aliases:
+      - CVE-2024-20952
+      - GHSA-343v-9ccv-7535
+    events:
+      - timestamp: 2024-04-13T07:35:08Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-13-default-jdk
+            componentID: c5a797af162c12af
+            componentName: openjdk-13-default-jdk
+            componentVersion: 13.0.14.5-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-98h6-cpxr-2pvp
+    aliases:
+      - CVE-2023-21967
+      - GHSA-wg7x-fvjp-r3fx
+    events:
+      - timestamp: 2024-04-13T07:34:57Z
         type: detection
         data:
           type: scan/v1
@@ -94,120 +256,12 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-98h6-cpxr-2pvp
+  - id: CGA-p6r6-rgfw-wjfc
     aliases:
-      - CVE-2023-21967
-      - GHSA-wg7x-fvjp-r3fx
+      - CVE-2023-21937
+      - GHSA-vr26-5f5w-r829
     events:
-      - timestamp: 2024-04-13T07:34:57Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-13-default-jdk
-            componentID: c5a797af162c12af
-            componentName: openjdk-13-default-jdk
-            componentVersion: 13.0.14.5-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-52fq-3hr9-8hh8
-    aliases:
-      - CVE-2023-21968
-      - GHSA-r6j2-4r52-mpg7
-    events:
-      - timestamp: 2024-04-13T07:34:58Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-13-default-jdk
-            componentID: c5a797af162c12af
-            componentName: openjdk-13-default-jdk
-            componentVersion: 13.0.14.5-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-vg54-p32r-5h98
-    aliases:
-      - CVE-2023-22041
-      - GHSA-rgxf-494f-377c
-    events:
-      - timestamp: 2024-04-13T07:35:00Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-13-default-jdk
-            componentID: c5a797af162c12af
-            componentName: openjdk-13-default-jdk
-            componentVersion: 13.0.14.5-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-8qvx-rpqp-4gpp
-    aliases:
-      - CVE-2023-25193
-      - GHSA-v8ff-vmc3-wr4m
-    events:
-      - timestamp: 2024-04-13T07:35:01Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-13-default-jdk
-            componentID: c5a797af162c12af
-            componentName: openjdk-13-default-jdk
-            componentVersion: 13.0.14.5-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-82j8-jhp4-cxch
-    aliases:
-      - CVE-2024-20918
-      - GHSA-45pc-2866-5hxx
-    events:
-      - timestamp: 2024-04-13T07:35:02Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-13-default-jdk
-            componentID: c5a797af162c12af
-            componentName: openjdk-13-default-jdk
-            componentVersion: 13.0.14.5-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-3chm-f6fp-3gj4
-    aliases:
-      - CVE-2024-20919
-      - GHSA-vgxv-38wx-r77w
-    events:
-      - timestamp: 2024-04-13T07:35:03Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-13-default-jdk
-            componentID: c5a797af162c12af
-            componentName: openjdk-13-default-jdk
-            componentVersion: 13.0.14.5-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-4cr9-hmr3-x33c
-    aliases:
-      - CVE-2024-20921
-      - GHSA-hxqj-hr64-7vf7
-    events:
-      - timestamp: 2024-04-13T07:35:05Z
+      - timestamp: 2024-04-13T07:34:54Z
         type: detection
         data:
           type: scan/v1
@@ -237,13 +291,18 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-06-05T12:28:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: NVD record says the affected version is 17.0.9, not a version range.
 
-  - id: CGA-8x9c-jmcv-hcjm
+  - id: CGA-vg54-p32r-5h98
     aliases:
-      - CVE-2024-20945
-      - GHSA-qj64-r5h2-w6f9
+      - CVE-2023-22041
+      - GHSA-rgxf-494f-377c
     events:
-      - timestamp: 2024-04-13T07:35:06Z
+      - timestamp: 2024-04-13T07:35:00Z
         type: detection
         data:
           type: scan/v1
@@ -251,78 +310,6 @@ advisories:
             subpackageName: openjdk-13-default-jdk
             componentID: c5a797af162c12af
             componentName: openjdk-13-default-jdk
-            componentVersion: 13.0.14.5-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-974q-c4v2-9rw6
-    aliases:
-      - CVE-2024-20952
-      - GHSA-343v-9ccv-7535
-    events:
-      - timestamp: 2024-04-13T07:35:08Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-13-default-jdk
-            componentID: c5a797af162c12af
-            componentName: openjdk-13-default-jdk
-            componentVersion: 13.0.14.5-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-3wmm-g5vr-38c5
-    aliases:
-      - CVE-2024-21011
-      - GHSA-7qqv-8pwc-x4xc
-    events:
-      - timestamp: 2024-04-19T13:34:23Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-13-jmods
-            componentID: 18530d8060d34702
-            componentName: openjdk-13-jmods
-            componentVersion: 13.0.14.5-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-4v29-q5gx-qqpf
-    aliases:
-      - CVE-2024-21012
-      - GHSA-ccmh-gwpx-35xj
-    events:
-      - timestamp: 2024-04-19T13:34:25Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-13-jmods
-            componentID: 18530d8060d34702
-            componentName: openjdk-13-jmods
-            componentVersion: 13.0.14.5-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-8vfw-fhww-7h6v
-    aliases:
-      - CVE-2024-21068
-      - GHSA-q4c6-w389-xqq6
-    events:
-      - timestamp: 2024-04-19T13:34:27Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-13-jmods
-            componentID: 18530d8060d34702
-            componentName: openjdk-13-jmods
             componentVersion: 13.0.14.5-r2
             componentType: apk
             componentLocation: /.PKGINFO
@@ -341,6 +328,24 @@ advisories:
             subpackageName: openjdk-13-jmods
             componentID: 18530d8060d34702
             componentName: openjdk-13-jmods
+            componentVersion: 13.0.14.5-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-x53f-gwvv-jqqq
+    aliases:
+      - CVE-2023-21930
+      - GHSA-4j35-7cr4-3mc8
+    events:
+      - timestamp: 2024-04-13T07:34:54Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-13-default-jdk
+            componentID: c5a797af162c12af
+            componentName: openjdk-13-default-jdk
             componentVersion: 13.0.14.5-r2
             componentType: apk
             componentLocation: /.PKGINFO

--- a/openjdk-14.advisories.yaml
+++ b/openjdk-14.advisories.yaml
@@ -4,12 +4,12 @@ package:
   name: openjdk-14
 
 advisories:
-  - id: CGA-hqrx-r43x-2r2c
+  - id: CGA-2gvw-hjx3-v5fp
     aliases:
-      - CVE-2023-21930
-      - GHSA-4j35-7cr4-3mc8
+      - CVE-2023-21939
+      - GHSA-xfrf-5cgw-f964
     events:
-      - timestamp: 2024-03-31T02:41:35Z
+      - timestamp: 2024-03-31T02:55:33Z
         type: fix-not-planned
         data:
           note: OpenJDK 14 is no longer supported upstream.
@@ -24,182 +24,6 @@ advisories:
         data:
           note: OpenJDK 14 is no longer supported upstream.
 
-  - id: CGA-hx46-gv4f-2qrc
-    aliases:
-      - CVE-2023-21938
-      - GHSA-9pqg-44mx-r5gr
-    events:
-      - timestamp: 2024-03-31T02:38:57Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
-  - id: CGA-2gvw-hjx3-v5fp
-    aliases:
-      - CVE-2023-21939
-      - GHSA-xfrf-5cgw-f964
-    events:
-      - timestamp: 2024-03-31T02:55:33Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
-  - id: CGA-wxhv-wx7r-9x97
-    aliases:
-      - CVE-2023-21954
-      - GHSA-8x3h-4f64-v6v6
-    events:
-      - timestamp: 2024-03-31T02:55:50Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
-  - id: CGA-9v59-mc7x-m6wh
-    aliases:
-      - CVE-2023-21967
-      - GHSA-wg7x-fvjp-r3fx
-    events:
-      - timestamp: 2024-03-31T02:55:00Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
-  - id: CGA-jh28-rwp8-hwrg
-    aliases:
-      - CVE-2023-21968
-      - GHSA-r6j2-4r52-mpg7
-    events:
-      - timestamp: 2024-03-31T02:40:36Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
-  - id: CGA-rv82-rfvg-64qj
-    aliases:
-      - CVE-2023-22041
-      - GHSA-rgxf-494f-377c
-    events:
-      - timestamp: 2024-03-31T02:55:09Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
-  - id: CGA-8qw3-g7jv-pff5
-    aliases:
-      - CVE-2023-25193
-      - GHSA-v8ff-vmc3-wr4m
-    events:
-      - timestamp: 2024-03-31T02:54:43Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
-  - id: CGA-qwq6-5h8c-9m5x
-    aliases:
-      - CVE-2024-20918
-      - GHSA-45pc-2866-5hxx
-    events:
-      - timestamp: 2024-04-13T09:26:00Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-14-default-jdk
-            componentID: b4a24d9d241a800a
-            componentName: openjdk-14-default-jdk
-            componentVersion: 14.0.2.12-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-      - timestamp: 2024-04-15T09:45:23Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
-  - id: CGA-q95x-2876-f5pf
-    aliases:
-      - CVE-2024-20919
-      - GHSA-vgxv-38wx-r77w
-    events:
-      - timestamp: 2024-04-13T09:26:02Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-14-default-jdk
-            componentID: b4a24d9d241a800a
-            componentName: openjdk-14-default-jdk
-            componentVersion: 14.0.2.12-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-      - timestamp: 2024-04-15T09:44:53Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
-  - id: CGA-pc5w-8frh-wwrg
-    aliases:
-      - CVE-2024-20921
-      - GHSA-hxqj-hr64-7vf7
-    events:
-      - timestamp: 2024-04-13T09:26:03Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-14-default-jdk
-            componentID: b4a24d9d241a800a
-            componentName: openjdk-14-default-jdk
-            componentVersion: 14.0.2.12-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-      - timestamp: 2024-04-15T09:44:33Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
-  - id: CGA-x929-j5hp-m894
-    aliases:
-      - CVE-2024-20932
-      - GHSA-ccwc-jrj7-h4v6
-    events:
-      - timestamp: 2024-05-24T08:14:16Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-14
-            componentID: 4067cce3b5b77188
-            componentName: openjdk-14
-            componentVersion: 14.0.2.12-r5
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-rc44-238m-xc76
-    aliases:
-      - CVE-2024-20945
-      - GHSA-qj64-r5h2-w6f9
-    events:
-      - timestamp: 2024-04-13T09:26:05Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-14-default-jdk
-            componentID: b4a24d9d241a800a
-            componentName: openjdk-14-default-jdk
-            componentVersion: 14.0.2.12-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-      - timestamp: 2024-04-15T09:44:14Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 14 is no longer supported upstream.
-
   - id: CGA-42r6-p23j-6c2x
     aliases:
       - CVE-2024-20952
@@ -210,12 +34,12 @@ advisories:
         data:
           note: OpenJDK 14 is no longer supported upstream.
 
-  - id: CGA-5jgh-xx22-pvr7
+  - id: CGA-4r7x-wppq-c8vr
     aliases:
-      - CVE-2024-21011
-      - GHSA-7qqv-8pwc-x4xc
+      - CVE-2024-21012
+      - GHSA-ccmh-gwpx-35xj
     events:
-      - timestamp: 2024-04-19T15:15:32Z
+      - timestamp: 2024-04-19T15:15:35Z
         type: detection
         data:
           type: scan/v1
@@ -228,12 +52,12 @@ advisories:
             componentLocation: /usr/lib/jvm/java-14-openjdk/bin/java
             scanner: grype
 
-  - id: CGA-4r7x-wppq-c8vr
+  - id: CGA-5jgh-xx22-pvr7
     aliases:
-      - CVE-2024-21012
-      - GHSA-ccmh-gwpx-35xj
+      - CVE-2024-21011
+      - GHSA-7qqv-8pwc-x4xc
     events:
-      - timestamp: 2024-04-19T15:15:35Z
+      - timestamp: 2024-04-19T15:15:32Z
         type: detection
         data:
           type: scan/v1
@@ -264,6 +88,26 @@ advisories:
             componentLocation: /usr/lib/jvm/java-14-openjdk/bin/java
             scanner: grype
 
+  - id: CGA-8qw3-g7jv-pff5
+    aliases:
+      - CVE-2023-25193
+      - GHSA-v8ff-vmc3-wr4m
+    events:
+      - timestamp: 2024-03-31T02:54:43Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
+  - id: CGA-9v59-mc7x-m6wh
+    aliases:
+      - CVE-2023-21967
+      - GHSA-wg7x-fvjp-r3fx
+    events:
+      - timestamp: 2024-03-31T02:55:00Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
   - id: CGA-gj5w-6fcc-2jgh
     aliases:
       - CVE-2024-21094
@@ -281,3 +125,164 @@ advisories:
             componentType: binary
             componentLocation: /usr/lib/jvm/java-14-openjdk/bin/java
             scanner: grype
+
+  - id: CGA-hqrx-r43x-2r2c
+    aliases:
+      - CVE-2023-21930
+      - GHSA-4j35-7cr4-3mc8
+    events:
+      - timestamp: 2024-03-31T02:41:35Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
+  - id: CGA-hx46-gv4f-2qrc
+    aliases:
+      - CVE-2023-21938
+      - GHSA-9pqg-44mx-r5gr
+    events:
+      - timestamp: 2024-03-31T02:38:57Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
+  - id: CGA-jh28-rwp8-hwrg
+    aliases:
+      - CVE-2023-21968
+      - GHSA-r6j2-4r52-mpg7
+    events:
+      - timestamp: 2024-03-31T02:40:36Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
+  - id: CGA-pc5w-8frh-wwrg
+    aliases:
+      - CVE-2024-20921
+      - GHSA-hxqj-hr64-7vf7
+    events:
+      - timestamp: 2024-04-13T09:26:03Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-14-default-jdk
+            componentID: b4a24d9d241a800a
+            componentName: openjdk-14-default-jdk
+            componentVersion: 14.0.2.12-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-04-15T09:44:33Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
+  - id: CGA-q95x-2876-f5pf
+    aliases:
+      - CVE-2024-20919
+      - GHSA-vgxv-38wx-r77w
+    events:
+      - timestamp: 2024-04-13T09:26:02Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-14-default-jdk
+            componentID: b4a24d9d241a800a
+            componentName: openjdk-14-default-jdk
+            componentVersion: 14.0.2.12-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-04-15T09:44:53Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
+  - id: CGA-qwq6-5h8c-9m5x
+    aliases:
+      - CVE-2024-20918
+      - GHSA-45pc-2866-5hxx
+    events:
+      - timestamp: 2024-04-13T09:26:00Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-14-default-jdk
+            componentID: b4a24d9d241a800a
+            componentName: openjdk-14-default-jdk
+            componentVersion: 14.0.2.12-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-04-15T09:45:23Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
+  - id: CGA-rc44-238m-xc76
+    aliases:
+      - CVE-2024-20945
+      - GHSA-qj64-r5h2-w6f9
+    events:
+      - timestamp: 2024-04-13T09:26:05Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-14-default-jdk
+            componentID: b4a24d9d241a800a
+            componentName: openjdk-14-default-jdk
+            componentVersion: 14.0.2.12-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-04-15T09:44:14Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
+  - id: CGA-rv82-rfvg-64qj
+    aliases:
+      - CVE-2023-22041
+      - GHSA-rgxf-494f-377c
+    events:
+      - timestamp: 2024-03-31T02:55:09Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
+  - id: CGA-wxhv-wx7r-9x97
+    aliases:
+      - CVE-2023-21954
+      - GHSA-8x3h-4f64-v6v6
+    events:
+      - timestamp: 2024-03-31T02:55:50Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 14 is no longer supported upstream.
+
+  - id: CGA-x929-j5hp-m894
+    aliases:
+      - CVE-2024-20932
+      - GHSA-ccwc-jrj7-h4v6
+    events:
+      - timestamp: 2024-05-24T08:14:16Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-14
+            componentID: 4067cce3b5b77188
+            componentName: openjdk-14
+            componentVersion: 14.0.2.12-r5
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-06-05T12:28:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: NVD record says the affected version is 17.0.9, not a version range.

--- a/openjdk-15.advisories.yaml
+++ b/openjdk-15.advisories.yaml
@@ -14,42 +14,12 @@ advisories:
         data:
           note: OpenJDK 15 is no longer supported upstream.
 
-  - id: CGA-cxc7-c386-jwx5
+  - id: CGA-4m5m-7mmw-26xx
     aliases:
-      - CVE-2023-21937
-      - GHSA-vr26-5f5w-r829
+      - CVE-2023-25193
+      - GHSA-v8ff-vmc3-wr4m
     events:
-      - timestamp: 2024-03-31T02:41:10Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 15 is no longer supported upstream.
-
-  - id: CGA-7mw5-55mq-g7f8
-    aliases:
-      - CVE-2023-21938
-      - GHSA-9pqg-44mx-r5gr
-    events:
-      - timestamp: 2024-03-31T02:38:57Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 15 is no longer supported upstream.
-
-  - id: CGA-8g97-5p24-c3x2
-    aliases:
-      - CVE-2023-21939
-      - GHSA-xfrf-5cgw-f964
-    events:
-      - timestamp: 2024-03-31T02:55:33Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 15 is no longer supported upstream.
-
-  - id: CGA-859c-fhpv-wwgm
-    aliases:
-      - CVE-2023-21954
-      - GHSA-8x3h-4f64-v6v6
-    events:
-      - timestamp: 2024-03-31T02:55:50Z
+      - timestamp: 2024-03-31T02:54:43Z
         type: fix-not-planned
         data:
           note: OpenJDK 15 is no longer supported upstream.
@@ -64,6 +34,16 @@ advisories:
         data:
           note: OpenJDK 15 is no longer supported upstream.
 
+  - id: CGA-7mw5-55mq-g7f8
+    aliases:
+      - CVE-2023-21938
+      - GHSA-9pqg-44mx-r5gr
+    events:
+      - timestamp: 2024-03-31T02:38:57Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 15 is no longer supported upstream.
+
   - id: CGA-7r6c-99qc-2j4g
     aliases:
       - CVE-2023-21968
@@ -74,32 +54,50 @@ advisories:
         data:
           note: OpenJDK 15 is no longer supported upstream.
 
-  - id: CGA-p95x-mf8j-49fm
+  - id: CGA-859c-fhpv-wwgm
     aliases:
-      - CVE-2023-22041
-      - GHSA-rgxf-494f-377c
+      - CVE-2023-21954
+      - GHSA-8x3h-4f64-v6v6
     events:
-      - timestamp: 2024-03-31T02:55:09Z
+      - timestamp: 2024-03-31T02:55:50Z
         type: fix-not-planned
         data:
           note: OpenJDK 15 is no longer supported upstream.
 
-  - id: CGA-4m5m-7mmw-26xx
+  - id: CGA-8g97-5p24-c3x2
     aliases:
-      - CVE-2023-25193
-      - GHSA-v8ff-vmc3-wr4m
+      - CVE-2023-21939
+      - GHSA-xfrf-5cgw-f964
     events:
-      - timestamp: 2024-03-31T02:54:43Z
+      - timestamp: 2024-03-31T02:55:33Z
         type: fix-not-planned
         data:
           note: OpenJDK 15 is no longer supported upstream.
 
-  - id: CGA-q99x-j2w7-cr2j
+  - id: CGA-8grq-95rf-2hp6
     aliases:
-      - CVE-2024-20918
-      - GHSA-45pc-2866-5hxx
+      - CVE-2024-21012
+      - GHSA-ccmh-gwpx-35xj
     events:
-      - timestamp: 2024-04-13T07:12:49Z
+      - timestamp: 2024-04-19T11:12:17Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-15-jre
+            componentID: 392fc4969272d959
+            componentName: openjdk-15-jre
+            componentVersion: 15.0.10.5-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-8mfh-gq8j-c8ff
+    aliases:
+      - CVE-2024-20921
+      - GHSA-hxqj-hr64-7vf7
+    events:
+      - timestamp: 2024-04-13T07:12:52Z
         type: detection
         data:
           type: scan/v1
@@ -111,7 +109,17 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
-      - timestamp: 2024-04-15T09:49:17Z
+      - timestamp: 2024-04-15T09:49:49Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 15 is no longer supported upstream.
+
+  - id: CGA-cxc7-c386-jwx5
+    aliases:
+      - CVE-2023-21937
+      - GHSA-vr26-5f5w-r829
+    events:
+      - timestamp: 2024-03-31T02:41:10Z
         type: fix-not-planned
         data:
           note: OpenJDK 15 is no longer supported upstream.
@@ -138,28 +146,6 @@ advisories:
         data:
           note: OpenJDK 15 is no longer supported upstream.
 
-  - id: CGA-8mfh-gq8j-c8ff
-    aliases:
-      - CVE-2024-20921
-      - GHSA-hxqj-hr64-7vf7
-    events:
-      - timestamp: 2024-04-13T07:12:52Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-15-default-jdk
-            componentID: 877dde9acd774075
-            componentName: openjdk-15-default-jdk
-            componentVersion: 15.0.10.5-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-      - timestamp: 2024-04-15T09:49:49Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 15 is no longer supported upstream.
-
   - id: CGA-gqq8-8g86-85hx
     aliases:
       - CVE-2024-20932
@@ -177,6 +163,79 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-06-05T12:29:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: NVD record says the affected version is 17.0.9, not a version range.
+
+  - id: CGA-m746-pqf6-r9mf
+    aliases:
+      - CVE-2024-21094
+      - GHSA-g3wm-f7gr-3fwh
+    events:
+      - timestamp: 2024-04-19T11:12:21Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-15-jre
+            componentID: 392fc4969272d959
+            componentName: openjdk-15-jre
+            componentVersion: 15.0.10.5-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-p95x-mf8j-49fm
+    aliases:
+      - CVE-2023-22041
+      - GHSA-rgxf-494f-377c
+    events:
+      - timestamp: 2024-03-31T02:55:09Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 15 is no longer supported upstream.
+
+  - id: CGA-phwc-42p8-h6pm
+    aliases:
+      - CVE-2024-21011
+      - GHSA-7qqv-8pwc-x4xc
+    events:
+      - timestamp: 2024-04-19T11:12:15Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-15-jre
+            componentID: 392fc4969272d959
+            componentName: openjdk-15-jre
+            componentVersion: 15.0.10.5-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-q99x-j2w7-cr2j
+    aliases:
+      - CVE-2024-20918
+      - GHSA-45pc-2866-5hxx
+    events:
+      - timestamp: 2024-04-13T07:12:49Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-15-default-jdk
+            componentID: 877dde9acd774075
+            componentName: openjdk-15-default-jdk
+            componentVersion: 15.0.10.5-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-04-15T09:49:17Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 15 is no longer supported upstream.
 
   - id: CGA-qvxc-rh35-4p32
     aliases:
@@ -200,52 +259,6 @@ advisories:
         data:
           note: OpenJDK 15 is no longer supported upstream.
 
-  - id: CGA-vhfm-7c4p-2whh
-    aliases:
-      - CVE-2024-20952
-      - GHSA-343v-9ccv-7535
-    events:
-      - timestamp: 2024-03-31T02:41:57Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 15 is no longer supported upstream.
-
-  - id: CGA-phwc-42p8-h6pm
-    aliases:
-      - CVE-2024-21011
-      - GHSA-7qqv-8pwc-x4xc
-    events:
-      - timestamp: 2024-04-19T11:12:15Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-15-jre
-            componentID: 392fc4969272d959
-            componentName: openjdk-15-jre
-            componentVersion: 15.0.10.5-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-8grq-95rf-2hp6
-    aliases:
-      - CVE-2024-21012
-      - GHSA-ccmh-gwpx-35xj
-    events:
-      - timestamp: 2024-04-19T11:12:17Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-15-jre
-            componentID: 392fc4969272d959
-            componentName: openjdk-15-jre
-            componentVersion: 15.0.10.5-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
   - id: CGA-r2jw-q8hm-7qmx
     aliases:
       - CVE-2024-21068
@@ -264,20 +277,12 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-m746-pqf6-r9mf
+  - id: CGA-vhfm-7c4p-2whh
     aliases:
-      - CVE-2024-21094
-      - GHSA-g3wm-f7gr-3fwh
+      - CVE-2024-20952
+      - GHSA-343v-9ccv-7535
     events:
-      - timestamp: 2024-04-19T11:12:21Z
-        type: detection
+      - timestamp: 2024-03-31T02:41:57Z
+        type: fix-not-planned
         data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-15-jre
-            componentID: 392fc4969272d959
-            componentName: openjdk-15-jre
-            componentVersion: 15.0.10.5-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
+          note: OpenJDK 15 is no longer supported upstream.

--- a/openjdk-16.advisories.yaml
+++ b/openjdk-16.advisories.yaml
@@ -4,42 +4,12 @@ package:
   name: openjdk-16
 
 advisories:
-  - id: CGA-gjgm-5hqf-4qcg
+  - id: CGA-3gxm-h4h7-fw22
     aliases:
-      - CVE-2023-21930
-      - GHSA-4j35-7cr4-3mc8
+      - CVE-2023-21967
+      - GHSA-wg7x-fvjp-r3fx
     events:
-      - timestamp: 2024-03-31T02:41:35Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 16 is no longer supported upstream.
-
-  - id: CGA-v4rx-wrhf-gw83
-    aliases:
-      - CVE-2023-21937
-      - GHSA-vr26-5f5w-r829
-    events:
-      - timestamp: 2024-03-31T02:41:10Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 16 is no longer supported upstream.
-
-  - id: CGA-vwhm-6g44-r477
-    aliases:
-      - CVE-2023-21938
-      - GHSA-9pqg-44mx-r5gr
-    events:
-      - timestamp: 2024-03-31T02:38:57Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 16 is no longer supported upstream.
-
-  - id: CGA-49v7-m3q8-q2v7
-    aliases:
-      - CVE-2023-21939
-      - GHSA-xfrf-5cgw-f964
-    events:
-      - timestamp: 2024-03-31T02:55:33Z
+      - timestamp: 2024-03-31T02:55:00Z
         type: fix-not-planned
         data:
           note: OpenJDK 16 is no longer supported upstream.
@@ -54,42 +24,75 @@ advisories:
         data:
           note: OpenJDK 16 is no longer supported upstream.
 
-  - id: CGA-3gxm-h4h7-fw22
+  - id: CGA-49v7-m3q8-q2v7
     aliases:
-      - CVE-2023-21967
-      - GHSA-wg7x-fvjp-r3fx
+      - CVE-2023-21939
+      - GHSA-xfrf-5cgw-f964
     events:
-      - timestamp: 2024-03-31T02:55:00Z
+      - timestamp: 2024-03-31T02:55:33Z
         type: fix-not-planned
         data:
           note: OpenJDK 16 is no longer supported upstream.
 
-  - id: CGA-v76x-xh6c-57xq
+  - id: CGA-6hx7-6w3p-7824
     aliases:
-      - CVE-2023-21968
-      - GHSA-r6j2-4r52-mpg7
+      - CVE-2024-20932
+      - GHSA-ccwc-jrj7-h4v6
     events:
-      - timestamp: 2024-03-31T02:40:36Z
-        type: fix-not-planned
+      - timestamp: 2024-05-24T08:13:36Z
+        type: detection
         data:
-          note: OpenJDK 16 is no longer supported upstream.
-
-  - id: CGA-w823-88hj-m77c
-    aliases:
-      - CVE-2023-22041
-      - GHSA-rgxf-494f-377c
-    events:
-      - timestamp: 2024-03-31T02:55:09Z
-        type: fix-not-planned
+          type: scan/v1
+          data:
+            subpackageName: openjdk-16
+            componentID: 3f7e17e515351b4d
+            componentName: openjdk-16
+            componentVersion: 16.0.2.7-r5
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-06-05T12:30:02Z
+        type: false-positive-determination
         data:
-          note: OpenJDK 16 is no longer supported upstream.
+          type: vulnerable-code-version-not-used
+          note: NVD record says the affected version is 17.0.9, not a version range.
 
-  - id: CGA-r8q6-rj77-56qj
+  - id: CGA-726q-pm25-jjgc
     aliases:
-      - CVE-2023-25193
-      - GHSA-v8ff-vmc3-wr4m
+      - CVE-2024-21012
+      - GHSA-ccmh-gwpx-35xj
     events:
-      - timestamp: 2024-03-31T02:54:43Z
+      - timestamp: 2024-04-19T13:03:32Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-16
+            componentID: 8815c3ad6a30b005
+            componentName: openjdk-16
+            componentVersion: 16.0.2.7-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-72h6-cc9f-fr5q
+    aliases:
+      - CVE-2024-20919
+      - GHSA-vgxv-38wx-r77w
+    events:
+      - timestamp: 2024-04-13T09:27:08Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-16-doc
+            componentID: 4cff56e044c42352
+            componentName: openjdk-16-doc
+            componentVersion: 16.0.2.7-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-04-15T09:51:35Z
         type: fix-not-planned
         data:
           note: OpenJDK 16 is no longer supported upstream.
@@ -116,28 +119,6 @@ advisories:
         data:
           note: OpenJDK 16 is no longer supported upstream.
 
-  - id: CGA-72h6-cc9f-fr5q
-    aliases:
-      - CVE-2024-20919
-      - GHSA-vgxv-38wx-r77w
-    events:
-      - timestamp: 2024-04-13T09:27:08Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-16-doc
-            componentID: 4cff56e044c42352
-            componentName: openjdk-16-doc
-            componentVersion: 16.0.2.7-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-      - timestamp: 2024-04-15T09:51:35Z
-        type: fix-not-planned
-        data:
-          note: OpenJDK 16 is no longer supported upstream.
-
   - id: CGA-cc49-pmqc-h4ph
     aliases:
       - CVE-2024-20921
@@ -160,20 +141,40 @@ advisories:
         data:
           note: OpenJDK 16 is no longer supported upstream.
 
-  - id: CGA-6hx7-6w3p-7824
+  - id: CGA-gjgm-5hqf-4qcg
     aliases:
-      - CVE-2024-20932
-      - GHSA-ccwc-jrj7-h4v6
+      - CVE-2023-21930
+      - GHSA-4j35-7cr4-3mc8
     events:
-      - timestamp: 2024-05-24T08:13:36Z
+      - timestamp: 2024-03-31T02:41:35Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 16 is no longer supported upstream.
+
+  - id: CGA-px84-hwgp-hm88
+    aliases:
+      - CVE-2024-20952
+      - GHSA-343v-9ccv-7535
+    events:
+      - timestamp: 2024-03-31T02:41:57Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 16 is no longer supported upstream.
+
+  - id: CGA-qx82-qhjp-v627
+    aliases:
+      - CVE-2024-21068
+      - GHSA-q4c6-w389-xqq6
+    events:
+      - timestamp: 2024-04-19T13:03:35Z
         type: detection
         data:
           type: scan/v1
           data:
             subpackageName: openjdk-16
-            componentID: 3f7e17e515351b4d
+            componentID: 8815c3ad6a30b005
             componentName: openjdk-16
-            componentVersion: 16.0.2.7-r5
+            componentVersion: 16.0.2.7-r3
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
@@ -200,12 +201,70 @@ advisories:
         data:
           note: OpenJDK 16 is no longer supported upstream.
 
-  - id: CGA-px84-hwgp-hm88
+  - id: CGA-r8q6-rj77-56qj
     aliases:
-      - CVE-2024-20952
-      - GHSA-343v-9ccv-7535
+      - CVE-2023-25193
+      - GHSA-v8ff-vmc3-wr4m
     events:
-      - timestamp: 2024-03-31T02:41:57Z
+      - timestamp: 2024-03-31T02:54:43Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 16 is no longer supported upstream.
+
+  - id: CGA-rfwp-26m4-mwp7
+    aliases:
+      - CVE-2024-21094
+      - GHSA-g3wm-f7gr-3fwh
+    events:
+      - timestamp: 2024-04-19T13:03:37Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-16
+            componentID: 8815c3ad6a30b005
+            componentName: openjdk-16
+            componentVersion: 16.0.2.7-r3
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-v4rx-wrhf-gw83
+    aliases:
+      - CVE-2023-21937
+      - GHSA-vr26-5f5w-r829
+    events:
+      - timestamp: 2024-03-31T02:41:10Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 16 is no longer supported upstream.
+
+  - id: CGA-v76x-xh6c-57xq
+    aliases:
+      - CVE-2023-21968
+      - GHSA-r6j2-4r52-mpg7
+    events:
+      - timestamp: 2024-03-31T02:40:36Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 16 is no longer supported upstream.
+
+  - id: CGA-vwhm-6g44-r477
+    aliases:
+      - CVE-2023-21938
+      - GHSA-9pqg-44mx-r5gr
+    events:
+      - timestamp: 2024-03-31T02:38:57Z
+        type: fix-not-planned
+        data:
+          note: OpenJDK 16 is no longer supported upstream.
+
+  - id: CGA-w823-88hj-m77c
+    aliases:
+      - CVE-2023-22041
+      - GHSA-rgxf-494f-377c
+    events:
+      - timestamp: 2024-03-31T02:55:09Z
         type: fix-not-planned
         data:
           note: OpenJDK 16 is no longer supported upstream.
@@ -216,60 +275,6 @@ advisories:
       - GHSA-7qqv-8pwc-x4xc
     events:
       - timestamp: 2024-04-19T13:03:30Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-16
-            componentID: 8815c3ad6a30b005
-            componentName: openjdk-16
-            componentVersion: 16.0.2.7-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-726q-pm25-jjgc
-    aliases:
-      - CVE-2024-21012
-      - GHSA-ccmh-gwpx-35xj
-    events:
-      - timestamp: 2024-04-19T13:03:32Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-16
-            componentID: 8815c3ad6a30b005
-            componentName: openjdk-16
-            componentVersion: 16.0.2.7-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-qx82-qhjp-v627
-    aliases:
-      - CVE-2024-21068
-      - GHSA-q4c6-w389-xqq6
-    events:
-      - timestamp: 2024-04-19T13:03:35Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-16
-            componentID: 8815c3ad6a30b005
-            componentName: openjdk-16
-            componentVersion: 16.0.2.7-r3
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-rfwp-26m4-mwp7
-    aliases:
-      - CVE-2024-21094
-      - GHSA-g3wm-f7gr-3fwh
-    events:
-      - timestamp: 2024-04-19T13:03:37Z
         type: detection
         data:
           type: scan/v1

--- a/openjdk-7.advisories.yaml
+++ b/openjdk-7.advisories.yaml
@@ -183,6 +183,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-06-05T12:24:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: NVD record says the affected version is 17.0.9, not a version range.
 
   - id: CGA-824g-cf4x-phj9
     aliases:

--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -22,113 +22,12 @@ advisories:
             componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
             scanner: grype
 
-  - id: CGA-x74r-26jc-x9px
+  - id: CGA-54pm-rxx7-5ph2
     aliases:
-      - CVE-2023-21937
-      - GHSA-vr26-5f5w-r829
+      - CVE-2024-21004
+      - GHSA-r5cc-f7pr-5v73
     events:
-      - timestamp: 2024-01-11T07:10:54Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-8-jre
-            componentID: cb7e5b68577405bc
-            componentName: java
-            componentVersion: 1.8.0_392-b08
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
-            scanner: grype
-
-  - id: CGA-wh4h-q24p-73mj
-    aliases:
-      - CVE-2023-21938
-      - GHSA-9pqg-44mx-r5gr
-    events:
-      - timestamp: 2024-01-11T07:10:54Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-8-jre
-            componentID: cb7e5b68577405bc
-            componentName: java
-            componentVersion: 1.8.0_392-b08
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
-            scanner: grype
-
-  - id: CGA-6m9g-xxxf-x3h8
-    aliases:
-      - CVE-2023-21939
-      - GHSA-xfrf-5cgw-f964
-    events:
-      - timestamp: 2024-01-11T07:10:54Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-8-jre
-            componentID: cb7e5b68577405bc
-            componentName: java
-            componentVersion: 1.8.0_392-b08
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
-            scanner: grype
-
-  - id: CGA-pjwr-v2cc-mwvf
-    aliases:
-      - CVE-2023-21954
-      - GHSA-8x3h-4f64-v6v6
-    events:
-      - timestamp: 2024-01-11T07:10:55Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-8-jre
-            componentID: cb7e5b68577405bc
-            componentName: java
-            componentVersion: 1.8.0_392-b08
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
-            scanner: grype
-
-  - id: CGA-574g-qhpx-45cf
-    aliases:
-      - CVE-2023-21967
-      - GHSA-wg7x-fvjp-r3fx
-    events:
-      - timestamp: 2024-01-11T07:10:56Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-8-jre
-            componentID: cb7e5b68577405bc
-            componentName: java
-            componentVersion: 1.8.0_392-b08
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
-            scanner: grype
-
-  - id: CGA-hq6j-c6fw-x9gp
-    aliases:
-      - CVE-2023-21968
-      - GHSA-r6j2-4r52-mpg7
-    events:
-      - timestamp: 2023-08-11T20:23:47Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-version-not-used
-          note: The vulnerability was patched upstream in 362, prior to Wolfi packaging.
-
-  - id: CGA-h9q4-xm2r-6j7p
-    aliases:
-      - CVE-2023-41074
-      - GHSA-xq9m-9whg-jv3m
-    events:
-      - timestamp: 2024-05-01T23:36:19Z
+      - timestamp: 2024-05-01T23:36:28Z
         type: detection
         data:
           type: scan/v1
@@ -141,28 +40,6 @@ advisories:
             componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
             scanner: grype
       - timestamp: 2024-05-27T00:38:23Z
-        type: fixed
-        data:
-          fixed-version: 8.412.08-r0
-
-  - id: CGA-qwp7-r45h-hfhv
-    aliases:
-      - CVE-2023-41993
-      - GHSA-2hcr-79rm-r8rp
-    events:
-      - timestamp: 2024-05-01T23:36:21Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-8
-            componentID: 2e3d139249f9eb66
-            componentName: java/jdk
-            componentVersion: 1.8.0_392-b08
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
-            scanner: grype
-      - timestamp: 2024-05-27T00:38:22Z
         type: fixed
         data:
           fixed-version: 8.412.08-r0
@@ -189,111 +66,23 @@ advisories:
         data:
           fixed-version: 8.412.08-r0
 
-  - id: CGA-p68w-hvwf-gr64
+  - id: CGA-574g-qhpx-45cf
     aliases:
-      - CVE-2024-20932
-      - GHSA-ccwc-jrj7-h4v6
+      - CVE-2023-21967
+      - GHSA-wg7x-fvjp-r3fx
     events:
-      - timestamp: 2024-05-24T07:33:55Z
+      - timestamp: 2024-01-11T07:10:56Z
         type: detection
         data:
           type: scan/v1
           data:
-            subpackageName: openjdk-8
-            componentID: 714fb05b58350ef6
-            componentName: openjdk-8
-            componentVersion: 8.392.08-r2
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-q89h-mvr2-6xwx
-    aliases:
-      - CVE-2024-21002
-      - GHSA-5wrr-m725-w8jw
-    events:
-      - timestamp: 2024-05-01T23:36:24Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-8
-            componentID: 2e3d139249f9eb66
-            componentName: java/jdk
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
             componentVersion: 1.8.0_392-b08
             componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
             scanner: grype
-      - timestamp: 2024-05-27T00:38:22Z
-        type: fixed
-        data:
-          fixed-version: 8.412.08-r0
-
-  - id: CGA-pf5g-h32q-mp23
-    aliases:
-      - CVE-2024-21003
-      - GHSA-wg7v-w4x5-xvmx
-    events:
-      - timestamp: 2024-05-01T23:36:26Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-8
-            componentID: 2e3d139249f9eb66
-            componentName: java/jdk
-            componentVersion: 1.8.0_392-b08
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
-            scanner: grype
-      - timestamp: 2024-05-27T00:38:24Z
-        type: fixed
-        data:
-          fixed-version: 8.412.08-r0
-
-  - id: CGA-54pm-rxx7-5ph2
-    aliases:
-      - CVE-2024-21004
-      - GHSA-r5cc-f7pr-5v73
-    events:
-      - timestamp: 2024-05-01T23:36:28Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-8
-            componentID: 2e3d139249f9eb66
-            componentName: java/jdk
-            componentVersion: 1.8.0_392-b08
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
-            scanner: grype
-      - timestamp: 2024-05-27T00:38:23Z
-        type: fixed
-        data:
-          fixed-version: 8.412.08-r0
-
-  - id: CGA-pppq-g286-2qm8
-    aliases:
-      - CVE-2024-21005
-      - GHSA-55g5-m7rx-jf99
-    events:
-      - timestamp: 2024-05-01T23:36:30Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-8
-            componentID: 2e3d139249f9eb66
-            componentName: java/jdk
-            componentVersion: 1.8.0_392-b08
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
-            scanner: grype
-      - timestamp: 2024-05-27T00:38:21Z
-        type: fixed
-        data:
-          fixed-version: 8.412.08-r0
 
   - id: CGA-5ph7-mpw6-hqcm
     aliases:
@@ -317,6 +106,79 @@ advisories:
         data:
           fixed-version: 8.412.08-r0
 
+  - id: CGA-6m9g-xxxf-x3h8
+    aliases:
+      - CVE-2023-21939
+      - GHSA-xfrf-5cgw-f964
+    events:
+      - timestamp: 2024-01-11T07:10:54Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype
+
+  - id: CGA-g6p4-m46f-4jmh
+    aliases:
+      - CVE-2024-21085
+      - GHSA-273j-fjrx-gf2f
+    events:
+      - timestamp: 2024-04-19T13:25:28Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype
+      - timestamp: 2024-05-27T00:38:21Z
+        type: fixed
+        data:
+          fixed-version: 8.412.08-r0
+
+  - id: CGA-h9q4-xm2r-6j7p
+    aliases:
+      - CVE-2023-41074
+      - GHSA-xq9m-9whg-jv3m
+    events:
+      - timestamp: 2024-05-01T23:36:19Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8
+            componentID: 2e3d139249f9eb66
+            componentName: java/jdk
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
+            scanner: grype
+      - timestamp: 2024-05-27T00:38:23Z
+        type: fixed
+        data:
+          fixed-version: 8.412.08-r0
+
+  - id: CGA-hq6j-c6fw-x9gp
+    aliases:
+      - CVE-2023-21968
+      - GHSA-r6j2-4r52-mpg7
+    events:
+      - timestamp: 2023-08-11T20:23:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The vulnerability was patched upstream in 362, prior to Wolfi packaging.
+
   - id: CGA-p48c-96mf-2mqv
     aliases:
       - CVE-2024-21068
@@ -339,24 +201,47 @@ advisories:
         data:
           fixed-version: 8.412.08-r0
 
-  - id: CGA-g6p4-m46f-4jmh
+  - id: CGA-p68w-hvwf-gr64
     aliases:
-      - CVE-2024-21085
-      - GHSA-273j-fjrx-gf2f
+      - CVE-2024-20932
+      - GHSA-ccwc-jrj7-h4v6
     events:
-      - timestamp: 2024-04-19T13:25:28Z
+      - timestamp: 2024-05-24T07:33:55Z
         type: detection
         data:
           type: scan/v1
           data:
-            subpackageName: openjdk-8-jre
-            componentID: cb7e5b68577405bc
-            componentName: java
+            subpackageName: openjdk-8
+            componentID: 714fb05b58350ef6
+            componentName: openjdk-8
+            componentVersion: 8.392.08-r2
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-06-05T12:22:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: NVD record says the affected version is 17.0.9, not a version range.
+
+  - id: CGA-pf5g-h32q-mp23
+    aliases:
+      - CVE-2024-21003
+      - GHSA-wg7v-w4x5-xvmx
+    events:
+      - timestamp: 2024-05-01T23:36:26Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8
+            componentID: 2e3d139249f9eb66
+            componentName: java/jdk
             componentVersion: 1.8.0_392-b08
             componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
             scanner: grype
-      - timestamp: 2024-05-27T00:38:21Z
+      - timestamp: 2024-05-27T00:38:24Z
         type: fixed
         data:
           fixed-version: 8.412.08-r0
@@ -382,3 +267,123 @@ advisories:
         type: fixed
         data:
           fixed-version: 8.412.08-r0
+
+  - id: CGA-pjwr-v2cc-mwvf
+    aliases:
+      - CVE-2023-21954
+      - GHSA-8x3h-4f64-v6v6
+    events:
+      - timestamp: 2024-01-11T07:10:55Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype
+
+  - id: CGA-pppq-g286-2qm8
+    aliases:
+      - CVE-2024-21005
+      - GHSA-55g5-m7rx-jf99
+    events:
+      - timestamp: 2024-05-01T23:36:30Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8
+            componentID: 2e3d139249f9eb66
+            componentName: java/jdk
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
+            scanner: grype
+      - timestamp: 2024-05-27T00:38:21Z
+        type: fixed
+        data:
+          fixed-version: 8.412.08-r0
+
+  - id: CGA-q89h-mvr2-6xwx
+    aliases:
+      - CVE-2024-21002
+      - GHSA-5wrr-m725-w8jw
+    events:
+      - timestamp: 2024-05-01T23:36:24Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8
+            componentID: 2e3d139249f9eb66
+            componentName: java/jdk
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
+            scanner: grype
+      - timestamp: 2024-05-27T00:38:22Z
+        type: fixed
+        data:
+          fixed-version: 8.412.08-r0
+
+  - id: CGA-qwp7-r45h-hfhv
+    aliases:
+      - CVE-2023-41993
+      - GHSA-2hcr-79rm-r8rp
+    events:
+      - timestamp: 2024-05-01T23:36:21Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8
+            componentID: 2e3d139249f9eb66
+            componentName: java/jdk
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/jdb
+            scanner: grype
+      - timestamp: 2024-05-27T00:38:22Z
+        type: fixed
+        data:
+          fixed-version: 8.412.08-r0
+
+  - id: CGA-wh4h-q24p-73mj
+    aliases:
+      - CVE-2023-21938
+      - GHSA-9pqg-44mx-r5gr
+    events:
+      - timestamp: 2024-01-11T07:10:54Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype
+
+  - id: CGA-x74r-26jc-x9px
+    aliases:
+      - CVE-2023-21937
+      - GHSA-vr26-5f5w-r829
+    events:
+      - timestamp: 2024-01-11T07:10:54Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-8-jre
+            componentID: cb7e5b68577405bc
+            componentName: java
+            componentVersion: 1.8.0_392-b08
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.8-openjdk/bin/java, /usr/lib/jvm/java-1.8-openjdk/jre/bin/java
+            scanner: grype

--- a/openjdk-9.advisories.yaml
+++ b/openjdk-9.advisories.yaml
@@ -4,102 +4,12 @@ package:
   name: openjdk-9
 
 advisories:
-  - id: CGA-x7wj-wgqx-c8v2
-    aliases:
-      - CVE-2023-21930
-      - GHSA-4j35-7cr4-3mc8
-    events:
-      - timestamp: 2024-04-04T11:31:08Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-demos
-            componentID: 6f29d36076a19cf8
-            componentName: openjdk-9-demos
-            componentVersion: 9.0.4-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
   - id: CGA-42qp-v3hv-ccrx
     aliases:
       - CVE-2023-21937
       - GHSA-vr26-5f5w-r829
     events:
       - timestamp: 2024-04-04T11:31:38Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-demos
-            componentID: 6f29d36076a19cf8
-            componentName: openjdk-9-demos
-            componentVersion: 9.0.4-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-8c3c-8832-4h4m
-    aliases:
-      - CVE-2023-21938
-      - GHSA-9pqg-44mx-r5gr
-    events:
-      - timestamp: 2024-04-04T11:31:48Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-demos
-            componentID: 6f29d36076a19cf8
-            componentName: openjdk-9-demos
-            componentVersion: 9.0.4-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-4w9h-9cr6-v5jj
-    aliases:
-      - CVE-2023-21939
-      - GHSA-xfrf-5cgw-f964
-    events:
-      - timestamp: 2024-04-04T11:32:04Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-demos
-            componentID: 6f29d36076a19cf8
-            componentName: openjdk-9-demos
-            componentVersion: 9.0.4-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-hjpf-3gwx-g4w7
-    aliases:
-      - CVE-2023-21954
-      - GHSA-8x3h-4f64-v6v6
-    events:
-      - timestamp: 2024-04-04T11:32:24Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-demos
-            componentID: 6f29d36076a19cf8
-            componentName: openjdk-9-demos
-            componentVersion: 9.0.4-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-vpr5-f53x-64jc
-    aliases:
-      - CVE-2023-21967
-      - GHSA-wg7x-fvjp-r3fx
-    events:
-      - timestamp: 2024-04-04T11:32:48Z
         type: detection
         data:
           type: scan/v1
@@ -130,12 +40,12 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-xr4c-6qfm-gwf2
+  - id: CGA-4w9h-9cr6-v5jj
     aliases:
-      - CVE-2023-22041
-      - GHSA-rgxf-494f-377c
+      - CVE-2023-21939
+      - GHSA-xfrf-5cgw-f964
     events:
-      - timestamp: 2024-04-04T11:33:54Z
+      - timestamp: 2024-04-04T11:32:04Z
         type: detection
         data:
           type: scan/v1
@@ -146,60 +56,6 @@ advisories:
             componentVersion: 9.0.4-r4
             componentType: apk
             componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-xg88-pcc2-j423
-    aliases:
-      - CVE-2023-25193
-      - GHSA-v8ff-vmc3-wr4m
-    events:
-      - timestamp: 2024-04-04T11:34:34Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-demos
-            componentID: 6f29d36076a19cf8
-            componentName: openjdk-9-demos
-            componentVersion: 9.0.4-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-frx4-q5x5-xcwm
-    aliases:
-      - CVE-2024-20918
-      - GHSA-45pc-2866-5hxx
-    events:
-      - timestamp: 2024-04-14T07:34:01Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-jre-base
-            componentID: bbe1181a4d4a9166
-            componentName: java
-            componentVersion: 9+9-wolfi-r4
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.9-openjdk/bin/java
-            scanner: grype
-
-  - id: CGA-w96j-8xp8-fmfh
-    aliases:
-      - CVE-2024-20919
-      - GHSA-vgxv-38wx-r77w
-    events:
-      - timestamp: 2024-04-14T07:34:03Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-jre-base
-            componentID: bbe1181a4d4a9166
-            componentName: java
-            componentVersion: 9+9-wolfi-r4
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.9-openjdk/bin/java
             scanner: grype
 
   - id: CGA-5724-8hfg-fh92
@@ -218,78 +74,6 @@ advisories:
             componentVersion: 9+9-wolfi-r4
             componentType: binary
             componentLocation: /usr/lib/jvm/java-1.9-openjdk/bin/java
-            scanner: grype
-
-  - id: CGA-xwmm-c29v-58c4
-    aliases:
-      - CVE-2024-20926
-      - GHSA-hjh6-9v4w-w32w
-    events:
-      - timestamp: 2024-04-14T07:34:06Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-jre-base
-            componentID: bbe1181a4d4a9166
-            componentName: java
-            componentVersion: 9+9-wolfi-r4
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.9-openjdk/bin/java
-            scanner: grype
-
-  - id: CGA-vc4h-mmw2-v2p6
-    aliases:
-      - CVE-2024-20932
-      - GHSA-ccwc-jrj7-h4v6
-    events:
-      - timestamp: 2024-05-24T07:20:27Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9
-            componentID: c13e23ad31c2bc23
-            componentName: openjdk-9
-            componentVersion: 9.0.4-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-pqh3-8cvq-h5j9
-    aliases:
-      - CVE-2024-20945
-      - GHSA-qj64-r5h2-w6f9
-    events:
-      - timestamp: 2024-04-14T07:34:08Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-jre-base
-            componentID: bbe1181a4d4a9166
-            componentName: java
-            componentVersion: 9+9-wolfi-r4
-            componentType: binary
-            componentLocation: /usr/lib/jvm/java-1.9-openjdk/bin/java
-            scanner: grype
-
-  - id: CGA-8v9x-28ww-q5x2
-    aliases:
-      - CVE-2024-20952
-      - GHSA-343v-9ccv-7535
-    events:
-      - timestamp: 2024-04-04T11:35:19Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openjdk-9-demos
-            componentID: 6f29d36076a19cf8
-            componentName: openjdk-9-demos
-            componentVersion: 9.0.4-r4
-            componentType: apk
-            componentLocation: /.PKGINFO
             scanner: grype
 
   - id: CGA-5xc4-6xmp-mhv5
@@ -328,12 +112,48 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
-  - id: CGA-m9f5-2jqm-j22m
+  - id: CGA-8c3c-8832-4h4m
     aliases:
-      - CVE-2024-21068
-      - GHSA-q4c6-w389-xqq6
+      - CVE-2023-21938
+      - GHSA-9pqg-44mx-r5gr
     events:
-      - timestamp: 2024-04-19T14:43:56Z
+      - timestamp: 2024-04-04T11:31:48Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-demos
+            componentID: 6f29d36076a19cf8
+            componentName: openjdk-9-demos
+            componentVersion: 9.0.4-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-8v9x-28ww-q5x2
+    aliases:
+      - CVE-2024-20952
+      - GHSA-343v-9ccv-7535
+    events:
+      - timestamp: 2024-04-04T11:35:19Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-demos
+            componentID: 6f29d36076a19cf8
+            componentName: openjdk-9-demos
+            componentVersion: 9.0.4-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-frx4-q5x5-xcwm
+    aliases:
+      - CVE-2024-20918
+      - GHSA-45pc-2866-5hxx
+    events:
+      - timestamp: 2024-04-14T07:34:01Z
         type: detection
         data:
           type: scan/v1
@@ -364,12 +184,197 @@ advisories:
             componentLocation: /usr/lib/jvm/java-1.9-openjdk/bin/java
             scanner: grype
 
+  - id: CGA-hjpf-3gwx-g4w7
+    aliases:
+      - CVE-2023-21954
+      - GHSA-8x3h-4f64-v6v6
+    events:
+      - timestamp: 2024-04-04T11:32:24Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-demos
+            componentID: 6f29d36076a19cf8
+            componentName: openjdk-9-demos
+            componentVersion: 9.0.4-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
   - id: CGA-jf7j-87c2-2j73
     aliases:
       - CVE-2024-21094
       - GHSA-g3wm-f7gr-3fwh
     events:
       - timestamp: 2024-04-19T14:44:01Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-jre-base
+            componentID: bbe1181a4d4a9166
+            componentName: java
+            componentVersion: 9+9-wolfi-r4
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.9-openjdk/bin/java
+            scanner: grype
+
+  - id: CGA-m9f5-2jqm-j22m
+    aliases:
+      - CVE-2024-21068
+      - GHSA-q4c6-w389-xqq6
+    events:
+      - timestamp: 2024-04-19T14:43:56Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-jre-base
+            componentID: bbe1181a4d4a9166
+            componentName: java
+            componentVersion: 9+9-wolfi-r4
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.9-openjdk/bin/java
+            scanner: grype
+
+  - id: CGA-pqh3-8cvq-h5j9
+    aliases:
+      - CVE-2024-20945
+      - GHSA-qj64-r5h2-w6f9
+    events:
+      - timestamp: 2024-04-14T07:34:08Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-jre-base
+            componentID: bbe1181a4d4a9166
+            componentName: java
+            componentVersion: 9+9-wolfi-r4
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.9-openjdk/bin/java
+            scanner: grype
+
+  - id: CGA-vc4h-mmw2-v2p6
+    aliases:
+      - CVE-2024-20932
+      - GHSA-ccwc-jrj7-h4v6
+    events:
+      - timestamp: 2024-05-24T07:20:27Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9
+            componentID: c13e23ad31c2bc23
+            componentName: openjdk-9
+            componentVersion: 9.0.4-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-06-05T12:26:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: NVD record says the affected version is 17.0.9, not a version range.
+
+  - id: CGA-vpr5-f53x-64jc
+    aliases:
+      - CVE-2023-21967
+      - GHSA-wg7x-fvjp-r3fx
+    events:
+      - timestamp: 2024-04-04T11:32:48Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-demos
+            componentID: 6f29d36076a19cf8
+            componentName: openjdk-9-demos
+            componentVersion: 9.0.4-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-w96j-8xp8-fmfh
+    aliases:
+      - CVE-2024-20919
+      - GHSA-vgxv-38wx-r77w
+    events:
+      - timestamp: 2024-04-14T07:34:03Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-jre-base
+            componentID: bbe1181a4d4a9166
+            componentName: java
+            componentVersion: 9+9-wolfi-r4
+            componentType: binary
+            componentLocation: /usr/lib/jvm/java-1.9-openjdk/bin/java
+            scanner: grype
+
+  - id: CGA-x7wj-wgqx-c8v2
+    aliases:
+      - CVE-2023-21930
+      - GHSA-4j35-7cr4-3mc8
+    events:
+      - timestamp: 2024-04-04T11:31:08Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-demos
+            componentID: 6f29d36076a19cf8
+            componentName: openjdk-9-demos
+            componentVersion: 9.0.4-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-xg88-pcc2-j423
+    aliases:
+      - CVE-2023-25193
+      - GHSA-v8ff-vmc3-wr4m
+    events:
+      - timestamp: 2024-04-04T11:34:34Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-demos
+            componentID: 6f29d36076a19cf8
+            componentName: openjdk-9-demos
+            componentVersion: 9.0.4-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-xr4c-6qfm-gwf2
+    aliases:
+      - CVE-2023-22041
+      - GHSA-rgxf-494f-377c
+    events:
+      - timestamp: 2024-04-04T11:33:54Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openjdk-9-demos
+            componentID: 6f29d36076a19cf8
+            componentName: openjdk-9-demos
+            componentVersion: 9.0.4-r4
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+
+  - id: CGA-xwmm-c29v-58c4
+    aliases:
+      - CVE-2024-20926
+      - GHSA-hjh6-9v4w-w32w
+    events:
+      - timestamp: 2024-04-14T07:34:06Z
         type: detection
         data:
           type: scan/v1


### PR DESCRIPTION
The diff looks weird... I wouldn't expect reordering to happen, cc: @cpanato 

Here's the business logic-aware diff:

```console
$ wolfictl adv diff
Auto-detected distro: Wolfi

( - removed / ~ modified / + added )

~ document "openjdk-10"
  ~ advisory "CGA-p98q-52v3-j278"
    + event "false-positive-determination" @ 2024-06-05T12:27:37Z
~ document "openjdk-11"
  ~ advisory "CGA-35qf-ggjq-7xrf"
    + event "false-positive-determination" @ 2024-06-05T12:28:07Z
~ document "openjdk-12"
  ~ advisory "CGA-pj65-xr32-978w"
    + event "false-positive-determination" @ 2024-06-05T12:28:21Z
~ document "openjdk-13"
  ~ advisory "CGA-p74m-xf73-7g2j"
    + event "false-positive-determination" @ 2024-06-05T12:28:39Z
~ document "openjdk-14"
  ~ advisory "CGA-x929-j5hp-m894"
    + event "false-positive-determination" @ 2024-06-05T12:28:57Z
~ document "openjdk-15"
  ~ advisory "CGA-gqq8-8g86-85hx"
    + event "false-positive-determination" @ 2024-06-05T12:29:43Z
~ document "openjdk-16"
  ~ advisory "CGA-6hx7-6w3p-7824"
    + event "false-positive-determination" @ 2024-06-05T12:30:02Z
~ document "openjdk-7"
  ~ advisory "CGA-822h-xhw6-v52h"
    + event "false-positive-determination" @ 2024-06-05T12:24:45Z
~ document "openjdk-8"
  ~ advisory "CGA-p68w-hvwf-gr64"
    + event "false-positive-determination" @ 2024-06-05T12:22:39Z
~ document "openjdk-9"
  ~ advisory "CGA-vc4h-mmw2-v2p6"
    + event "false-positive-determination" @ 2024-06-05T12:26:11Z
```