### PR TITLE
Revert "adv(false positive): all the CVE here is marked false positive by main…"

### DIFF
--- a/cassandra-5.0.advisories.yaml
+++ b/cassandra-5.0.advisories.yaml
@@ -21,11 +21,6 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/snakeyaml-1.26.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
 
   - id: CGA-3gw6-5crj-7ph4
     aliases:
@@ -44,11 +39,6 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/snakeyaml-1.26.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
 
   - id: CGA-4v88-fh58-2mpr
     aliases:
@@ -67,11 +57,6 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/snakeyaml-1.26.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
 
   - id: CGA-c43g-8x54-j827
     aliases:
@@ -90,11 +75,6 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/jackson-databind-2.13.2.2.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
 
   - id: CGA-c8jc-9q83-4vwf
     aliases:
@@ -113,11 +93,6 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/snakeyaml-1.26.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
 
   - id: CGA-g26m-2r5c-xh44
     aliases:
@@ -136,11 +111,6 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/logback-core-1.2.12.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
 
   - id: CGA-h55v-gg7j-gc5v
     aliases:
@@ -159,11 +129,6 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/snakeyaml-1.26.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
 
   - id: CGA-jj3r-w482-76m6
     aliases:
@@ -182,11 +147,6 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/snakeyaml-1.26.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
 
   - id: CGA-jx7r-g27c-g947
     aliases:
@@ -205,11 +165,6 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/logback-classic-1.2.12.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
 
   - id: CGA-vmw3-v8q5-r6vx
     aliases:
@@ -228,11 +183,6 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/jackson-databind-2.13.2.2.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
 
   - id: CGA-vv26-h372-g4hq
     aliases:
@@ -251,8 +201,3 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/snakeyaml-1.26.jar
             scanner: grype
-      - timestamp: 2024-10-07T14:33:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'


### PR DESCRIPTION
Reverts wolfi-dev/advisories#8569 There are two incorrectly marked CVEs, the wording on the maintainer's page is not as verbose as one would like on the distinction between what is suppressed and what is a false positive and is easily missed. Something wasn't sitting right so I dug deeper and found two that are incorrectly labeled here. CVE-2022-42004 and CVE-2022-42003