### PR TITLE
spark-3.5/GHSA-735f-pc8j-v9w8

### DIFF
--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -370,6 +370,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/mesos-1.4.3-shaded-protobuf.jar
             scanner: grype
+      - timestamp: 2024-10-01T21:29:11Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to protobuf-java v3.3.0 included by the shaded JARs mesos-1.4.3-shaded-protobuf.jar and hadoop-client-runtime-3.3.6.jar. There are no newer versions of these shaded JARs available to fix the vulnerability.
 
   - id: CGA-j2wq-qxcv-mc23
     aliases:


### PR DESCRIPTION
Much like what is found in a [recently addressed PR here](https://github.com/wolfi-dev/advisories/pull/8504),  The affected component protobuf-java v3.3.0 is a transitive dependency included by the shaded JARs [mesos-1.4.3-shaded-protobuf](https://mvnrepository.com/artifact/org.apache.mesos/mesos#:~:text=Feb%2002%2C%202018-,1.4.x,-1.4.3).jar and [hadoop-client-runtime-3.3.6.](https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-client-runtime#:~:text=Mar%2019%2C%202024-,3.3.x,-3.3.6)jar. There are no newer versions of these shaded JARs available to fix the vulnerability.