### PR TITLE
CVE-2024-21094, CVE-2024-21068, CVE-2024-21012 advisory updates for openjdk-16

### DIFF
--- a/openjdk-16.advisories.yaml
+++ b/openjdk-16.advisories.yaml
@@ -110,6 +110,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-08-28T10:57:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'NVD record says the affected version is 17.0.10, not a version range. Record: https://nvd.nist.gov/vuln/detail/CVE-2024-21012'
 
   - id: CGA-72h6-cc9f-fr5q
     aliases:
@@ -250,6 +255,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-08-28T10:52:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'NVD record says the affected version is 17.0.10, not a version range. Record: https://nvd.nist.gov/vuln/detail/CVE-2024-21068'
 
   - id: CGA-r359-rxvq-7fhx
     aliases:
@@ -300,6 +310,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-08-28T10:55:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'NVD record says the affected version is 17.0.10, not a version range. Record: https://nvd.nist.gov/vuln/detail/CVE-2024-21094'
 
   - id: CGA-v4rx-wrhf-gw83
     aliases:


### PR DESCRIPTION
NVD record says the affected version is 17.0.10, not a version range. 

https://nvd.nist.gov/vuln/detail/CVE-2024-21012
https://nvd.nist.gov/vuln/detail/CVE-2024-21068
https://nvd.nist.gov/vuln/detail/CVE-2024-21094