### PR TITLE
mattermost: GHSA-59hf-mpf8-pqjh is a false positive

### DIFF
--- a/mattermost-10.0.advisories.yaml
+++ b/mattermost-10.0.advisories.yaml
@@ -83,7 +83,7 @@ advisories:
             This vulnerability relates to v8.1.x of mattermost, which is several releases old.
             The componentVersion is also being flagged incorrectly here by some scanners.
             A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
-            See: https://github.com/anchore/syft/issues/2980.
+            See: https://github.com/anchore/syft/issues/80.
 
   - id: CGA-64jc-pf3r-8hwj
     aliases:
@@ -110,7 +110,7 @@ advisories:
             This vulnerability relates to v8.1.x of mattermost, which is several releases old.
             The componentVersion is also being flagged incorrectly here by some scanners.
             A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
-            See: https://github.com/anchore/syft/issues/2980.
+            See: https://github.com/anchore/syft/issues/80.
 
   - id: CGA-7q4c-cqwg-26gh
     aliases:
@@ -137,7 +137,7 @@ advisories:
             This vulnerability relates to v8.1.x of mattermost, which is several releases old.
             The componentVersion is also being flagged incorrectly here by some scanners.
             A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
-            See: https://github.com/anchore/syft/issues/2980.
+            See: https://github.com/anchore/syft/issues/80.
 
   - id: CGA-7r6f-4rr6-h63g
     aliases:
@@ -159,7 +159,7 @@ advisories:
       - timestamp: 2024-09-29T01:22:08Z
         type: false-positive-determination
         data:
-          type: component-vulnerability-mismatch
+          type: vulnerable-code-version-not-used
           note: |
             This vulnerability relates to v8.0.x of mattermost, which is several releases old.
             The componentVersion is also being flagged incorrectly here by some scanners.

--- a/mattermost-10.0.advisories.yaml
+++ b/mattermost-10.0.advisories.yaml
@@ -83,7 +83,7 @@ advisories:
             This vulnerability relates to v8.1.x of mattermost, which is several releases old.
             The componentVersion is also being flagged incorrectly here by some scanners.
             A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
-            See: https://github.com/anchore/syft/issues/80.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-64jc-pf3r-8hwj
     aliases:
@@ -110,7 +110,7 @@ advisories:
             This vulnerability relates to v8.1.x of mattermost, which is several releases old.
             The componentVersion is also being flagged incorrectly here by some scanners.
             A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
-            See: https://github.com/anchore/syft/issues/80.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-7q4c-cqwg-26gh
     aliases:
@@ -137,7 +137,7 @@ advisories:
             This vulnerability relates to v8.1.x of mattermost, which is several releases old.
             The componentVersion is also being flagged incorrectly here by some scanners.
             A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
-            See: https://github.com/anchore/syft/issues/80.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-7r6f-4rr6-h63g
     aliases:

--- a/mattermost-10.0.advisories.yaml
+++ b/mattermost-10.0.advisories.yaml
@@ -156,6 +156,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-09-29T01:22:08Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |
+            This vulnerability relates to v8.0.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-82fr-vcch-9r64
     aliases:


### PR DESCRIPTION
There is a version mismatch in the detection of this CVE caused by grype.