### PR TITLE
Various Advisories Filed For sonarqube

### DIFF
--- a/sonarqube-10.advisories.yaml
+++ b/sonarqube-10.advisories.yaml
@@ -39,6 +39,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/lib/sonar-application-10.6.0.92116.jar
             scanner: grype
+      - timestamp: 2024-10-11T04:53:04Z
+        type: pending-upstream-fix
+        data:
+          note: The xmlsec dependency is a transitive dependency that is brought in as a part of the sonar-application.jar and is not defined in the declared dependencies. This requires a fix from upstream maintainers.
 
   - id: CGA-683m-fm7m-7mvf
     aliases:
@@ -111,6 +115,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/modules/x-pack-core/nimbus-jose-jwt-9.23.jar
             scanner: grype
+      - timestamp: 2024-10-11T07:46:07Z
+        type: pending-upstream-fix
+        data:
+          note: This is a transitive dependency that is brought in as a part of elasticsearch dependency. Elasticsearch has been updated to the most recent version and so this requires a fix from upstream maintainers.
 
   - id: CGA-f3c9-jr4v-wvfr
     aliases:
@@ -129,6 +137,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/modules/x-pack-core/nimbus-jose-jwt-9.23.jar
             scanner: grype
+      - timestamp: 2024-10-11T04:48:18Z
+        type: pending-upstream-fix
+        data:
+          note: This is a transitive dependency that is brought in as a part of elasticsearch dependency. Elasticsearch has been updated to the most recent version and so this requires a fix from upstream maintainers.
 
   - id: CGA-g9h5-gx89-c9v8
     aliases:
@@ -147,6 +159,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/lib/tools/plugin-cli/bc-fips-1.0.2.4.jar
             scanner: grype
+      - timestamp: 2024-10-11T07:41:34Z
+        type: pending-upstream-fix
+        data:
+          note: 'This is a transitive dependency that is brought in as a part of elasticsearch dependency. Elasticsearch has been updated to the most recent version and so this requires a fix from upstream maintainers. '
 
   - id: CGA-hc2h-3vhp-c8h8
     aliases:
@@ -219,3 +235,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/lib/sonar-application-10.6.0.92116.jar
             scanner: grype
+      - timestamp: 2024-10-11T04:50:54Z
+        type: pending-upstream-fix
+        data:
+          note: This is a transitive dependency that is brought in as a part of elasticsearch dependency. Elasticsearch has been updated to the most recent version and so this requires a fix from upstream maintainers.


### PR DESCRIPTION
What can be fixed has in a [related PR that can be found here](https://github.com/wolfi-dev/os/pull/30618). The CVE advisory updates that are seen in this PR are all transitive jar dependencies that despite the upgrade to the latest elastic search version that can be made in this package, these still remain and are required to be updated by the upstream elasticsearch maintainers. Addresses the following for visibility and future searching: GHSA-xfrj-6vvc-3xm2/GHSA-gvpg-vgmx-xg6w/GHSA-493p-pfq6-5258/GHSA-8xfc-gm6g-vgpv