### PR TITLE
litestream v0.3.13 CVE-2024-41254/GHSA-qpgw-j75c-j585 advisory update

### DIFF
--- a/litestream.advisories.yaml
+++ b/litestream.advisories.yaml
@@ -41,6 +41,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-08-23T16:15:17Z
+        type: pending-upstream-fix
+        data:
+          note: 'Issue has been opened in litestream repository. No prior issues, PRs or commits that reference this CVE and the affected version is the most current release. Issue: https://github.com/benbjohnson/litestream/issues/602'
 
   - id: CGA-fm8f-cmvr-fj72
     aliases:


### PR DESCRIPTION
pending upstream fix tag has been added with note. Issue has been opened in litestream repository. No prior issues, PRs or commits that reference this CVE and the affected version is the most current release. Issue: https://github.com/benbjohnson/litestream/issues/602