### PR TITLE
chore(harbor-2.11): Add advisory for CVE-2024-40465

### DIFF
--- a/harbor-2.11.advisories.yaml
+++ b/harbor-2.11.advisories.yaml
@@ -69,6 +69,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.11.0-r3
+      - timestamp: 2024-08-12T13:02:28Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability can not be remediated by upgrading beego without making additional changes to Harbor. Upstream has merged a fix on main, but this hasn't been backported to released versions of Harbor.
 
   - id: CGA-8m74-393p-mc58
     aliases:


### PR DESCRIPTION
This vulnerability can not be remediated by upgrading beego without making additional changes to Harbor. Upstream has merged a fix on main, but this hasn't been backported to released versions of Harbor.