### PR TITLE
Remove extra scan event for CVE-2023-27043.

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -58,18 +58,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.10.13-r5
-      - timestamp: 2024-05-23T07:35:45Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: python-3.10
-            componentID: 4bd99e38d1761a8a
-            componentName: python
-            componentVersion: 3.10.14
-            componentType: binary
-            componentLocation: /usr/bin/python3.10, /usr/lib/libpython3.10.so.1.0
-            scanner: grype
 
   - id: CGA-6xpf-gwq5-cp42
     aliases:


### PR DESCRIPTION
This shouldn't be present and is causing security scanners to miss this fix event.