### PR TITLE
feat(cve remediation): Remediate CVE GHSA-v23v-6jw2-98fq in kaniko

### DIFF
--- a/kaniko.advisories.yaml
+++ b/kaniko.advisories.yaml
@@ -97,6 +97,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/executor
             scanner: grype
+      - timestamp: 2024-08-09T15:11:43Z
+        type: pending-upstream-fix
+        data:
+          note: There has been two attempts at remediating this CVE upstream wit attempted docker upgrades @ https://github.com/GoogleContainerTools/kaniko/pull/3278 and https://github.com/GoogleContainerTools/kaniko/pull/3270. Both attempts failed with failing tests. As such marking this CVE as pending-upstream-fix.
 
   - id: CGA-f5hh-5rrg-27h8
     aliases:


### PR DESCRIPTION
kaniko 1.23.2-r1 is vulnerable to GHSA-v23v-6jw2-98fq/CVE-2024-41110

There has been two attempts at remediating this CVE upstream wit attempted docker
upgrades @ https://github.com/GoogleContainerTools/kaniko/pull/3278 and
https://github.com/GoogleContainerTools/kaniko/pull/3270.

Both attempts failed with failing tests.

As such marking this CVE as pending-upstream-fix.

Links:

GHSA-v23v-6jw2-98fq - https://github.com/advisories/GHSA-v23v-6jw2-98fq

Signed-off-by: philroche <phil.roche@chainguard.dev>
