### PR TITLE
Adds a false positive event for mariadb-test CVE-2024-1597

### DIFF
--- a/mariadb-10.11.advisories.yaml
+++ b/mariadb-10.11.advisories.yaml
@@ -4,12 +4,12 @@ package:
   name: mariadb-10.11
 
 advisories:
-  - id: CGA-69ff-4xff-qv2w
+  - id: CGA-4p65-rcvr-255v
     aliases:
-      - CVE-2020-13692
-      - GHSA-88cc-g835-76rp
+      - CVE-2022-21724
+      - GHSA-v7wg-cpwc-24m4
     events:
-      - timestamp: 2024-01-24T16:39:12Z
+      - timestamp: 2024-01-24T16:39:13Z
         type: detection
         data:
           type: scan/v1
@@ -22,12 +22,12 @@ advisories:
             componentLocation: /usr/mysql-test/plugin/connect/connect/std_data/JdbcMariaDB.jar
             scanner: grype
 
-  - id: CGA-4p65-rcvr-255v
+  - id: CGA-69ff-4xff-qv2w
     aliases:
-      - CVE-2022-21724
-      - GHSA-v7wg-cpwc-24m4
+      - CVE-2020-13692
+      - GHSA-88cc-g835-76rp
     events:
-      - timestamp: 2024-01-24T16:39:13Z
+      - timestamp: 2024-01-24T16:39:12Z
         type: detection
         data:
           type: scan/v1
@@ -76,3 +76,8 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/mysql-test/plugin/connect/connect/std_data/JdbcMariaDB.jar
             scanner: grype
+      - timestamp: 2024-06-25T18:11:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This CVE appears to stem from a hardcoded postgres jar file used specifically for a stale test

--- a/mariadb-11.2.advisories.yaml
+++ b/mariadb-11.2.advisories.yaml
@@ -60,6 +60,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/mariadb-test/plugin/connect/connect/std_data/JdbcMariaDB.jar
             scanner: grype
+      - timestamp: 2024-06-25T18:13:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This CVE appears to stem from a hardcoded postgres jar file used specifically for a stale test
 
   - id: CGA-63j7-vh89-wc5p
     aliases:


### PR DESCRIPTION
https://github.com/wolfi-dev/os/actions/runs/9651623275/job/26621058665?pr=22539

Found the CVE reported in the above OS PR check and did some digging: 
* In the upstream repository, they are pulling in a hardcoded postgres jar file for a test (really old version) that _shouldn't_ be in the live execution path for mariadb
* We _could_ even consider removing the test package as there are no public OS packages depending on it. 