### PR TITLE
Add advisories for py3.11 for the -dev variant of the node image

### DIFF
--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -199,3 +199,29 @@ advisories:
         type: fixed
         data:
           fixed-version: 18.16.1-r0
+
+  - id: CGA-74jf-4783-w9x6
+    aliases:
+      - CVE-2024-6923
+      - GHSA-87qc-q3w7-7m8w
+    events:
+      - timestamp: 2024-08-30T15:48:05Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This CVE relates to python 3.11, which is only included in the nodejs -dev image variant.
+            CVE remediation is awaiting core review then release on the 3.11 branch.
+            More information can be found here: https://github.com/python/cpython/pull/122608
+
+  - id: CGA-c6x4-w8qf-qrh6
+    aliases:
+      - CVE-2024-7592
+      - GHSA-7pwv-g7hj-39pr
+    events:
+      - timestamp: 2024-08-30T15:48:05Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This CVE relates to python 3.11, which is only included in the nodejs -dev image variant.
+            A fix has been proposed upstream but it has yet to be approved or merged.
+            More information can be found here: https://github.com/python/cpython/pull/123105'

--- a/nodejs-20.advisories.yaml
+++ b/nodejs-20.advisories.yaml
@@ -228,3 +228,29 @@ advisories:
         type: fixed
         data:
           fixed-version: 20.5.1-r0
+
+  - id: CGA-74jf-4783-w9x6
+    aliases:
+      - CVE-2024-6923
+      - GHSA-87qc-q3w7-7m8w
+    events:
+      - timestamp: 2024-08-30T15:48:05Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This CVE relates to python 3.11, which is only included in the nodejs -dev image variant.
+            CVE remediation is awaiting core review then release on the 3.11 branch.
+            More information can be found here: https://github.com/python/cpython/pull/122608
+
+  - id: CGA-c6x4-w8qf-qrh6
+    aliases:
+      - CVE-2024-7592
+      - GHSA-7pwv-g7hj-39pr
+    events:
+      - timestamp: 2024-08-30T15:48:05Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This CVE relates to python 3.11, which is only included in the nodejs -dev image variant.
+            A fix has been proposed upstream but it has yet to be approved or merged.
+            More information can be found here: https://github.com/python/cpython/pull/123105'

--- a/nodejs-22.advisories.yaml
+++ b/nodejs-22.advisories.yaml
@@ -23,3 +23,29 @@ advisories:
         type: fixed
         data:
           fixed-version: 22.4.1-r0
+
+  - id: CGA-74jf-4783-w9x6
+    aliases:
+      - CVE-2024-6923
+      - GHSA-87qc-q3w7-7m8w
+    events:
+      - timestamp: 2024-08-30T15:48:05Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This CVE relates to python 3.11, which is only included in the nodejs -dev image variant.
+            CVE remediation is awaiting core review then release on the 3.11 branch.
+            More information can be found here: https://github.com/python/cpython/pull/122608
+
+  - id: CGA-c6x4-w8qf-qrh6
+    aliases:
+      - CVE-2024-7592
+      - GHSA-7pwv-g7hj-39pr
+    events:
+      - timestamp: 2024-08-30T15:48:05Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This CVE relates to python 3.11, which is only included in the nodejs -dev image variant.
+            A fix has been proposed upstream but it has yet to be approved or merged.
+            More information can be found here: https://github.com/python/cpython/pull/123105'


### PR DESCRIPTION
Our -dev image variant contains python 3.11. We're reviewing this in future and may remove this, but will require some notifications. This PR copies over the advisories already raised for CVE-2024-7592 and CVE-2024-6923 for python 3.11, and associates them with the node packages (that are still active and supported).