### PR TITLE
spark-3.5/GHSA-f5fw-25gw-5m92 advisory update

### DIFF
--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -501,6 +501,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hadoop-client-api-3.3.6.jar
             scanner: grype
+      - timestamp: 2024-10-03T17:37:26Z
+        type: pending-upstream-fix
+        data:
+          note: 'The changes required to implement an upgrade from hadoop 3.3.6 to hadoop 3.4.0 require core code changes which are set to be released as a part of the spark 4.0.0 release that is in preview now. PR can be found here: https://github.com/apache/spark/commit/49b4c3bc9c09325de941dfaf41e4fd3a4a4c345f '
 
   - id: CGA-pv3f-mmpx-7xwc
     aliases:


### PR DESCRIPTION
The changes required to implement an upgrade from hadoop 3.3.6 to hadoop 3.4.0 require core code changes which are set to be released as a part of the spark 4.0.0 release that is in preview now. [PR can be found here](https://github.com/apache/spark/commit/49b4c3bc9c09325de941dfaf41e4fd3a4a4c345f)