### PR TITLE
Update Cassandra-5.0 CVE-2022-42003 and CVE-2022-42004 to pending upstream fix

### DIFF
--- a/cassandra-5.0.advisories.yaml
+++ b/cassandra-5.0.advisories.yaml
@@ -95,6 +95,10 @@ advisories:
         data:
           type: vulnerability-record-analysis-contested
           note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
+      - timestamp: 2024-10-08T19:39:33Z
+        type: pending-upstream-fix
+        data:
+          note: 'jackson-databind 2.13.2.2 was suppressed as a CVE which can be found outlined in this issue here: https://issues.apache.org/jira/browse/CASSANDRA-17966  Though suppressed by the maintainers, the CVE is still valid.'
 
   - id: CGA-c8jc-9q83-4vwf
     aliases:
@@ -233,6 +237,10 @@ advisories:
         data:
           type: vulnerability-record-analysis-contested
           note: 'CVE considered a false positive by the maintainers: https://github.com/apache/cassandra/blob/cassandra-5.0/.build/owasp/dependency-check-suppressions.xml'
+      - timestamp: 2024-10-08T19:45:37Z
+        type: pending-upstream-fix
+        data:
+          note: 'jackson-databind 2.13.2.2 was suppressed as a CVE which can be found outlined in this issue here: https://issues.apache.org/jira/browse/CASSANDRA-17966  Though suppressed by the maintainers, the CVE is still valid.'
 
   - id: CGA-vv26-h372-g4hq
     aliases:


### PR DESCRIPTION
There were two incorrectly marked CVEs, the wording on the maintainer's page is not as verbose as one would like on the distinction between what is suppressed and what is a false positive and is easily missed. Something wasn't sitting right so I dug deeper and found two that are incorrectly labeled. This PR fixes the incorrect labeling. jackson-databind 2.13.2.2 was suppressed as a CVE which can be found outlined [in this issue here.](https://issues.apache.org/jira/browse/CASSANDRA-17966) Though suppressed by the maintainers, the CVE is still valid