### PR TITLE
kubeflow-volumes-web-app/GHSA-hxwh-jpp2-84pm flask-cors 4.0.1

### DIFF
--- a/kubeflow-volumes-web-app.advisories.yaml
+++ b/kubeflow-volumes-web-app.advisories.yaml
@@ -127,6 +127,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.12/site-packages/Flask_Cors-4.0.1.dist-info/METADATA, /usr/lib/python3.12/site-packages/Flask_Cors-4.0.1.dist-info/RECORD, /usr/lib/python3.12/site-packages/Flask_Cors-4.0.1.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-08-28T07:25:30Z
+        type: pending-upstream-fix
+        data:
+          note: The version of flask-cors affected in this CVE (4.0.1) is the most current release, there is a PR open addressing this vulnerability in the flask-cors repo where the fix will be implemented in the next major version release (5.0.0) PR:https://github.com/corydolphin/flask-cors/pull/363
 
   - id: CGA-ph4r-hmw2-vp9r
     aliases:


### PR DESCRIPTION
The version of flask-cors affected in this CVE (4.0.1) is the most current release, there is a PR open addressing this vulnerability in the flask-cors repo where the fix will be implemented in the next major version release (5.0.0) PR:https://github.com/corydolphin/flask-cors/pull/363