### PR TITLE
python-3.11/CVE-2024-7592 advisory update

### DIFF
--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -88,6 +88,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-08-29T07:03:41Z
+        type: pending-upstream-fix
+        data:
+          note: 'Waiting for upstream fix to be merged into 3.11 branch. PR: https://github.com/python/cpython/pull/123105'
 
   - id: CGA-fvmf-843x-pvhj
     aliases:


### PR DESCRIPTION
While the upstream fix [could be implemented](https://github.com/wolfi-dev/os/pull/27288) as it stands now, it does not make sense to ship a fix that has only been approved in other branches for a low severity CVE. 