### PR TITLE
python-3.10: Delete incorrect "detection" advisory

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -54,18 +54,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.10.13-r5
-      - timestamp: 2024-05-23T07:35:45Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: python-3.10
-            componentID: 4bd99e38d1761a8a
-            componentName: python
-            componentVersion: 3.10.14
-            componentType: binary
-            componentLocation: /usr/bin/python3.10, /usr/lib/libpython3.10.so.1.0
-            scanner: grype
 
   - id: CVE-2023-36632
     aliases:


### PR DESCRIPTION
I'm a bit puzzled as to what happened here. When I scan our `python-3.10` package there are no findings. We patched python-3.10 (https://github.com/wolfi-dev/advisories/pull/1738).

It's possible that our advisory automation reacted to an older scan, perhaps? It would be helpful to include the APK package version in the detection metadata to make this type of problem more debuggable.