### PR TITLE
updated druid GHSA-735f-pc8j-v9w8 advisory

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -533,9 +533,6 @@ advisories:
         type: detection
         data:
           type: manual
-          componentName: protobuf-java
-          componentVersion: 3.7.1
-          componentLocation: /usr/share/java/druid/extensions/druid-deltalake-extensions/hadoop-client-runtime-3.3.4.jar
       - timestamp: 2024-10-01T18:13:55Z
         type: pending-upstream-fix
         data:

--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -525,6 +525,21 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/lib/protobuf-java-3.24.0.jar
             scanner: grype
+      - timestamp: 2024-10-01T18:03:48Z
+        type: fixed
+        data:
+          fixed-version: 30.0.1-r1
+      - timestamp: 2024-10-01T18:13:22Z
+        type: detection
+        data:
+          type: manual
+          componentName: protobuf-java
+          componentVersion: 3.7.1
+          componentLocation: /usr/share/java/druid/extensions/druid-deltalake-extensions/hadoop-client-runtime-3.3.4.jar
+      - timestamp: 2024-10-01T18:13:55Z
+        type: pending-upstream-fix
+        data:
+          note: The protobuf 3.7 dependency causing this CVE is the result of a transitive dependency from hadoop used in druid extensions and must be remediated upstream.
 
   - id: CGA-qm53-pfmc-7gxx
     aliases:


### PR DESCRIPTION
The GHSA-735f-pc8j-v9w8 advisory is shared between the 3.24 and 3.7.1 detection, 3.24 event has been [fixed here in revision 1.](https://github.com/wolfi-dev/os/pull/29794) I have preemptively addressed the remaining protobuf issue that would have just come up in automation in a few days anyway when the remediation ticket above is merged and built. The remaining issue that is pending an upstream fix is the protobuf 3.7 dependency causing this CVE is the result of a transitive dependency from hadoop used in druid extensions. Ensure this is not merged until the following [package update is merged as well](https://github.com/wolfi-dev/os/pull/29794)