### PR TITLE
fix(openssl): CVE-2024-4603 was fixed not nacked

### DIFF
--- a/openssl.advisories.yaml
+++ b/openssl.advisories.yaml
@@ -121,23 +121,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.3.0-r8
-      - timestamp: 2024-05-30T07:20:32Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: openssl
-            componentID: 3a54114a51f84e92
-            componentName: openssl
-            componentVersion: 3.3.0
-            componentType: binary
-            componentLocation: /usr/bin/openssl
-            scanner: grype
-      - timestamp: 2024-05-31T10:19:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: This code has been manually patched using the upstream patches from commit (85ccbab216da245cf9a6503dd327072f21950d9b).
 
   - id: CGA-c2c3-7c62-3x6m
     aliases:


### PR DESCRIPTION
cc: @cpanato @hectorj2f 

Expected validation result:

```text
invalid change(s) in diff:
    openssl:
        CGA-9c28-ww88-6g95:
            one or more events were removed
```