### PR TITLE
feature(cve remediation) Update advisories for GHSA-r55c-59qm-vjw6 and GHSA-5866-49gr-22v4 for package logstash

### DIFF
--- a/logstash.advisories.yaml
+++ b/logstash.advisories.yaml
@@ -25,6 +25,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: Logstash bundles an old version of jruby v3.2.5 which installs a vulnerable version of rexml. Upstream jruby should fix this vulnerability for this version as it updates its default gems on some next release.
+      - timestamp: 2024-08-20T12:40:53Z
+        type: pending-upstream-fix
+        data:
+          note: GHSA-r55c-59qm-vjw6 is still vulnerable in the currently vendored/bundled rexml 3.3.2 and is still pending upstream fix in logstash by bumping the bundled version of jruby (and thus rexml). jruby has landed changes upstream @ https://github.com/jruby/jruby/commit/201a87abd48d0630acc1b5a21787d079d3050180 but no new tag has been created yet.
 
   - id: CGA-266c-v62g-2862
     aliases:

--- a/logstash.advisories.yaml
+++ b/logstash.advisories.yaml
@@ -94,6 +94,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: Logstash bundles an old version of jruby v3.2.5 which installs a vulnerable version of rexml. Upstream jruby should fix this vulnerability for this version as it updates its default gems on some next release.
+      - timestamp: 2024-08-20T12:54:41Z
+        type: pending-upstream-fix
+        data:
+          note: GHSA-5866-49gr-22v4 is still vulnerable in the currently vendored/bundled rexml 3.3.2 and is still pending upstream fix in logstash by bumping the bundled version of jruby (and thus rexml). jruby has landed changes upstream @ https://github.com/jruby/jruby/commit/201a87abd48d0630acc1b5a21787d079d3050180 but no new tag has been created yet.
 
   - id: CGA-4cgj-59hq-h2hc
     aliases:


### PR DESCRIPTION
- **feat(cve remediation): Update advisory for GHSA-r55c-59qm-vjw6 for package logstash**
- **feat(cve remediation): Update advisory for GHSA-5866-49gr-22v4 for package logstash**
