### PR TITLE
GHSA-c5q2-7r4c-mv6g: add advisory entries for the affected packages

### DIFF
--- a/kots.advisories.yaml
+++ b/kots.advisories.yaml
@@ -337,6 +337,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kots
             scanner: grype
+      - timestamp: 2024-06-12T07:05:14Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability has recently updated the list of affected packages. Unfortunately the new affected package 'gopkg.in/square/go-jose.v2' is currently used by many indirect dependencies to this package which makes impossible to fix it without upstream code changes.
 
   - id: CGA-rv9j-m6wv-xr75
     aliases:

--- a/kubernetes-dashboard.advisories.yaml
+++ b/kubernetes-dashboard.advisories.yaml
@@ -85,6 +85,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/share/kubernetes-dashboard/dashboard
             scanner: grype
+      - timestamp: 2024-06-12T07:05:14Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability has recently updated the list of affected packages. Unfortunately the new affected package 'gopkg.in/square/go-jose.v2' is currently used by many indirect dependencies to this package which makes impossible to fix it without upstream code changes.
 
   - id: CGA-7fv2-8xrw-rg82
     aliases:

--- a/neuvector-controller.advisories.yaml
+++ b/neuvector-controller.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/local/bin/controller
             scanner: grype
+      - timestamp: 2024-06-12T07:05:14Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability has recently updated the list of affected packages. Unfortunately the new affected package 'gopkg.in/square/go-jose.v2' is currently used by many indirect dependencies to this package which makes impossible to fix it without upstream code changes.
 
   - id: CGA-c9g7-qfj6-p2g3
     aliases:

--- a/traefik.advisories.yaml
+++ b/traefik.advisories.yaml
@@ -113,6 +113,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/traefik
             scanner: grype
+      - timestamp: 2024-06-12T07:05:14Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability has recently updated the list of affected packages. Unfortunately the new affected package 'gopkg.in/square/go-jose.v2' is currently used by many indirect dependencies to this package which makes impossible to fix it without upstream code changes.
 
   - id: CGA-fj5h-2qwj-2xpj
     aliases:

--- a/zot.advisories.yaml
+++ b/zot.advisories.yaml
@@ -474,6 +474,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/zot
             scanner: grype
+      - timestamp: 2024-06-12T07:05:14Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability has recently updated the list of affected packages. Unfortunately the new affected package 'gopkg.in/square/go-jose.v2' is currently used by many indirect dependencies to this package which makes impossible to fix it without upstream code changes.
 
   - id: CGA-vp7m-2gwq-p332
     aliases:


### PR DESCRIPTION
The new affected package makes unmanageable  to replace or patch the code due to the amount of indirect dependencies that still use it for most of the repositories. 