### PR TITLE
python-3.12 - Mark CVE-2024-6923 as fixed in 3.12.5

### DIFF
--- a/python-3.12.advisories.yaml
+++ b/python-3.12.advisories.yaml
@@ -140,6 +140,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-08-08T14:31:44Z
+        type: fixed
+        data:
+          fixed-version: 3.12.5-r0
 
   - id: CGA-xh4x-jg73-pf94
     aliases:


### PR DESCRIPTION
The fix for this issue was included in upstream release of 3.12.5. https://github.com/python/cpython/pull/122599