### PR TITLE
fix teleport timestamp for the false positive event

### DIFF
--- a/teleport.advisories.yaml
+++ b/teleport.advisories.yaml
@@ -63,7 +63,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/local/bin/tsh
             scanner: grype
-      - timestamp: 2024-05-24T16:20:22Z
+      - timestamp: 2024-05-26T16:20:22Z
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used

--- a/teleport.advisories.yaml
+++ b/teleport.advisories.yaml
@@ -63,7 +63,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/local/bin/tsh
             scanner: grype
-      - timestamp: 2024-05-26T16:20:22Z
+      - timestamp: 2024-06-26T16:20:22Z
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used


### PR DESCRIPTION
The false positive event had an older timestamp than the detection event which suggests a problem during the rebase of the events.

