### PR TITLE
CVE-2024-41110, GHSA-v23v-6jw2-98fq - advisory for zarf

### DIFF
--- a/zarf.advisories.yaml
+++ b/zarf.advisories.yaml
@@ -98,6 +98,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/zarf
             scanner: grype
+      - timestamp: 2024-05-17T08:31:36Z
+        type: pending-upstream-fix
+        data:
+          note: We are unable to upgrade this dependency as this introduces breaking changes. There are multiple dependencies which are using depreciated methods, including orcas-go and moby. Waiting for upstream to fix and issue a new release.
 
   - id: CGA-687x-cx28-9fcm
     aliases:

--- a/zarf.advisories.yaml
+++ b/zarf.advisories.yaml
@@ -98,7 +98,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/zarf
             scanner: grype
-      - timestamp: 2024-05-17T08:31:36Z
+      - timestamp: 2024-08-04T21:08:05Z
         type: pending-upstream-fix
         data:
           note: We are unable to upgrade this dependency as this introduces breaking changes. There are multiple dependencies which are using depreciated methods, including orcas-go and moby. Waiting for upstream to fix and issue a new release.


### PR DESCRIPTION
Raising 'pending-upstream-fix' advisory for zarf, as we're unable to remediate this CVE ourselves by bumping the dependency.