### PR TITLE
druid/GHSA-r7pg-v2c8-mfg3 advisory update

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -374,7 +374,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/extensions/druid-avro-extensions/avro-1.11.3.jar
             scanner: grype
-      - timestamp: 2024-10-11T06:24:11Z
+      - timestamp: 2024-10-15T06:24:11Z
         type: pending-upstream-fix
         data:
           note: 'The remaining avro dependency that gets flagged with this CVE is a transitive dependency that is part of the hadoop-client-runtime.jar and requires a fix from the upstream maintainers. '

--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -356,6 +356,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/extensions/druid-avro-extensions/avro-1.11.3.jar
             scanner: grype
+      - timestamp: 2024-10-11T06:24:11Z
+        type: pending-upstream-fix
+        data:
+          note: 'The remaining avro dependency that gets flagged with this CVE is a transitive dependency that is part of the hadoop-client-runtime.jar and requires a fix from the upstream maintainers. '
 
   - id: CGA-h9pg-8x4v-69rh
     aliases:


### PR DESCRIPTION
The remaining avro dependency that gets flagged with this CVE is a transitive dependency that is part of the hadoop-client-runtime.jar and requires a fix from the upstream maintainers. This advisory relates to the remediation found in the [following PR](https://github.com/wolfi-dev/os/pull/30615)