### PR TITLE
wordpress: CVE-2007-2627, CVE-2012-4271, CVE-2012-6527, CVE-2013-7240…

### DIFF
--- a/wordpress.advisories.yaml
+++ b/wordpress.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-07-12T09:56:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Affected package is an entrypoint script used to setup environment and config files, this doesn't include and wordpress php code
 
   - id: CGA-8gfh-h5vg-754q
     aliases:
@@ -39,6 +44,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-07-12T09:50:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Affected package is an entrypoint script used to setup environment and config files, this doesn't include and wordpress php code
 
   - id: CGA-g3j4-4p89-vgpq
     aliases:
@@ -57,6 +67,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-07-12T09:55:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Affected package is an entrypoint script used to setup environment and config files, this doesn't include and wordpress php code
 
   - id: CGA-j295-hqc3-w776
     aliases:
@@ -75,6 +90,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-07-12T09:54:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Affected package is an entrypoint script used to setup environment and config files, this doesn't include and wordpress php code
 
   - id: CGA-r3mv-fhmp-j2ph
     aliases:
@@ -93,3 +113,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-07-12T09:55:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Affected package is an entrypoint script used to setup environment and config files, this doesn't include and wordpress php code


### PR DESCRIPTION
…, CVE-2011-5216

The affected package from the Grype scan is the OCI entrypoint script that contains no PHP code