### PR TITLE
Feat(adv): Fix not planed for GHSA-rcjc-c4pj-xxrp and GHSA-c27h-mcmw-48hv

### DIFF
--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -277,6 +277,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/derby-10.14.2.0.jar
             scanner: grype
+      - timestamp: 2024-09-13T10:34:37Z
+        type: fix-not-planned
+        data:
+          note: |
+            This relates to 'derby',Spark-3.5 currently uses version 10.14.2.0, while the closest fixed version available in the Maven Central repository is 10.17.1.0. However, this version requires a minimum of Java 17 to build, whereas Spark-3.5 is built with Java 8 and 11 as well. Upgrading to 10.17.1.0 would cause a build break due to Java bytecode version incompatibility. At this time, we are not planning to upgrade the version of Derby in Spark-3.5. The upstream project has updated to version 10.16.1.1, which does not resolve the vulnerability. The upstream is currently waiting for a backport to Derby version 10.16.2.x which they have planed to fix in version spark-4 or later. For reference, see: https://github.com/apache/spark/pull/44174
 
   - id: CGA-cwcv-4cmx-49fj
     aliases:

--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -41,6 +41,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/jackson-mapper-asl-1.9.13.jar
             scanner: grype
+      - timestamp: 2024-09-13T11:36:26Z
+        type: fix-not-planned
+        data:
+          note: "This issue concerns codehaus jackson-mapper-asl, which is no longer maintained. Spark has a transitive dependency on this library due to Hive 2.3, which requires it to initialize the FunctionRegistry. Hive 3.x, planned for Spark 4.x, should remove the dependency on codehaus-jackson. However, even if the vulnerability is fixed in Spark 4.x, it won't be possible to backport the fix to Spark 3.5.x due to its dependency on Hive 2.3. For more details: https://issues.apache.org/jira/browse/SPARK-44114, https://github.com/apache/spark/pull/40893, https://issues.apache.org/jira/browse/SPARK-30466"
 
   - id: CGA-2c2c-g9hq-66c4
     aliases:


### PR DESCRIPTION
Reason GHSA-rcjc-c4pj-xxrp

Updated the advisory note to explain why Spark-3.5 cannot upgrade Derby from version 10.14.2.0 to 10.17.1.0 due to Java bytecode version incompatibility. The upstream project has updated to version 10.16.1.1, which does not resolve the vulnerability. The fix is planing to fix this in spark-4 or later if there is a backported fix Derby version like 10.16.2.x. For more details, see: https://github.com/apache/spark/pull/44174