### PR TITLE
argo-cd-2.11: GHSA-m5vv-6r4h-3vj9

### DIFF
--- a/argo-cd-2.11.advisories.yaml
+++ b/argo-cd-2.11.advisories.yaml
@@ -31,6 +31,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argocd
             scanner: grype
+      - timestamp: 2024-06-27T01:35:56Z
+        type: pending-upstream-fix
+        data:
+          note: "This vulnerability requires upstream changes to upgrade a strict dependency 'github.com/Azure/kubelogin' from the current v0.0.20 version to v0.1.3 which does not contain any vulnerable code.
 
   - id: CGA-8x39-9j48-5wcw
     aliases:

--- a/argo-cd-2.11.advisories.yaml
+++ b/argo-cd-2.11.advisories.yaml
@@ -34,7 +34,7 @@ advisories:
       - timestamp: 2024-06-27T01:35:56Z
         type: pending-upstream-fix
         data:
-          note: "This vulnerability requires upstream changes to upgrade a strict dependency 'github.com/Azure/kubelogin' from the current v0.0.20 version to v0.1.3 which does not contain any vulnerable code.
+          note: "This vulnerability requires upstream changes to upgrade a strict dependency 'github.com/Azure/kubelogin' from the current v0.0.20 version to v0.1.3 which does not contain any vulnerable code."
 
   - id: CGA-8x39-9j48-5wcw
     aliases:


### PR DESCRIPTION
Bumping kube-login to the non-vulnerable version breaks the rest of the code.