### PR TITLE
buck2/GHSA-hc92-9h3m-c39j advisory update

### DIFF
--- a/buck2.advisories.yaml
+++ b/buck2.advisories.yaml
@@ -58,6 +58,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/buck2
             scanner: grype
+      - timestamp: 2024-10-09T09:39:20Z
+        type: pending-upstream-fix
+        data:
+          note: The affected dependency is no longer maintained in an official capacity and is the responsiblity of upstream maintainers to implement a different dependency or fix.
 
   - id: CGA-g62h-6j69-738r
     aliases:

--- a/buck2.advisories.yaml
+++ b/buck2.advisories.yaml
@@ -61,7 +61,7 @@ advisories:
       - timestamp: 2024-10-09T09:39:20Z
         type: pending-upstream-fix
         data:
-          note: The affected dependency is no longer maintained in an official capacity and is the responsiblity of upstream maintainers to implement a different dependency or fix.
+          note: The affected dependency is no longer maintained in an official capacity and is the responsibility of upstream maintainers to implement a different dependency or fix.
 
   - id: CGA-g62h-6j69-738r
     aliases:


### PR DESCRIPTION
The affected dependency is no longer maintained in an official capacity and is the responsibility of upstream maintainers to implement a different dependency or fix. More information can be found here https://rustsec.org/advisories/RUSTSEC-2021-0065.html