### PR TITLE
fix: duplicate CGA IDs were used

### DIFF
--- a/nodejs-18.advisories.yaml
+++ b/nodejs-18.advisories.yaml
@@ -200,7 +200,7 @@ advisories:
         data:
           fixed-version: 18.16.1-r0
 
-  - id: CGA-74jf-4783-w9x6
+  - id: CGA-w4f3-cfqj-j8hv
     aliases:
       - CVE-2024-6923
       - GHSA-87qc-q3w7-7m8w
@@ -213,7 +213,7 @@ advisories:
             CVE remediation is awaiting core review then release on the 3.11 branch.
             More information can be found here: https://github.com/python/cpython/pull/122608
 
-  - id: CGA-c6x4-w8qf-qrh6
+  - id: CGA-9qw9-xxfh-c4v2
     aliases:
       - CVE-2024-7592
       - GHSA-7pwv-g7hj-39pr

--- a/nodejs-20.advisories.yaml
+++ b/nodejs-20.advisories.yaml
@@ -229,7 +229,7 @@ advisories:
         data:
           fixed-version: 20.5.1-r0
 
-  - id: CGA-74jf-4783-w9x6
+  - id: CGA-c23x-7ppp-8vqm
     aliases:
       - CVE-2024-6923
       - GHSA-87qc-q3w7-7m8w
@@ -242,7 +242,7 @@ advisories:
             CVE remediation is awaiting core review then release on the 3.11 branch.
             More information can be found here: https://github.com/python/cpython/pull/122608
 
-  - id: CGA-c6x4-w8qf-qrh6
+  - id: CGA-hjjp-j4vg-j855
     aliases:
       - CVE-2024-7592
       - GHSA-7pwv-g7hj-39pr

--- a/nodejs-22.advisories.yaml
+++ b/nodejs-22.advisories.yaml
@@ -24,7 +24,7 @@ advisories:
         data:
           fixed-version: 22.4.1-r0
 
-  - id: CGA-74jf-4783-w9x6
+  - id: CGA-488p-fcg5-8vm8
     aliases:
       - CVE-2024-6923
       - GHSA-87qc-q3w7-7m8w
@@ -37,7 +37,7 @@ advisories:
             CVE remediation is awaiting core review then release on the 3.11 branch.
             More information can be found here: https://github.com/python/cpython/pull/122608
 
-  - id: CGA-c6x4-w8qf-qrh6
+  - id: CGA-4h6r-23fp-w9w8
     aliases:
       - CVE-2024-7592
       - GHSA-7pwv-g7hj-39pr

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -49,7 +49,7 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows.
 
-  - id: CGA-74jf-4783-w9x6
+  - id: CGA-95mj-h49g-qh4h
     aliases:
       - CVE-2024-6923
       - GHSA-87qc-q3w7-7m8w
@@ -71,7 +71,7 @@ advisories:
         data:
           note: 'CVE remediation is awaiting core review then release on the 3.11 branch. More information can be found here: https://github.com/python/cpython/pull/122608'
 
-  - id: CGA-c6x4-w8qf-qrh6
+  - id: CGA-8v84-p6q7-fc4w
     aliases:
       - CVE-2024-7592
       - GHSA-7pwv-g7hj-39pr


### PR DESCRIPTION
CGA IDs are intended to be unique per advisory, that is, per `{vulnerability, package}` tuple. This is important for downstream processing logic, such as OSV feed generation, which publishes individual advisories as `{ID}.json`.

We've now added validation for this in wolfictl: https://github.com/wolfi-dev/wolfictl/pull/1155. However, this validation will fail until the data in this git repo is cleaned up.

This PR cleans up the data by replacing all instances of the following re-used CGA IDs with brand new CGA IDs:

- `CGA-74jf-4783-w9x6`
- `CGA-c6x4-w8qf-qrh6`

⚠️ This will fail validation because we're modifying existing entries. This is necessary to get us out of the current invalid state. **We'll need to override CI.**