### PR TITLE
apache-nifi/GHSA-735f-pc8j-v9w8 advisory

### DIFF
--- a/apache-nifi.advisories.yaml
+++ b/apache-nifi.advisories.yaml
@@ -117,6 +117,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/nifi/nifi-current/lib/nifi-hadoop-libraries-nar-1.27.0.nar
             scanner: grype
+      - timestamp: 2024-10-02T14:46:18Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability exists within a pre-compiled dependency which nifi depends on, and we lack the ability to patch. The upstream maintainers must mitigate this CVE.
 
   - id: CGA-4f97-xch2-fqp3
     aliases:


### PR DESCRIPTION
Much like what is found in a https://github.com/wolfi-dev/advisories/pull/8504, The affected component protobuf-java v2.5.0 is a transitive dependency included by the JAR hadoop-libraries-nar-1.27.0.nar. This vulnerability exists within a pre-compiled dependency which nifi depends on, and we lack the ability to patch. The upstream maintainers must mitigate this CVE.