### PR TITLE
Revert "advise cluster-autoscaler-1.26 CVE-2024-3177"

### DIFF
--- a/cluster-autoscaler-1.26.advisories.yaml
+++ b/cluster-autoscaler-1.26.advisories.yaml
@@ -96,13 +96,3 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.26.4-r5
-
-  - id: CVE-2024-3177
-    aliases:
-      - GHSA-pxhw-596r-rwq5
-    events:
-      - timestamp: 2024-06-26T11:12:15Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Go vulndb has marked this CVE as a false positive.


### PR DESCRIPTION
Reverts wolfi-dev/advisories#6120

This advisory event should be added in enterprise-advisories repository.