### PR TITLE
kubernetes-1.31: Add pending-upstream-fix for CVE-2024-28180

### DIFF
--- a/kubernetes-1.31.advisories.yaml
+++ b/kubernetes-1.31.advisories.yaml
@@ -147,6 +147,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kube-apiserver-1.31
             scanner: grype
+      - timestamp: 2024-10-02T19:06:50Z
+        type: pending-upstream-fix
+        data:
+          note: https://github.com/square/go-jose is deprecated, replaced with https://github.com/go-jose/go-jose. This dependency cannot be easily replaced without upstream changes due to interface requirements.
 
   - id: CGA-jcxv-jc3v-2wf7
     aliases:


### PR DESCRIPTION
This package is being flagged for a CVE in an archived repository. We cannot replace the dependency with it's maintained counterpart without breaking the build. This will require upstream changes to move the types over to the new module with the fixed version.

Related: https://github.com/wolfi-dev/os/pull/29927