### PR TITLE
openjdk-15/CVE-2024-21145 advisory update

### DIFF
--- a/openjdk-15.advisories.yaml
+++ b/openjdk-15.advisories.yaml
@@ -87,6 +87,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-08-29T07:34:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'NVD record says the affected version is 17.0.11, not a version range. Record: https://nvd.nist.gov/vuln/detail/CVE-2024-21131'
 
   - id: CGA-7mw5-55mq-g7f8
     aliases:


### PR DESCRIPTION
NVD record says the affected version is 17.0.11, not a version range. Record: https://nvd.nist.gov/vuln/detail/CVE-2024-21131