### PR TITLE
ci-cve-scan: allow staging bot to read advisories 

### DIFF
--- a/.github/chainguard/ci-cve-scan.sts.yaml
+++ b/.github/chainguard/ci-cve-scan.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://accounts.google.com
+
+# staging-enforce: ci-cve-scan-y3p1d12mopp7me1maq@staging-enforce-cd1e.iam.gserviceaccount.com (116393215694983881739)
+# prod-images: TODO
+subject_pattern: "(116393215694983881739)"
+
+permissions:
+  contents: read

--- a/.github/chainguard/ci-cve-scan.yaml
+++ b/.github/chainguard/ci-cve-scan.yaml
@@ -1,8 +1,0 @@
-issuer: https://accounts.google.com
-
-# staging-enforce: ci-cve-scan-y3p1d12mopp7me1maq@staging-enforce-cd1e.iam.gserviceaccount.com (116393215694983881739)
-# prod-images: TODO
-subject_pattern: "(116393215694983881739)"
-
-permissions:
-  contents: read

--- a/.github/chainguard/ci-cve-scan.yaml
+++ b/.github/chainguard/ci-cve-scan.yaml
@@ -1,0 +1,8 @@
+issuer: https://accounts.google.com
+
+# staging-enforce: ci-cve-scan-y3p1d12mopp7me1maq@staging-enforce-cd1e.iam.gserviceaccount.com (116393215694983881739)
+# prod-images: TODO
+subject_pattern: "(116393215694983881739)"
+
+permissions:
+  contents: read


### PR DESCRIPTION
https://github.com/chainguard-dev/internal-dev/issues/1519