### PR TITLE
chromium: CVE-2024-7533 is a false positive

### DIFF
--- a/chromium.advisories.yaml
+++ b/chromium.advisories.yaml
@@ -1573,6 +1573,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-08-13T23:52:31Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This match comes from the scanner mis-processing CPE data: the vulnerability is specific to iOS.'
 
   - id: CGA-xg53-gr2g-vffm
     aliases:


### PR DESCRIPTION
This looks like another victim of https://github.com/anchore/grype/issues/1349.