### PR TITLE
superset Flash-Appbuilder 4.5.1 advisory update

### DIFF
--- a/superset.advisories.yaml
+++ b/superset.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/superset/venv/lib/python3.11/site-packages/Flask_AppBuilder-4.4.1.dist-info/METADATA, /usr/share/superset/venv/lib/python3.11/site-packages/Flask_AppBuilder-4.4.1.dist-info/RECORD, /usr/share/superset/venv/lib/python3.11/site-packages/Flask_AppBuilder-4.4.1.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-09-19T19:46:42Z
+        type: pending-upstream-fix
+        data:
+          note: 'Bringing in the fix version of Flask-Appbuilder 4.5.1 to the superset package currently introduces build breaking changes. '
 
   - id: CGA-37xg-qrch-w8h8
     aliases:


### PR DESCRIPTION
Bringing in the fix version of Flask-Appbuilder 4.5.1 to the superset package currently introduces build breaking changes. Thread on the topic here: https://chainguard-dev.slack.com/archives/C05CM0DM7RV/p1726605374075999