### PR TITLE
dotnet-8: CVE-2024-38095, CVE-2024-30105

### DIFF
--- a/dotnet-8.advisories.yaml
+++ b/dotnet-8.advisories.yaml
@@ -1,0 +1,25 @@
+schema-version: 2.0.2
+
+package:
+  name: dotnet-8
+
+advisories:
+  - id: CGA-972h-cm25-9vm2
+    aliases:
+      - CVE-2024-38095
+      - GHSA-447r-wph3-92pm
+    events:
+      - timestamp: 2024-07-30T00:09:04Z
+        type: fixed
+        data:
+          fixed-version: 8.0.7-r0
+
+  - id: CGA-jh5q-2rrw-hwjq
+    aliases:
+      - CVE-2024-30105
+      - GHSA-hh2w-p6rv-4g7w
+    events:
+      - timestamp: 2024-07-30T00:05:41Z
+        type: fixed
+        data:
+          fixed-version: 8.0.7-r0


### PR DESCRIPTION
CVE-2024-30105 was fixed in `8.0.7` according to https://github.com/dotnet/runtime/issues/104619.

CVE-2024-38095 was fixed in `8.0.7` according to https://nvd.nist.gov/vuln/detail/CVE-2024-38095.