### PR TITLE
libgcrypt: CVE-2024-2236

### DIFF
--- a/libgcrypt.advisories.yaml
+++ b/libgcrypt.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: 2.0.2
+
+package:
+  name: libgcrypt
+
+advisories:
+  - id: CGA-gfvq-j3vc-vxvm
+    aliases:
+      - CVE-2024-2236
+      - GHSA-w2gx-4fh8-wm9f
+    events:
+      - timestamp: 2024-07-18T19:46:34Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability has no upstream fix for this issue as of 2024-06-17.


### PR DESCRIPTION
This vulnerability wasn't detected by our scanners but we want to add a note about it for customers.