### PR TITLE
GHSA-4jwc-w2hc-78qv - tonic: pending-upstream-fix advisory

### DIFF
--- a/wadm.advisories.yaml
+++ b/wadm.advisories.yaml
@@ -21,3 +21,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/wadm
             scanner: grype
+      - timestamp: 2024-10-05T23:58:06Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this vulnerability requires upgrading tonic to v0.12.13.
+            However, upgrading this causes issues with other dependencies, namely opentelemetry-otlp and wadm-cli, which are not compatible with this version.
+            Pending upstream fix.


### PR DESCRIPTION
Filing a ending-upstream-fix advisory for GHSA-2326-pfpj-vx3h, which relates to the parsable package, and one of it's dependencies: lexical-core.

----------

**After this is approved / merged**, please close the following PR and delete the associated branch:
 - https://github.com/wolfi-dev/os/pull/29870