### PR TITLE
vault-csi-provider.advisories missing advisory event entry

### DIFF
--- a/vault-csi-provider.advisories.yaml
+++ b/vault-csi-provider.advisories.yaml
@@ -309,6 +309,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/vault-csi-provider
             scanner: grype
+      - timestamp: 2024-06-25T09:19:43Z
+        type: pending-upstream-fix
+        data:
+          note: There is no fix for dependency gopkg.in/square/go-jose.v2 and to fix that need code changes to replace the affected dependency.
 
   - id: CGA-jvpc-p2v5-92fx
     aliases:


### PR DESCRIPTION
To fix GHSA-c5q2-7r4c-mv6g, it is necessary to make code changes to the upstream repository.