### PR TITLE
airflow: add adv entry for GHSA-62qf-qm3g-fvcw

### DIFF
--- a/airflow.advisories.yaml
+++ b/airflow.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/venv/lib/python3.12/site-packages/apache_airflow_providers_fab-1.2.1.dist-info/METADATA, /opt/airflow/venv/lib/python3.12/site-packages/apache_airflow_providers_fab-1.2.1.dist-info/RECORD
             scanner: grype
+      - timestamp: 2024-08-14T15:23:17Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability requires a new release to include an upgrade of the apache-airflow-providers-fab module to a non-vulnerable version v1.2.2. This upgrade has been included into a recent release candidate '2.10.0rc1'.
 
   - id: CGA-33w6-99cx-72gx
     aliases:


### PR DESCRIPTION
A non vulnerable version is available in main and in a recent release candidate `2.10.0rc1` so we assume a new stable release won't take much time. Otherwise, any attempt to bump this dependency might cause other issues, so I recommend to wait for a new release.