### PR TITLE
 Adding adviory for GHSA-fhqq-8f65-5xfc. Grype is still reporting thi…

### DIFF
--- a/podman.advisories.yaml
+++ b/podman.advisories.yaml
@@ -127,7 +127,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/podman
             scanner: grype
-      - timestamp: 2023-12-28T19:09:32Z
+      - timestamp: 2024-10-14T12:04:02Z
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used

--- a/podman.advisories.yaml
+++ b/podman.advisories.yaml
@@ -127,6 +127,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/podman
             scanner: grype
+      - timestamp: 2023-12-28T19:09:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: |
+            This vulnerability was fixed in podman version v5.2.4, however, grype is still reporting this vulnerability when scanning the v5.2.4 package.
+            For evidence of the fix, please see the advisory, which lists v5.2.4 as the fixed version: https://github.com/advisories/GHSA-fhqq-8f65-5xfc.
+            Additionally, see the podman release notes, which list v5.2.4 as the fixed version of for this CVE. The code diff also shows buildah being bumped to v1.37.4: https://github.com/containers/podman/releases/tag/v5.2.4.
 
   - id: CGA-pcc8-jrq6-wc28
     aliases:


### PR DESCRIPTION
Addresses: https://github.com/wolfi-dev/os/pull/30494

-------

GHSA-fhqq-8f65-5xfc / CVE-2024-9407 was a vulnerability in podman, which originated from one of it's dependencies (buildah). This was fixed in v5.2.4 of podman.

Here is the release notes: https://github.com/containers/podman/releases/tag/v5.2.4
```
This release addresses CVE-2024-9407, which allows arbitrary access to the host filesystem from RUN --mount arguments to a Dockerfile being built.
Updated Buildah to v1.37.4
```

If you look in [the code diff](https://github.com/containers/podman/compare/v5.2.3...v5.2.4#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R15), you can also see buildah bumped in v1.37.4. However when running a grype scan, it is still reporting this vulnerability. Strangely, it detects the podman version, then says it's fixed in the... same version:

```
% wolfictl scan packages/aarch64/podman-5.2.4-r1.apk
🔎 Scanning "packages/aarch64/podman-5.2.4-r1.apk"
├── 📄 /usr/bin/podman
│       📦 github.com/containers/podman/v5 v3.45.1 (go-module)
│           Medium CVE-2024-9407 GHSA-fhqq-8f65-5xfc fixed in 5.2.4
│
└── 📄 /usr/bin/podman-remote
        📦 github.com/containers/podman/v5 v3.45.1 (go-module)
            Medium CVE-2024-9407 GHSA-fhqq-8f65-5xfc fixed in 5.2.4
```

This PR raises a 'false-positive-determination' advisory for this.



