### PR TITLE
mlflow: Mark CVEs as pending-upstream-fix

### DIFF
--- a/mlflow.advisories.yaml
+++ b/mlflow.advisories.yaml
@@ -25,6 +25,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.13.2-r0
+      - timestamp: 2024-07-02T18:47:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest versions have been recognized as affected. The upstream project has been alerted: https://github.com/mlflow/mlflow/issues/12256'
 
   - id: CGA-3f38-vqc4-r77r
     aliases:
@@ -47,6 +51,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.13.2-r0
+      - timestamp: 2024-07-02T18:47:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest versions have been recognized as affected. The upstream project has been alerted: https://github.com/mlflow/mlflow/issues/12256'
 
   - id: CGA-5rg5-hmwm-f62r
     aliases:
@@ -69,6 +77,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.13.2-r0
+      - timestamp: 2024-07-02T18:47:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest versions have been recognized as affected. The upstream project has been alerted: https://github.com/mlflow/mlflow/issues/12256'
 
   - id: CGA-65wr-34fv-rm58
     aliases:
@@ -91,6 +103,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.13.2-r0
+      - timestamp: 2024-07-02T18:47:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest versions have been recognized as affected. The upstream project has been alerted: https://github.com/mlflow/mlflow/issues/12256'
 
   - id: CGA-92hc-jqrg-xcvw
     aliases:
@@ -113,6 +129,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.13.2-r0
+      - timestamp: 2024-07-02T18:47:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest versions have been recognized as affected. The upstream project has been alerted: https://github.com/mlflow/mlflow/issues/12256'
 
   - id: CGA-9rf9-q23x-g8v6
     aliases:
@@ -135,6 +155,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.13.2-r0
+      - timestamp: 2024-07-02T18:47:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest versions have been recognized as affected. The upstream project has been alerted: https://github.com/mlflow/mlflow/issues/12256'
 
   - id: CGA-cm9x-7fjr-fcm9
     aliases:
@@ -179,6 +203,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.13.2-r0
+      - timestamp: 2024-07-02T18:47:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest versions have been recognized as affected. The upstream project has been alerted: https://github.com/mlflow/mlflow/issues/12256'
 
   - id: CGA-hhrg-5mf5-r2p5
     aliases:
@@ -223,6 +251,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.13.2-r0
+      - timestamp: 2024-07-02T18:47:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest versions have been recognized as affected. The upstream project has been alerted: https://github.com/mlflow/mlflow/issues/12256'
 
   - id: CGA-jqq5-p5w5-hr5j
     aliases:
@@ -267,3 +299,7 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.13.2-r0
+      - timestamp: 2024-07-02T18:47:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest versions have been recognized as affected. The upstream project has been alerted: https://github.com/mlflow/mlflow/issues/12256'


### PR DESCRIPTION
The fixed version range has been updated on GHSA and the fix for these vulnerabilities is disputed: https://github.com/mlflow/mlflow/issues/12256

Marking as pending-upstream-fix since these findings are still showing on scanners.