### PR TITLE
CVE-2016-1000027: Publish corrected information

### DIFF
--- a/apache-nifi.advisories.yaml
+++ b/apache-nifi.advisories.yaml
@@ -1370,6 +1370,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: Remediating this CVE will require upgrading from Spring v5 to Spring v6, which is a major version increment with high risk. Awaiting for Upstream to migrate from Spring 5.3.x to 6.x
+      - timestamp: 2024-07-16T18:09:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: 'This CVE is disputed by upstream Spring Framework developers: https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-582313417. The Spring Framework provides an option to invoke ObjectInputStream (along with documented warnings). The presence of this capability in the Spring Framework doesn''t represent a vulnerability.'
 
   - id: CGA-vqqq-58x5-rqr9
     aliases:

--- a/jenkins.advisories.yaml
+++ b/jenkins.advisories.yaml
@@ -134,6 +134,11 @@ advisories:
         data:
           type: vulnerable-code-not-in-execution-path
           note: Data serialization is performed by the Jenkins framework, nothing specific to this application.
+      - timestamp: 2024-07-16T18:09:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: 'This CVE is disputed by upstream Spring Framework developers: https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-582313417. The Spring Framework provides an option to invoke ObjectInputStream (along with documented warnings). The presence of this capability in the Spring Framework doesn''t represent a vulnerability.'
 
   - id: CGA-96m8-9rvf-gh6w
     aliases:


### PR DESCRIPTION
Update advisories for CVE-2016-1000027 on `jenkins` and `apache-nifi` for consistency. CVE-2016-1000027 is largely contested. This change includes more information in our advisory feed.