### PR TITLE
Update buck2.advisories.yaml

### DIFF
--- a/buck2.advisories.yaml
+++ b/buck2.advisories.yaml
@@ -46,15 +46,3 @@ advisories:
         type: fixed
         data:
           fixed-version: 20240701-r2
-      - timestamp: 2024-07-31T08:17:21Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: buck2
-            componentID: d524ae68101acd7d
-            componentName: anymap
-            componentVersion: 0.12.1
-            componentType: rust-crate
-            componentLocation: /usr/bin/buck2
-            scanner: grype


### PR DESCRIPTION
this was fixed using a patch but there is no fixed version in https://github.com/advisories/GHSA-hc92-9h3m-c39j