### PR TITLE
Adding pending-upstream-fix advisory for rustup package

### DIFF
--- a/rustup.advisories.yaml
+++ b/rustup.advisories.yaml
@@ -41,3 +41,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/rustup-init
             scanner: grype
+      - timestamp: 2024-10-08T00:51:02Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this vulnerability requires upgrading the 'openssl' crate to 0.10.66 or later.
+            Unfortunately, we are not able to upgrade this dependency, without build compilation issues.
+            Pending fix from upstream.


### PR DESCRIPTION
_Related PR: https://github.com/wolfi-dev/os/pull/29085_

Adding pending-upstream-fix advisories for 'openssl' crate dependency. These corresponds to: GHSA-q445-7m23-qrmw.

Unfortunately we are able to remediate without build issues. See note in advisories for more info. 