### PR TITLE
newrelic-fluent-bit-output/CVE-2024-34155 advisory update

### DIFF
--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -244,6 +244,10 @@ advisories:
             componentType: go-module
             componentLocation: /fluent-bit/bin/out_newrelic.so
             scanner: grype
+      - timestamp: 2024-09-20T20:34:12Z
+        type: pending-upstream-fix
+        data:
+          note: 'Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning https://github.com/newrelic/newrelic-fluent-bit-output/blob/747dc5cf609ae298e2a255613aa9bddcc233d1cb/Dockerfile.windows#L31 PR on this issue is open upstream and can be found here: https://github.com/golang/go/issues/62130'
 
   - id: CGA-jq5w-f63x-38hh
     aliases:


### PR DESCRIPTION
Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning
https://github.com/newrelic/newrelic-fluent-bit-output/blob/747dc5cf609ae298e2a255613aa9bddcc233d1cb/Dockerfile.windows#L31
PR on this issue is open upstream and can be found here:
https://github.com/golang/go/issues/62130