### PR TITLE
Several nodejs-16 CVE advisory updates: no fix, EOL

### DIFF
--- a/nodejs-16.advisories.yaml
+++ b/nodejs-16.advisories.yaml
@@ -69,6 +69,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-09-17T21:21:02Z
+        type: fix-not-planned
+        data:
+          note: 'Nodejs-16 is no longer receiving support, latest version release of 16.x branch was in August of 2023: https://nodejs.org/download/release/v16.20.2/ and LTS ended in September of 2023: https://endoflife.date/nodejs This CVE fix is merged and awaiting upstream release in v22.x version stream.'
 
   - id: CGA-7482-pcrv-6wxj
     aliases:
@@ -137,6 +141,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-09-17T21:19:57Z
+        type: fix-not-planned
+        data:
+          note: 'Nodejs-16 is no longer receiving support, latest version release of 16.x branch was in August of 2023: https://nodejs.org/download/release/v16.20.2/ and LTS ended in September of 2023: https://endoflife.date/nodejs To remediate this CVE upgrade node to 22.x version stream (latest) in order to receive longest support that also incorporates these fixes.'
 
   - id: CGA-fr56-qrc9-jmw9
     aliases:
@@ -175,6 +183,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-09-17T21:13:50Z
+        type: fix-not-planned
+        data:
+          note: 'Nodejs-16 is no longer receiving support, latest version release of 16.x branch was in August of 2023: https://nodejs.org/download/release/v16.20.2/ and LTS ended in September of 2023: https://endoflife.date/nodejs To remediate this CVE upgrade node to 22.x version stream (latest) in order to receive longest support that also incorporates these fixes.'
 
   - id: CGA-j999-cggp-cjvv
     aliases:
@@ -193,6 +205,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-09-17T21:20:42Z
+        type: fix-not-planned
+        data:
+          note: 'Nodejs-16 is no longer receiving support, latest version release of 16.x branch was in August of 2023: https://nodejs.org/download/release/v16.20.2/ and LTS ended in September of 2023: https://endoflife.date/nodejs To remediate this CVE upgrade node to 22.x version stream (latest) in order to receive longest support that also incorporates these fixes.'
 
   - id: CGA-jww3-p5wg-57h9
     aliases:
@@ -229,6 +245,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-09-17T21:19:25Z
+        type: fix-not-planned
+        data:
+          note: 'Nodejs-16 is no longer receiving support, latest version release of 16.x branch was in August of 2023: https://nodejs.org/download/release/v16.20.2/ and LTS ended in September of 2023: https://endoflife.date/nodejs To remediate this CVE upgrade node to 22.x version stream (latest) in order to receive longest support that also incorporates these fixes.'
 
   - id: CGA-mhrf-mm82-69mm
     aliases:
@@ -289,6 +309,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-09-17T21:20:20Z
+        type: fix-not-planned
+        data:
+          note: 'Nodejs-16 is no longer receiving support, latest version release of 16.x branch was in August of 2023: https://nodejs.org/download/release/v16.20.2/ and LTS ended in September of 2023: https://endoflife.date/nodejs To remediate this CVE upgrade node to 22.x version stream (latest) in order to receive longest support that also incorporates these fixes.'
 
   - id: CGA-rx96-8896-rjh9
     aliases:


### PR DESCRIPTION
Advisory updates for CVE-2024-22019, CVE-2024-22025, CVE-2024-27982, CVE-2024-21892, CVE-2024-27983, CVE-2024-22020. Nodejs-16 is no longer receiving support, latest version release of 16.x branch was in [August of 2023](https://nodejs.org/download/release/v16.20.2/) and[ LTS ended in September of 2023](https://endoflife.date/nodejs).