### PR TITLE
rsyslog/CVE-2015-3243 advisory update

### DIFF
--- a/rsyslog.advisories.yaml
+++ b/rsyslog.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-09-27T05:13:51Z
+        type: pending-upstream-fix
+        data:
+          note: 'Issue has been opened upstream, the conversation can be found here: https://github.com/rsyslog/rsyslog/issues/5459'


### PR DESCRIPTION
This is quite an old CVE, in the investigation redhat may have found a way to circumvent the security issue by setting the persmissions to access log files at the image level but the ticket ended up being labeled ["CLOSED WONTFIX"](https://bugzilla.redhat.com/show_bug.cgi?id=1232826#:~:text=Status%3A-,CLOSED%20WONTFIX,-Alias%3A). An [issue was opened upstream](https://github.com/rsyslog/rsyslog/issues/5459) to get clarification on if this will be addressed at the maintainer level. Until word comes back from that, filing as pending upstream fix 