### PR TITLE
pending-upstream-fix advisories for GHSA-4f8r-qqr9-fq8j - batch 2

### DIFF
--- a/gitsign.advisories.yaml
+++ b/gitsign.advisories.yaml
@@ -108,6 +108,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gitsign
             scanner: grype
+      - timestamp: 2024-10-10T21:42:40Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Gitsign currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-f2j8-pww7-x5pm
     aliases:

--- a/melange.advisories.yaml
+++ b/melange.advisories.yaml
@@ -145,6 +145,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/melange
             scanner: grype
+      - timestamp: 2024-10-10T21:42:40Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Melange currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-8v58-cxw6-mjqh
     aliases:

--- a/rekor.advisories.yaml
+++ b/rekor.advisories.yaml
@@ -228,6 +228,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/backfill-redis
             scanner: grype
+      - timestamp: 2024-10-10T21:42:40Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Rektor currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-hv35-ggrf-c49j
     aliases:

--- a/tekton-chains.advisories.yaml
+++ b/tekton-chains.advisories.yaml
@@ -60,6 +60,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/tekton-chains
             scanner: grype
+      - timestamp: 2024-10-10T21:42:40Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            tekton-chains currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-7rr5-prcv-mjvc
     aliases:

--- a/tkn.advisories.yaml
+++ b/tkn.advisories.yaml
@@ -221,6 +221,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/tkn
             scanner: grype
+      - timestamp: 2024-10-10T21:42:40Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Tkn currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-85p6-jrf4-v39m
     aliases:

--- a/trivy.advisories.yaml
+++ b/trivy.advisories.yaml
@@ -296,6 +296,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/trivy
             scanner: grype
+      - timestamp: 2024-10-10T21:42:40Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Trivy currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-jcgf-crc8-xxg6
     aliases:

--- a/vexctl.advisories.yaml
+++ b/vexctl.advisories.yaml
@@ -401,3 +401,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/vexctl
             scanner: grype
+      - timestamp: 2024-10-10T21:42:40Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Vexctl currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.

--- a/zarf.advisories.yaml
+++ b/zarf.advisories.yaml
@@ -120,6 +120,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/zarf
             scanner: grype
+      - timestamp: 2024-10-10T21:42:40Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            There are two separately named releases for 'go-tuf'.Zarf application currently depends on both, 'go-tuf', and 'go-tuf/v2'.
+            go-tuf does not contain a fix for this vulnerability, and looks depreciated in favor of 'go-tuf/v2'.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-658v-w5jj-qjgv
     aliases:


### PR DESCRIPTION
There are two published packages (separate names) for the go-tuf. These applications are affected by GHSA-4f8r-qqr9-fq8j, which relates to the older version: go-tuf. Note go-tuf/v2 contains a fix for this, but also significant changes, requiring upstream to issue a fix.

Also, this may be relevant re: different versions and CVE finding:
 - https://github.com/github/advisory-database/pull/4893
