### PR TITLE
Pending upstream fix for GHSA-34jh-p97f-mpxf in py3-cassandra-medusa

### DIFF
--- a/py3-cassandra-medusa.advisories.yaml
+++ b/py3-cassandra-medusa.advisories.yaml
@@ -109,6 +109,10 @@ advisories:
             componentType: python
             componentLocation: /home/cassandra/.venv/lib/python3.11/site-packages/urllib3-2.0.7.dist-info/METADATA, /home/cassandra/.venv/lib/python3.11/site-packages/urllib3-2.0.7.dist-info/RECORD
             scanner: grype
+      - timestamp: 2024-06-20T18:57:46Z
+        type: pending-upstream-fix
+        data:
+          note: cassandra-medusa depends on botocore which latest version is still depends on urllib3 (>=1.25.4,<1.27). Require botocore to update urllib3 dependency.
 
   - id: CGA-692f-82fw-6r2x
     aliases:


### PR DESCRIPTION
cassandra-medusa depends on botocore which latest version is still depends on urllib3 (>=1.25.4,<1.27). Require botocore to update urllib3 dependency.

try to update the python version from 3.11 to 3.12 but getting error