### PR TITLE
libreoffice-24.2: CVE-2012-5639 advisory `libreoffice`

### DIFF
--- a/libreoffice-24.2.advisories.yaml
+++ b/libreoffice-24.2.advisories.yaml
@@ -21,3 +21,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-06-15T15:51:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This is a CVE which was reported against libreoffice, but was contested as a feature request. It has since been closed in that regard. For more info - https://bugs.documentfoundation.org/show_bug.cgi?id=58295&redirected_from=fdo


### PR DESCRIPTION
Copying over the advisory for CVE-2012-5639 as described on the `libreoffice` package.