### PR TITLE
openjdk-14/CVE-2024-21131 advisory update

### DIFF
--- a/openjdk-14.advisories.yaml
+++ b/openjdk-14.advisories.yaml
@@ -87,6 +87,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-08-29T07:52:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'NVD record says the affected version is 17.0.11, not a version range. Record: https://nvd.nist.gov/vuln/detail/CVE-2024-21131'
 
   - id: CGA-829j-4v3w-vphp
     aliases:


### PR DESCRIPTION
NVD record says the affected version is 17.0.11, not a version range. Record: https://nvd.nist.gov/vuln/detail/CVE-2024-21131