### PR TITLE
File pending-upstream-fix advisory for kubescape: `GHSA-c77r-fh37-x2px`

### DIFF
--- a/kubescape.advisories.yaml
+++ b/kubescape.advisories.yaml
@@ -75,6 +75,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubescape
             scanner: grype
+      - timestamp: 2024-09-22T00:38:11Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Fixing this CVE, requires bumping 'open-policy-agent/opa' to version v0.68.0 or higher.
+            Upgrading this dependency in the current git release, results in kubescape failing to build successfully.
+            In addition, upstream are yet to upgrade this dependency in the main branch. Waiting for fix from upstream.
 
   - id: CGA-3wv3-c8pc-vfc7
     aliases:


### PR DESCRIPTION
Remediation of GHSA-c77r-fh37-x2px requires upgrading `open-policy-agent/opa` to v0.68.0 or later. Upgrading this dependency results in kubescape failing to build. Additionally, upstream have yet to upgrade this dependency, even in their main branch. Raising this as `pending-upstream-fix`.

Once merged, the following automated PR which attempted to bump the dependency, can be closed out:
- https://github.com/wolfi-dev/os/pull/29084