### PR TITLE
openssl: add CVE-2024-6119 manual detection event

### DIFF
--- a/openssl.advisories.yaml
+++ b/openssl.advisories.yaml
@@ -300,6 +300,15 @@ advisories:
         data:
           fixed-version: 3.0.7-r0
 
+  - id: CGA-whjp-f75j-mjxh
+    aliases:
+      - CVE-2024-6119
+    events:
+      - timestamp: 2024-09-03T15:54:30Z
+        type: detection
+        data:
+          type: manual
+
   - id: CGA-x5xm-v7pj-7rpw
     aliases:
       - CVE-2023-3446


### PR DESCRIPTION
Based on the security advisory published here https://openssl-library.org/news/secadv/20240903.txt