### PR TITLE
CVE detection: openjdk-16/CVE-2024-21145 advisory update

### DIFF
--- a/openjdk-16.advisories.yaml
+++ b/openjdk-16.advisories.yaml
@@ -367,7 +367,7 @@ advisories:
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used
-          note: ' NVD record says the affected version is 17.0.11, not a version range. https://nvd.nist.gov/vuln/detail/CVE-2024-21145'
+          note: 'NVD record says the affected version is 17.0.11, not a version range. https://nvd.nist.gov/vuln/detail/CVE-2024-21145'
 
   - id: CGA-w823-88hj-m77c
     aliases:

--- a/openjdk-16.advisories.yaml
+++ b/openjdk-16.advisories.yaml
@@ -363,6 +363,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-08-29T08:06:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: ' NVD record says the affected version is 17.0.11, not a version range. https://nvd.nist.gov/vuln/detail/CVE-2024-21145'
 
   - id: CGA-w823-88hj-m77c
     aliases:


### PR DESCRIPTION
NVD record says the affected version is 17.0.11, not a version range. https://nvd.nist.gov/vuln/detail/CVE-2024-21145