### PR TITLE
apache-nifi/GHSA-f5fw-25gw-5m92 advisory update

### DIFF
--- a/apache-nifi.advisories.yaml
+++ b/apache-nifi.advisories.yaml
@@ -1091,6 +1091,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/nifi/nifi-current/lib/nifi-hbase_2-client-service-nar-1.27.0.nar
             scanner: grype
+      - timestamp: 2024-10-07T21:12:58Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability exists within a pre-compiled dependency which nifi depends on, and we lack the ability to patch. The most recent version of nifi-hbase_2-client-service-nar is implemented and can be found here: https://mvnrepository.com/artifact/org.apache.nifi/nifi-hbase_2-client-service-nar/1.27.0 The upstream maintainers must mitigate this CVE.'
 
   - id: CGA-hvjw-cqfw-cqf3
     aliases:


### PR DESCRIPTION
This vulnerability exists within a pre-compiled dependency which nifi depends on, and we lack the ability to patch. The most recent version of nifi-hbase_2-client-service-nar [is implemented](https://github.com/apache/nifi/blob/e0c4461d90bd4f6e5f2b81765bcff5cd97ed3e18/nifi-assembly/pom.xml#L515) and [can be found here](https://mvnrepository.com/artifact/org.apache.nifi/nifi-hbase_2-client-service-nar/1.27.0). 