### PR TITLE
pending-upstream-fix advisory for GHSA-m5vv-6r4h-3vj9

### DIFF
--- a/modelmesh-runtime-adapter.advisories.yaml
+++ b/modelmesh-runtime-adapter.advisories.yaml
@@ -21,3 +21,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mlserver-adapter
             scanner: grype
+      - timestamp: 2024-10-09T01:00:59Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this vulnerability requires upgrading the 'azidentity' dependency to version v1.6.0 or later.
+            Upgrading this dependency, results in compatibility issues with another dependency, 'azblob'.
+            Attempting to upgrade both azidentity and azblob was also not successful.
+            Waiting on fix from upstream.


### PR DESCRIPTION
Pending-upstream-fix advisory for GHSA-m5vv-6r4h-3vj9, which relates to the 'azidentity' dependency used by modelmesh-runtime-adapter. Unfortunately our attempts at remediating were not successful.

----

Once approved / merged, **please close this** (attempted) **automated PR a**t remediating this:
 - https://github.com/wolfi-dev/os/pull/30364