### PR TITLE
cassandra-medusa advisory update for GHSA-jwhx-xcg6-8xhj

### DIFF
--- a/py3-cassandra-medusa.advisories.yaml
+++ b/py3-cassandra-medusa.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: python
             componentLocation: /home/cassandra/.venv/lib/python3.11/site-packages/aiohttp-3.9.4.dist-info/METADATA, /home/cassandra/.venv/lib/python3.11/site-packages/aiohttp-3.9.4.dist-info/RECORD, /home/cassandra/.venv/lib/python3.11/site-packages/aiohttp-3.9.4.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-08-21T23:02:05Z
+        type: pending-upstream-fix
+        data:
+          note: 'PR is open upstream but currently introduces build breaking changes in CI tests. PR: https://github.com/thelastpickle/cassandra-medusa/pull/795'
 
   - id: CGA-4pr8-qqxf-65pm
     aliases:


### PR DESCRIPTION
PR is open upstream but currently introduces build breaking changes in CI tests. PR: https://github.com/thelastpickle/cassandra-medusa/pull/795