### PR TITLE
newrelic-fluent-bit-output/CVE-2024-34156 avdvisory update

### DIFF
--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -69,6 +69,10 @@ advisories:
             componentType: go-module
             componentLocation: /fluent-bit/bin/out_newrelic.so
             scanner: grype
+      - timestamp: 2024-09-23T22:30:43Z
+        type: pending-upstream-fix
+        data:
+          note: 'Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning https://github.com/newrelic/newrelic-fluent-bit-output/blob/747dc5cf609ae298e2a255613aa9bddcc233d1cb/Dockerfile.windows#L31 PR on this issue is open upstream and can be found here: https://github.com/golang/go/issues/62130'
 
   - id: CGA-67wh-9fxr-2w4p
     aliases:


### PR DESCRIPTION
Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning
https://github.com/newrelic/newrelic-fluent-bit-output/blob/747dc5cf609ae298e2a255613aa9bddcc233d1cb/Dockerfile.windows#L31
PR on this issue is open upstream and can be found here:
https://github.com/golang/go/issues/62130