### PR TITLE
feat(gitlab-cng-17.3): pending upstream fix GHSA-9hf4-67fc-4vf4

### DIFF
--- a/gitlab-cng-17.3.advisories.yaml
+++ b/gitlab-cng-17.3.advisories.yaml
@@ -93,3 +93,7 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.2.0/specifications/puma-5.6.8.gemspec
             scanner: grype
+      - timestamp: 2024-10-11T16:24:18Z
+        type: pending-upstream-fix
+        data:
+          note: Due to the affected Gem version being defined inside a Gemfile.lock file, we are unable to determine in the build pipeline a different version for this dependency and must wait for upstream implementation.


### PR DESCRIPTION
Marking as pending upstream fix:

> Due to the affected Gem version being defined inside a Gemfile.lock file, we are unable to determine in the build pipeline a different version for this dependency and must wait for upstream implementation.

This follows on from the same advisory filed for gitlab-cng-17.4 @ https://github.com/wolfi-dev/advisories/pull/8537

Signed-off-by: philroche <phil.roche@chainguard.dev>
