### PR TITLE
nodejs-18: CVE-2024-21890

### DIFF
--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -103,6 +103,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-06-15T14:49:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability only affects active release lines 20.x and 21.x. More information: https://nodejs.org/en/blog/vulnerability/february-2024-security-releases'
 
   - id: CGA-h4hq-pj3g-852q
     aliases:


### PR DESCRIPTION
nodejs-18 was never affected per the February report: https://nodejs.org/en/blog/vulnerability/february-2024-security-releases