### PR TITLE
 jitsucom-jitsu: Fix timestamp for the pending-upstrem-fix event 

### DIFF
--- a/jitsucom-jitsu.advisories.yaml
+++ b/jitsucom-jitsu.advisories.yaml
@@ -21,7 +21,7 @@ advisories:
             componentType: npm
             componentLocation: /app/node_modules/.pnpm/html-minifier@4.0.0/node_modules/html-minifier/package.json
             scanner: grype
-      - timestamp: 2024-05-08T09:43:49Z
+      - timestamp: 2024-05-08T21:43:49Z
         type: pending-upstream-fix
         data:
           note: |


### PR DESCRIPTION
The pending-upstream-fix was added before the detection event when it should have happened the other way around. This could have been caused by a bad rebase.