### PR TITLE
datadog-agent: GHSA-248v-346w-9cwc

### DIFF
--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -369,6 +369,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/datadog-agent/lib/python3.11/site-packages/certifi-2024.6.2.dist-info/METADATA, /usr/share/datadog-agent/lib/python3.11/site-packages/certifi-2024.6.2.dist-info/RECORD, /usr/share/datadog-agent/lib/python3.11/site-packages/certifi-2024.6.2.dist-info/direct_url.json, /usr/share/datadog-agent/lib/python3.11/site-packages/certifi-2024.6.2.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-07-07T08:29:50Z
+        type: pending-upstream-fix
+        data:
+          note: The certifi non-vulnerable version is not available among the list of hosted datadog dependencies. Datadog needs to upgrade the available certifi dependency to use the non-vulnerable version.
 
   - id: CGA-q6w9-959q-j875
     aliases:


### PR DESCRIPTION
The hosted version of certifi under Datadog servers doesn't have the non-vulnerable version yet.