### PR TITLE
datadog-agent: re-append pending-upstream-fix issue

### DIFF
--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -50,6 +50,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 7.54.0-r1
+      - timestamp: 2024-06-11T20:00:27Z
+        type: pending-upstream-fix
+        data:
+          note: The tuf non-vulnerable version is not available among the list of hosted datadog dependencies. Datadog needs to upgrade the available tuf dependency to use the non-vulnerable version.
 
   - id: CGA-6p96-qff9-wmqm
     aliases:


### PR DESCRIPTION
This issue has been marked as fixed, but we need to re-append the pending-upstream-fix event again.