### PR TITLE
Add pending-upstream-fix advisory for GHSA-4jwc-w2hc-78qv, which we a…

### DIFF
--- a/linkerd2-proxy.advisories.yaml
+++ b/linkerd2-proxy.advisories.yaml
@@ -21,3 +21,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/linkerd2-proxy
             scanner: grype
+      - timestamp: 2024-10-06T01:02:56Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this vulnerability requires upgrading tonic to v0.12.13.
+            However, upgrading this causes issues with other dependencies, namely linkerd-app-core, which is not compatible with this version.
+            Pending upstream fix.


### PR DESCRIPTION
Filing a ending-upstream-fix advisory for GHSA-2326-pfpj-vx3h, which relates to the linkerd package, and one of it's dependencies: tonic.

----------

**After this is approved / merged**, please close the following PR and delete the associated branch:
 - https://github.com/wolfi-dev/os/pull/29867