### PR TITLE
multiple pending-upstream-fix advisories for zellij package

### DIFF
--- a/zellij.advisories.yaml
+++ b/zellij.advisories.yaml
@@ -72,6 +72,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zellij
             scanner: grype
+      - timestamp: 2024-10-09T01:59:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this vulnerability requires upgrading 'bumpalo' to 3.11.1 or later.
+            Unfortunately, we are not able to upgrade this dependency, without build compilation issues.
+            Specifically, the 'wasmer-compiler-cranelift' dependency expects an older version of bumpalo.
+            Pending fix from upstream.
 
   - id: CGA-m4f3-357j-5pq8
     aliases:
@@ -89,6 +97,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zellij
             scanner: grype
+      - timestamp: 2024-10-09T01:59:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this vulnerability requires upgrading 'remove_dir_all' to 0.8.0 or later.
+            Unfortunately, we are not able to upgrade this dependency, without build compilation issues with other dependencies.
+            Pending fix from upstream.
 
   - id: CGA-pqrx-g5p4-qcjm
     aliases:
@@ -124,6 +139,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zellij
             scanner: grype
+      - timestamp: 2024-10-09T02:10:56Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this vulnerability requires upgrading 'time' to 0.2.23 or later.
+            Unfortunately, we are not able to upgrade this dependency, without build compilation issues.
+            Pending fix from upstream.
 
   - id: CGA-wwr7-2chc-98v2
     aliases:
@@ -142,6 +164,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zellij
             scanner: grype
+      - timestamp: 2024-10-09T01:59:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this vulnerability requires upgrading 'mio' to 0.8.11 or later.
+            Unfortunately, we are not able to upgrade this dependency, without build compilation issues.
+            Pending fix from upstream.
 
   - id: CGA-xfjc-2627-77g7
     aliases:
@@ -160,3 +189,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zellij
             scanner: grype
+      - timestamp: 2024-10-09T01:59:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Remediating this vulnerability requires upgrading 'cranelift-codegen' to 0.91.1 or later.
+            Unfortunately, we are not able to upgrade this dependency, without build compilation issues with multiple other dependencies.
+            Pending fix from upstream.


### PR DESCRIPTION
Related PR: https://github.com/wolfi-dev/os/pull/28781

Raising multiple pending-upstream-fix advisories for the zellij package. I attempted bumping these but each resulted in failures. There were a couple we could bump (see link above). Refer to the advisory notes for more information.