### PR TITLE
Add grafana v11.2 advisory for CVE-2024-8986, GHSA-xxxw-3j6h-q7h6

### DIFF
--- a/grafana-11.2.advisories.yaml
+++ b/grafana-11.2.advisories.yaml
@@ -39,6 +39,12 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/grafana
             scanner: grype
+      - timestamp: 2024-09-22T17:10:24Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this CVE requires upgrading to v0.250.0 or later of the 'grafana-plugin-sdk-go'.
+            Upgrading this plugin in the current version of the code, results in build issues.
 
   - id: CGA-893x-8wh7-jvw3
     aliases:


### PR DESCRIPTION
Adds pending-upstream-fix advisory for https://github.com/advisories/GHSA-xxxw-3j6h-q7h6, https://github.com/advisories/GHSA-xxxw-3j6h-q7h6. Unfortunately, we have not been able to bump, as it causes build issues.

Once merged, these automated PRs that attempted to patch the CVE can be closed:
- https://github.com/wolfi-dev/os/pull/29090