### PR TITLE
GHSA-2326-pfpj-vx3h - parsable: pending-upstream-fix advisory

### DIFF
--- a/parseable.advisories.yaml
+++ b/parseable.advisories.yaml
@@ -42,6 +42,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/parseable
             scanner: grype
+      - timestamp: 2024-10-05T21:41:06Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Fixing this vulnerability requires upgrading lexical-core to v1.0.0.
+            However, another dependency: arrow-json, will not function with lexical-core v1.0.0.
+            arrow-json is preparing a 53.1.0 release, which upgrades it's dependency to a newer version of lexical-core.
+            However, this has not been released yet. Pending fix from upstream.
 
   - id: CGA-jhg5-22p5-x752
     aliases:


### PR DESCRIPTION
Filing a ending-upstream-fix advisory for GHSA-2326-pfpj-vx3h, which relates to the parsable package, and one of it's dependencies: lexical-core.

----------

**After this is approved / merged**, please close the following PR and delete the associated branch:
 - https://github.com/wolfi-dev/os/pull/29873