### PR TITLE
Pending-upstream-fix advisories for GHSA-4f8r-qqr9-fq8j - batch 3

### DIFF
--- a/aactl.advisories.yaml
+++ b/aactl.advisories.yaml
@@ -535,6 +535,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/aactl
             scanner: grype
+      - timestamp: 2024-10-10T22:21:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            aactl currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-wp6w-jc96-4vqg
     aliases:

--- a/apko.advisories.yaml
+++ b/apko.advisories.yaml
@@ -170,6 +170,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/apko
             scanner: grype
+      - timestamp: 2024-10-10T22:21:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            apko currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-fr9x-mfm9-9rpj
     aliases:

--- a/cosign.advisories.yaml
+++ b/cosign.advisories.yaml
@@ -327,6 +327,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cosign
             scanner: grype
+      - timestamp: 2024-10-10T22:21:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            There are two separately named releases for 'go-tuf'. This application currently depends on both, 'go-tuf', and 'go-tuf/v2'.
+            go-tuf does not contain a fix for this vulnerability, and looks depreciated in favor of 'go-tuf/v2'.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-hmh4-g97q-rfvv
     aliases:

--- a/flux-source-controller.advisories.yaml
+++ b/flux-source-controller.advisories.yaml
@@ -456,6 +456,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/source-controller
             scanner: grype
+      - timestamp: 2024-10-10T22:21:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            neuvector-sigstore-interface currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-wx3f-cprc-w93w
     aliases:

--- a/gh.advisories.yaml
+++ b/gh.advisories.yaml
@@ -131,6 +131,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gh
             scanner: grype
+      - timestamp: 2024-10-10T22:21:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            There are two separately named releases for 'go-tuf'. This application currently depends on both, 'go-tuf', and 'go-tuf/v2'.
+            go-tuf does not contain a fix for this vulnerability, and looks depreciated in favor of 'go-tuf/v2'.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-fhfw-3fm5-9f8m
     aliases:

--- a/kyverno-1.12.advisories.yaml
+++ b/kyverno-1.12.advisories.yaml
@@ -109,6 +109,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kyvernopre
             scanner: grype
+      - timestamp: 2024-10-10T22:21:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            There are two separately named releases for 'go-tuf'. Kyverno currently depends on both, 'go-tuf', and 'go-tuf/v2'.
+            go-tuf does not contain a fix for this vulnerability, and looks depreciated in favor of 'go-tuf/v2'.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-wqp4-rgmg-668p
     aliases:

--- a/neuvector-sigstore-interface.advisories.yaml
+++ b/neuvector-sigstore-interface.advisories.yaml
@@ -151,6 +151,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/local/bin/sigstore-interface
             scanner: grype
+      - timestamp: 2024-10-10T22:21:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            neuvector-sigstore-interface currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-v924-gcj3-ccj2
     aliases:

--- a/policy-controller.advisories.yaml
+++ b/policy-controller.advisories.yaml
@@ -289,6 +289,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/policy-controller
             scanner: grype
+      - timestamp: 2024-10-10T22:21:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            There are two separately named releases for 'go-tuf'. This application currently depends on both, 'go-tuf', and 'go-tuf/v2'.
+            go-tuf does not contain a fix for this vulnerability, and looks depreciated in favor of 'go-tuf/v2'.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-jw9x-fq37-2hr2
     aliases:

--- a/spire-server.advisories.yaml
+++ b/spire-server.advisories.yaml
@@ -375,6 +375,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/spire-agent
             scanner: grype
+      - timestamp: 2024-10-10T22:21:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Spire currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-w383-9wx6-9qwj
     aliases:


### PR DESCRIPTION
There are two published packages (separate names) for the go-tuf. These applications are affected by GHSA-4f8r-qqr9-fq8j, which relates to the older version: go-tuf. Note go-tuf/v2 contains a fix for this, but also significant changes, requiring upstream to issue a fix.

Also, this may be relevant re: different versions and CVE finding:
 - https://github.com/github/advisory-database/pull/4893
