### PR TITLE
add missing adv for airflow (GHSA-34jh-p97f-mpxf)

### DIFF
--- a/airflow.advisories.yaml
+++ b/airflow.advisories.yaml
@@ -116,6 +116,10 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/venv/lib/python3.12/site-packages/urllib3-2.2.1.dist-info/METADATA, /opt/airflow/venv/lib/python3.12/site-packages/urllib3-2.2.1.dist-info/RECORD
             scanner: grype
+      - timestamp: 2024-06-20T10:34:07Z
+        type: fixed
+        data:
+          fixed-version: 2.9.2-r1
 
   - id: CGA-8mx8-8v5r-99xg
     aliases:


### PR DESCRIPTION
```
$ wolfictl scan -r airflow
📡 Finding remote packages
🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/x86_64-airflow-2.9.2-r1-2509240695.apk"
├── 📄 /opt/airflow/venv/lib/python3.12/site-packages/cryptography-41.0.7.dist-info/METADATA, /opt/airflow/venv/lib/python3.12/site-packages/cryptography-41.0.7.dist-info/RECORD, /opt/airflow/venv/lib/python3.12/site-packages/cryptography-41.0.7.dist-info/top_level.txt
│       📦 cryptography 41.0.7 (python)
│           High CVE-2023-50782 GHSA-3ww4-gg4f-jr7f fixed in 42.0.0
│           High CVE-2024-26130 GHSA-6vqw-3v5j-54x4 fixed in 42.0.4
│           Medium CVE-2024-0727 GHSA-9v9h-cgj8-h64p fixed in 42.0.2
│
└── 📄 /opt/airflow/venv/lib/python3.12/site-packages/werkzeug-2.3.8.dist-info/METADATA, /opt/airflow/venv/lib/python3.12/site-packages/werkzeug-2.3.8.dist-info/RECORD
        📦 Werkzeug 2.3.8 (python)
            High CVE-2024-34069 GHSA-2g68-c3qc-8985 fixed in 3.0.3

🔎 Scanning "/var/folders/kl/q9mydw095ln5s7wj971qcrx40000gn/T/aarch64-airflow-2.9.2-r1-2874468551.apk"
├── 📄 /opt/airflow/venv/lib/python3.12/site-packages/cryptography-41.0.7.dist-info/METADATA, /opt/airflow/venv/lib/python3.12/site-packages/cryptography-41.0.7.dist-info/RECORD, /opt/airflow/venv/lib/python3.12/site-packages/cryptography-41.0.7.dist-info/top_level.txt
│       📦 cryptography 41.0.7 (python)
│           High CVE-2023-50782 GHSA-3ww4-gg4f-jr7f fixed in 42.0.0
│           High CVE-2024-26130 GHSA-6vqw-3v5j-54x4 fixed in 42.0.4
│           Medium CVE-2024-0727 GHSA-9v9h-cgj8-h64p fixed in 42.0.2
│
└── 📄 /opt/airflow/venv/lib/python3.12/site-packages/werkzeug-2.3.8.dist-info/METADATA, /opt/airflow/venv/lib/python3.12/site-packages/werkzeug-2.3.8.dist-info/RECORD
        📦 Werkzeug 2.3.8 (python)
            High CVE-2024-34069 GHSA-2g68-c3qc-8985 fixed in 3.0.3

```