### PR TITLE
Pending upstream fix for go-jose.v2 in traefik-3.0

### DIFF
--- a/traefik-3.0.advisories.yaml
+++ b/traefik-3.0.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/traefik
             scanner: grype
+      - timestamp: 2024-06-26T16:50:14Z
+        type: pending-upstream-fix
+        data:
+          note: There is no fix for dependency gopkg.in/square/go-jose.v2 and to fix that need code changes to replace the affected dependency.


### PR DESCRIPTION
GHSA-c5q2-7r4c-mv6g