### PR TITLE
feat(kubeflow-pipelines-visualization-server): pending upstream fix GHSA-h95x-26f3-88hr

### DIFF
--- a/kubeflow-pipelines-visualization-server.advisories.yaml
+++ b/kubeflow-pipelines-visualization-server.advisories.yaml
@@ -572,6 +572,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/Js2Py-0.74.dist-info/METADATA, /usr/lib/python3.10/site-packages/Js2Py-0.74.dist-info/RECORD, /usr/lib/python3.10/site-packages/Js2Py-0.74.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-10-14T15:09:26Z
+        type: pending-upstream-fix
+        data:
+          note: There is not currently a fixed version of the js2py package. So, the upstream project must migrate away from using js2py or wait for js2py to release a fixed version (and upgrade to it). Upstream PR @ https://github.com/PiotrDabkowski/Js2Py/pull/323 which is yet to be merged.
 
   - id: CGA-r33j-gmf8-rqgp
     aliases:


### PR DESCRIPTION
Marking as pending upstream fix:

> There is not currently a fixed version of the js2py package. So, the upstream project must migrate away from using js2py or wait for js2py to release a fixed version (and upgrade to it). Upstream PR @ https://github.com/PiotrDabkowski/Js2Py/pull/323 which is yet to be merged.

This follows on from the same advisory filed for apache-beam-python-3.11-sdk @ https://github.com/chainguard-dev/enterprise-advisories/pull/5130

Signed-off-by: philroche <phil.roche@chainguard.dev>
