### PR TITLE
Wordpress GHSA-q87j-q95m-j3x3 advisory update

### DIFF
--- a/wordpress.advisories.yaml
+++ b/wordpress.advisories.yaml
@@ -43,6 +43,11 @@ advisories:
             componentType: npm
             componentLocation: /usr/src/wordpress/wp-content/themes/twentytwentyone/package.json
             scanner: grype
+      - timestamp: 2024-08-30T21:35:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The vulnerable code was a package hosted by NPM that contained an install script leading to malicious malware. Chainguard does not source the twentytwentyone template from this now removed NPM source and pulls directy from the wordpress git repo. Chainguard's twentytwentyone package.json has been checked and verifed to not include install scripts that pull from a remote source.
 
   - id: CGA-8gfh-h5vg-754q
     aliases:

--- a/wordpress.advisories.yaml
+++ b/wordpress.advisories.yaml
@@ -47,7 +47,7 @@ advisories:
         type: false-positive-determination
         data:
           type: vulnerable-code-not-included-in-package
-          note: The vulnerable code was a package hosted by NPM that contained an install script leading to malicious malware. Chainguard does not source the twentytwentyone template from this now removed NPM source and pulls directy from the wordpress git repo. Chainguard's twentytwentyone package.json has been checked and verifed to not include install scripts that pull from a remote source.
+          note: The vulnerable code was a package hosted by NPM that contained an install script leading to malicious malware. Chainguard does not source the twentytwentyone template from this now removed NPM source and pulls directly from the wordpress git repo. Chainguard's twentytwentyone package.json has been checked and verifed to not include install scripts that pull from a remote source.
 
   - id: CGA-8gfh-h5vg-754q
     aliases:


### PR DESCRIPTION
The vulnerable code was in a package hosted by NPM (can be seen in[ this socket.dev page](https://socket.dev/npm/package/twentytwentyone/files/1.7.1/package.json) since its been removed from NPM itself) that contained an install script leading to malicious malware. Chainguard does not source the twentytwentyone template from this now removed NPM source and pulls directy from the wordpress git repo. Chainguard's twentytwentyone package.json has been checked and verifed to not include install scripts that pull from a remote source.
<img width="1097" alt="Screenshot 2024-08-30 at 2 47 22 PM" src="https://github.com/user-attachments/assets/9b65ff3f-f373-46b6-ba84-98e89a3341ee">
