### PR TITLE
Mark Pending upstream fix for 2nd detection of the CVE in metric-collector-for-apache-cassandra

### DIFF
--- a/metric-collector-for-apache-cassandra.advisories.yaml
+++ b/metric-collector-for-apache-cassandra.advisories.yaml
@@ -25,3 +25,8 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/metrics-collector/datastax-mcac-agent-0.3.3.jar
             scanner: grype
+      - timestamp: 2024-06-10T10:20:13Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            To fix the CVE, we have to upgrade 'snakeyaml' to '2.0' or later but this fix will require some code change since the upgrade cause to build fail due to compilation errors like: "/src/main/java/com/datastax/mcac/ConfigurationLoader.java:[106,19] incompatible types: java.lang.Class<capture#1 of ?> cannot be converted to org.yaml.snakeyaml.LoaderOptions"


### PR DESCRIPTION
Marking it as upstream fix as there is a breaking changes in snakeyaml 2.0 which causing failure in build.
Changelog snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes