### PR TITLE
zed pending-upstream-fix advisory for GHSA-c38w-74pg-36hr

### DIFF
--- a/zed.advisories.yaml
+++ b/zed.advisories.yaml
@@ -107,6 +107,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/libexec/zed
             scanner: grype
+      - timestamp: 2024-10-09T19:30:41Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability is related to the 'rsa' dependency, of which zed is already installing the most recent version (0.9.6).
+            There is no release of 'rsa' today with a fix for this vulnerability. The RSA GitHub project repo is working on pre-releases, so a fix may be expected soon.
+            Waiting for upstream (RSA) to cut a new release with a fix, and for zed to consume.
 
   - id: CGA-hpm6-2qvq-4337
     aliases:


### PR DESCRIPTION
Related package update PR: https://github.com/wolfi-dev/os/pull/30446

Creation of pending-upstream-fix advisory for GHSA-c38w-74pg-36hr. Originates from 'rsa' dependency, which we're running the latest version of, and currently does not have a fix published.