### PR TITLE
pending-upstream-fix advisories for GHSA-4f8r-qqr9-fq8j, which affect…

### DIFF
--- a/kubescape.advisories.yaml
+++ b/kubescape.advisories.yaml
@@ -750,6 +750,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubescape
             scanner: grype
+      - timestamp: 2024-10-10T20:24:56Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Kubescape currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-r3x7-rwj4-3hj4
     aliases:

--- a/sigstore-scaffolding.advisories.yaml
+++ b/sigstore-scaffolding.advisories.yaml
@@ -276,3 +276,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/tuf-server
             scanner: grype
+      - timestamp: 2024-10-10T20:24:56Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            There are two separately named releases for 'go-tuf'. This application currently depends on both, 'go-tuf', and 'go-tuf/v2'.
+            go-tuf does not contain a fix for this vulnerability, and looks depreciated in favor of 'go-tuf/v2'.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.

--- a/slsa-verifier.advisories.yaml
+++ b/slsa-verifier.advisories.yaml
@@ -186,6 +186,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/slsa-verifier
             scanner: grype
+      - timestamp: 2024-10-10T20:24:56Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            There are two separately named releases for 'go-tuf'. This application currently depends on both, 'go-tuf', and 'go-tuf/v2'.
+            go-tuf does not contain a fix for this vulnerability, and looks depreciated in favor of 'go-tuf/v2'.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-5227-fv4m-wvcg
     aliases:

--- a/spire-server.advisories.yaml
+++ b/spire-server.advisories.yaml
@@ -406,17 +406,3 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/spire-server
             scanner: grype
-
-  - id: CGA-qjjx-7rr6-52h2
-    aliases:
-      - CVE-2024-47534
-      - GHSA-4f8r-qqr9-fq8j
-    events:
-      - timestamp: 2024-10-10T20:24:56Z
-        type: pending-upstream-fix
-        data:
-          note: |
-            spire-server currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
-            There are significant changes between these releases, and attempting to upgrade results in build errors.
-            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
-            Related information: https://github.com/github/advisory-database/pull/4893.

--- a/spire-server.advisories.yaml
+++ b/spire-server.advisories.yaml
@@ -406,3 +406,17 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/spire-server
             scanner: grype
+
+  - id: CGA-qjjx-7rr6-52h2
+    aliases:
+      - CVE-2024-47534
+      - GHSA-4f8r-qqr9-fq8j
+    events:
+      - timestamp: 2024-10-10T20:24:56Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            spire-server currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.

--- a/wolfictl.advisories.yaml
+++ b/wolfictl.advisories.yaml
@@ -213,6 +213,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/wolfictl
             scanner: grype
+      - timestamp: 2024-10-10T20:24:56Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            wolfictl currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-q8cg-653r-89r9
     aliases:

--- a/zot.advisories.yaml
+++ b/zot.advisories.yaml
@@ -229,6 +229,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/zot
             scanner: grype
+      - timestamp: 2024-10-10T20:24:56Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            There are two separately named releases for 'go-tuf'. zot currently depends on both, 'go-tuf', and 'go-tuf/v2'.
+            go-tuf does not contain a fix for this vulnerability, and looks depreciated in favor of 'go-tuf/v2'.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-4xx5-vp4r-9vwm
     aliases:


### PR DESCRIPTION
There are two published packages (separate names) for the go-tuf. These applications are affected by GHSA-4f8r-qqr9-fq8j, which relates to the older version: go-tuf. Note go-tuf/v2 contains a fix for this, but also significant changes, requiring upstream to issue a fix.

Also, this may be relevant re: different versions and CVE finding:
 - https://github.com/github/advisory-database/pull/4893
