### PR TITLE
sonarqube: GHSA-4h8f-2wvx-gg5w

### DIFF
--- a/sonarqube.advisories.yaml
+++ b/sonarqube.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/lib/tools/security-cli/bcprov-jdk18on-1.76.jar
             scanner: grype
+      - timestamp: 2024-07-03T21:22:31Z
+        type: pending-upstream-fix
+        data:
+          note: "The ElasticSearch dependency within SonarQube must be bumped in the upstream for fixing this CVE in bcprov-jdk18on. Additionally, sonarqube core package uses a bcprov-jdk18on non-vulnerable version '1.78.1'."
 
   - id: CGA-c5gx-g32r-3gqj
     aliases:


### PR DESCRIPTION
The ElasticSearch dependency within SonarQube must be bumped in the upstream for fixing this CVE in bcprov-jdk18on. Additionally, sonarqube core package uses a bcprov-jdk18on non-vulnerable version '1.78.1'.