### PR TITLE
gitlab-runner-17.3: advisory entry for GHSA-v23v-6jw2-98fq

### DIFF
--- a/gitlab-runner-17.3.advisories.yaml
+++ b/gitlab-runner-17.3.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine
             scanner: grype
+      - timestamp: 2024-08-19T09:48:11Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability requires many upstream code changes and as a consequence a new release is needed to fix this vulnerability.


### PR DESCRIPTION
GHSA-v23v-6jw2-98fq