### PR TITLE
confluent-kafka GHSA-735f-pc8j-v9w8 advisory

### DIFF
--- a/confluent-kafka.advisories.yaml
+++ b/confluent-kafka.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/kafka/libs/protobuf-java-3.23.4.jar
             scanner: grype
+      - timestamp: 2024-09-30T23:05:40Z
+        type: pending-upstream-fix
+        data:
+          note: 'Due to the nature of protobuf being a transitive dependency in the confluent-kafka project, which can be seen as the only reference to protobuf in the build.gradle file is moving the protobuf package within the shared JAR: https://github.com/confluentinc/kafka/blob/03095817ba4083115063a1df964d3a290406d167/build.gradle#L1855 We must wait for the dependency to be bumped upstream.'
 
   - id: CGA-rf22-c48h-w77h
     aliases:


### PR DESCRIPTION
Due to the nature of protobuf being a transitive dependency in the confluent-kafka project, which can be seen as the only reference to protobuf in the build.gradle, versions.gradle or gradle.properties files is in the build.gradle, moving the [protobuf package within the shared JAR](https://github.com/confluentinc/kafka/blob/03095817ba4083115063a1df964d3a290406d167/build.gradle#L1855). We must wait for the dependency to be bumped upstream.