### PR TITLE
GHSA-h4gh-qq45-vh27 superset advisory update

### DIFF
--- a/airflow.advisories.yaml
+++ b/airflow.advisories.yaml
@@ -57,6 +57,10 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/venv/lib/python3.12/site-packages/Flask_AppBuilder-4.5.0.dist-info/METADATA, /opt/airflow/venv/lib/python3.12/site-packages/Flask_AppBuilder-4.5.0.dist-info/RECORD, /opt/airflow/venv/lib/python3.12/site-packages/Flask_AppBuilder-4.5.0.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-09-16T19:35:14Z
+        type: pending-upstream-fix
+        data:
+          note: 'Due to the tightly coupled nature of airflow and Flask-AppBuilder stated here: https://github.com/apache/airflow/blob/30925c739b60d8a54d84c7c58a3ab854c167f2c1/airflow/providers/fab/provider.yaml#L50, any changes to the security/manager.py file need to be implemented in an override file found here: https://github.com/apache/airflow/blob/main/airflow/providers/fab/auth_manager/security_manager/override.py a PR has been opened to suggest the changes however that is waiting upstream approval.   '
 
   - id: CGA-3mg6-hjmp-vwjr
     aliases:

--- a/superset.advisories.yaml
+++ b/superset.advisories.yaml
@@ -60,6 +60,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/superset/venv/lib/python3.11/site-packages/cryptography-42.0.4.dist-info/METADATA, /usr/share/superset/venv/lib/python3.11/site-packages/cryptography-42.0.4.dist-info/RECORD, /usr/share/superset/venv/lib/python3.11/site-packages/cryptography-42.0.4.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-09-16T17:05:44Z
+        type: pending-upstream-fix
+        data:
+          note: 'Upstream has pinned version of python package cryptography as seen here: https://github.com/apache/superset/blob/f0971a850c12c69b5f09874ab50b25976788a6de/requirements/base.txt#L83 Changes in 42.x.x to 43.x.x require upstream changes.'
 
   - id: CGA-77h5-pgh2-r2fg
     aliases:


### PR DESCRIPTION
Superset: Upstream has pinned version of python package cryptography [as seen here](https://github.com/apache/superset/blob/f0971a850c12c69b5f09874ab50b25976788a6de/requirements/base.txt#L83). Changes in 42.x.x to 43.x.x require upstream changes.'