### PR TITLE
pending-upstream-fix advisory for GHSA-wcg3-cvx6-7396

### DIFF
--- a/berg.advisories.yaml
+++ b/berg.advisories.yaml
@@ -21,6 +21,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/berg
             scanner: grype
+      - timestamp: 2024-10-08T11:17:39Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this vulnerability requires upgrading 'time' to 0.2.23 or later.
+            Unfortunately, we are not able to upgrade this dependency, without build compilation issues.
+            Specifically, the 'chrono' dependency expects an older version of time.
+            Pending fix from upstream.
 
   - id: CGA-6399-mq66-q9qw
     aliases:


### PR DESCRIPTION
related PR: https://github.com/wolfi-dev/os/pull/28727


pending-upstream-fix advisory for GHSA-wcg3-cvx6-7396, which relates to the 'time' dependency. Unfortunately we are unable to bump as other dependencies rely on older versions, resulting in build issues.

