### PR TITLE
gitlab-cng-17.4/GHSA-9hf4-67fc-4vf4

### DIFF
--- a/gitlab-cng-17.4.advisories.yaml
+++ b/gitlab-cng-17.4.advisories.yaml
@@ -39,3 +39,7 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.2.0/specifications/puma-5.6.8.gemspec
             scanner: grype
+      - timestamp: 2024-10-03T14:51:03Z
+        type: pending-upstream-fix
+        data:
+          note: Due to the affected Gem version being defined inside a Gemfile.lock file, we are unable to determine in the build pipeline a different version for this dependency and must wait for upstream implementation.


### PR DESCRIPTION
Due to the affected Gem version being defined inside a Gemfile.lock file, we are unable to determine in the build pipeline a different version for this dependency and must wait for upstream implementation.