### PR TITLE
datadog-agent/GHSA-h4gh-qq45-vh27 update

### DIFF
--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -252,6 +252,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/datadog-agent/lib/python3.11/site-packages/cryptography-42.0.8.dist-info/METADATA, /usr/share/datadog-agent/lib/python3.11/site-packages/cryptography-42.0.8.dist-info/RECORD, /usr/share/datadog-agent/lib/python3.11/site-packages/cryptography-42.0.8.dist-info/direct_url.json, /usr/share/datadog-agent/lib/python3.11/site-packages/cryptography-42.0.8.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-09-12T20:51:54Z
+        type: pending-upstream-fix
+        data:
+          note: 'While there are no blocking issues in the major version upgrade of the python cryptography dependency v42.0.8 to v43.0.0 and by extension v43.0.1 upstream in development, there are significant unreleased required code changes between the current release of 7.57.0 and upcoming implementations in 7.58.0-rc2 needed to incorporate this. '
 
   - id: CGA-c8pv-52m7-2mhm
     aliases:


### PR DESCRIPTION
While there are no blocking issues in the major version upgrade of the python cryptography dependency [v42.0.8 to v43.0.0](https://github.com/DataDog/integrations-core/pull/18478/files) and by extension [v43.0.1](https://pypi.org/project/cryptography/43.0.1/) upstream in development, there are significant unreleased required code changes between the current release of [7.57.0 and upcoming implementations in 7.58.0-rc2](https://github.com/DataDog/datadog-agent/compare/7.57.0...7.58.0-rc.2) needed to incorporate this.