### PR TITLE
New advisories for openssl-provider-fips package

### DIFF
--- a/openssl-provider-fips.advisories.yaml
+++ b/openssl-provider-fips.advisories.yaml
@@ -1,0 +1,318 @@
+schema-version: 2.0.2
+
+package:
+  name: openssl-provider-fips
+
+advisories:
+  - id: CGA-7qvp-hmgw-693v
+    aliases:
+      - CVE-2022-4203
+      - GHSA-w67w-mw4j-8qrv
+    events:
+      - timestamp: 2023-02-07T16:50:00Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-pqh8-r46p-4w3x
+    aliases:
+      - CVE-2024-5535
+      - GHSA-4fc7-mvrr-wv2c
+    events:
+      - timestamp: 2024-06-28T16:10:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The FIPS modules in 3.3, 3.2, 3.1 and 3.0 are not affected by this issue. https://openssl-library.org/news/secadv/20240627.txt
+
+  - id: CGA-m4wp-p4qq-w882
+    aliases:
+      - CVE-2024-0727
+      - GHSA-9v9h-cgj8-h64p
+    events:
+      - timestamp: 2024-02-05T07:11:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The FIPS modules in 3.2, 3.1 and 3.0 are not affected by this issue. https://openssl-library.org/news/secadv/20240125.txt
+
+  - id: CGA-892x-m288-m8g4
+    aliases:
+      - CVE-2023-3817
+      - GHSA-c945-cqj5-wfv6
+    events:
+      - timestamp: 2023-07-31T21:46:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The OpenSSL 3.0 and 3.1 FIPS providers are not affected by this issue. https://openssl-library.org/news/secadv/20230731.txt
+
+  - id: CGA-82jr-fq2j-892g
+    aliases:
+      - CVE-2023-0216
+      - GHSA-29xx-hcv2-c4cp
+    events:
+      - timestamp: 2023-02-07T16:50:29Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-wcjr-7x49-5hjq
+    aliases:
+      - CVE-2022-3996
+      - GHSA-vr8j-hgmm-jh9r
+    events:
+      - timestamp: 2022-12-22T17:26:45Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-3637-8hvr-78hj
+    aliases:
+      - CVE-2023-2975
+      - GHSA-hpqg-7fjp-436p
+    events:
+      - timestamp: 2023-07-17T21:45:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The FIPS provider is not affected as the AES-SIV algorithm is not FIPS approved and FIPS provider does not implement it. https://openssl-library.org/news/secadv/20230714.txt
+
+  - id: CGA-qq4x-8qqj-c9mx
+    aliases:
+      - CVE-2023-0286
+      - GHSA-x4qr-2fvf-3mr5
+    events:
+      - timestamp: 2023-02-07T16:49:30Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-c9g6-89vg-xw37
+    aliases:
+      - CVE-2023-4807
+      - GHSA-53wr-cx66-4578
+    events:
+      - timestamp: 2023-09-08T16:29:47Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Component is only vulnerable when running under Windows.
+      - timestamp: 2023-09-19T14:06:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Component is only vulnerable when running under Windows.
+
+  - id: CGA-q4w8-q29j-cf7q
+    aliases:
+      - CVE-2024-2511
+      - GHSA-299c-jvhc-gxj8
+    events:
+      - timestamp: 2024-04-23T13:02:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The FIPS modules in 3.2, 3.1 and 3.0 are not affected by this issue. https://openssl-library.org/news/secadv/20240408.txt
+
+  - id: CGA-crhv-mvc2-v59p
+    aliases:
+      - CVE-2024-4603
+      - GHSA-85xr-ghj6-6m46
+    events:
+      - timestamp: 2024-05-29T08:03:57Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: openssl
+            componentID: 371e7ec50e901726
+            componentName: openssl
+            componentVersion: 3.3.0-r7
+            componentType: apk
+            componentLocation: /.PKGINFO
+            scanner: grype
+      - timestamp: 2024-09-20T08:00:03Z
+        type: pending-upstream-fix
+        data:
+          note: The OpenSSL 3.0 and 3.1 FIPS providers are affected by this issue. However, there is no FIPS certified build available. See https://openssl-library.org/news/secadv/20240516.txt.
+
+  - id: CGA-gg5g-38pq-7vrj
+    aliases:
+      - CVE-2023-0465
+      - GHSA-77f3-6546-6rj7
+    events:
+      - timestamp: 2023-03-28T14:54:27Z
+        type: fixed
+        data:
+          fixed-version: 3.0.9-r0
+
+  - id: CGA-p4g2-7g4f-7m9w
+    aliases:
+      - CVE-2023-0466
+      - GHSA-pxvj-4wx4-gv6w
+    events:
+      - timestamp: 2023-04-08T16:32:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This was a case of documentation not matching function behavior. The upstream maintainers decided to update the documentation rather than change the behavior. See https://www.openssl.org/news/secadv/20230328.txt
+
+  - id: CGA-9vq3-7h7g-3qcp
+    aliases:
+      - CVE-2023-6129
+      - GHSA-rj8q-prqp-jwfg
+    events:
+      - timestamp: 2024-01-24T16:12:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The FIPS provider is not affected because the POLY1305 MAC algorithm is not FIPS approved and the FIPS provider does not implement it. https://openssl-library.org/news/secadv/20240109.txt
+
+  - id: CGA-9g54-69rw-c9j6
+    aliases:
+      - CVE-2022-3602
+      - GHSA-8rwr-x37p-mx23
+    events:
+      - timestamp: 2022-11-01T16:49:56Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-c7jh-6ff4-87gj
+    aliases:
+      - CVE-2023-2650
+      - GHSA-gqxg-9vfr-p9cg
+    events:
+      - timestamp: 2023-05-30T16:31:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: No version of the FIPS provider is affected by this issue. https://openssl-library.org/news/secadv/20230530.txt
+
+  - id: CGA-5m9g-jw9v-2cq5
+    aliases:
+      - CVE-2022-4304
+      - GHSA-p52g-cm5j-mjv4
+    events:
+      - timestamp: 2023-02-07T16:49:50Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-rm7q-7jfx-75fh
+    aliases:
+      - CVE-2023-0464
+      - GHSA-w2w6-xp88-5cvw
+    events:
+      - timestamp: 2023-03-23T09:31:00Z
+        type: fixed
+        data:
+          fixed-version: 3.0.9-r1
+
+  - id: CGA-qcgw-2468-442m
+    aliases:
+      - CVE-2023-5363
+      - GHSA-xw78-pcr6-wrg8
+    events:
+      - timestamp: 2023-10-24T15:21:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The OpenSSL 3.0 and 3.1 FIPS providers are not affected by this because the issue lies outside of the FIPS provider boundary. https://openssl-library.org/news/secadv/20231024.txt
+
+  - id: CGA-9m2x-c4m9-x3p3
+    aliases:
+      - CVE-2023-5678
+      - GHSA-2cj7-mg3x-9mhq
+    events:
+      - timestamp: 2023-11-06T17:42:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The OpenSSL 3.0 and 3.1 FIPS providers are not affected by this issue. https://openssl-library.org/news/secadv/20231106.txt
+
+  - id: CGA-h63g-4952-pf64
+    aliases:
+      - CVE-2022-4450
+      - GHSA-v5w6-wcm8-jm4q
+    events:
+      - timestamp: 2023-02-07T16:50:17Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-xj84-gc7j-x9gm
+    aliases:
+      - CVE-2023-6237
+      - GHSA-hvc4-mjv4-5mw6
+    events:
+      - timestamp: 2024-04-23T13:02:37Z
+        type: pending-upstream-fix
+        data:
+          note: The OpenSSL 3.0 and 3.1 FIPS providers are affected by this issue. However, there is no FIPS certified build available. See https://openssl-library.org/news/secadv/20240115.txt.
+
+  - id: CGA-x9pw-5rcv-8239
+    aliases:
+      - CVE-2023-0215
+      - GHSA-r7jw-wp68-3xch
+    events:
+      - timestamp: 2023-02-07T16:50:08Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-m5rv-23vv-7hr6
+    aliases:
+      - CVE-2023-0401
+      - GHSA-vrh7-x64v-7vxq
+    events:
+      - timestamp: 2023-02-07T16:50:53Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-p4g5-383c-jgvh
+    aliases:
+      - CVE-2024-6119
+    events:
+      - timestamp: 2024-09-03T15:54:30Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2024-09-03T17:07:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The FIPS modules in 3.3, 3.2, 3.1 and 3.0 are not affected by this issue. https://openssl-library.org/news/secadv/20240903.txt
+
+  - id: CGA-jm42-578h-f5w3
+    aliases:
+      - CVE-2023-3446
+      - GHSA-3p3x-vg38-6g9q
+    events:
+      - timestamp: 2023-07-19T17:06:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: The OpenSSL 3.0 and 3.1 FIPS providers are not affected by this issue. https://openssl-library.org/news/secadv/20230719.txt
+
+  - id: CGA-h379-76pp-6wx4
+    aliases:
+      - CVE-2023-0217
+      - GHSA-vxrh-cpg7-8vjr
+    events:
+      - timestamp: 2023-02-07T16:50:39Z
+        type: fixed
+        data:
+          fixed-version: 3.0.8-r0
+
+  - id: CGA-5fgr-29pq-jqpq
+    aliases:
+      - CVE-2023-1255
+      - GHSA-4wp2-xw7p-2gfx
+    events:
+      - timestamp: 2023-04-20T16:29:24Z
+        type: fixed
+        data:
+          fixed-version: 3.0.9-r0


### PR DESCRIPTION
Note this was created by hand, copying the openssl one and filling in the details.

CGA ids are duplicate from openssl and need regeneration.