### PR TITLE
nodejs-21/CVE-2024-36137 fix not planned update

### DIFF
--- a/nodejs-21.advisories.yaml
+++ b/nodejs-21.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-09-24T00:12:18Z
+        type: fix-not-planned
+        data:
+          note: 'Nodejs-21 is no longer receiving support, latest version release of 21.x branch was in April of 2024: https://nodejs.org/download/release/v21.7.3/ and LTS ended in June of 2024: https://endoflife.date/nodejs This CVE fix is in v22.x version stream: https://github.com/nodejs/node/commit/93574335ff'
 
   - id: CGA-5qcv-f6cg-wpcw
     aliases:


### PR DESCRIPTION
Nodejs-21 is no longer receiving support, latest version release of 21.x branch was in [April of 2024](https://nodejs.org/download/release/v21.7.3/) and [LTS ended](https://endoflife.date/nodejs) in June of 2024:  This CVE fix is in [v22.x version stream: ](https://github.com/nodejs/node/commit/93574335ff)