### PR TITLE
management-api-for-apache-cassandra-4.1/GHSA-78wr-2p64-hpwj advisory

### DIFF
--- a/management-api-for-apache-cassandra-4.1.advisories.yaml
+++ b/management-api-for-apache-cassandra-4.1.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/management-api/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar
             scanner: grype
+      - timestamp: 2024-10-16T01:02:18Z
+        type: pending-upstream-fix
+        data:
+          note: Commons-io v2.9.0 is a transitive dependency that is brought in under the resteasy-client-api, even the most up to date version of the 4.x.x version stream (4.7.9) contains the affected version of commons-io. This requires the upstream maintainers to implement a fix.
 
   - id: CGA-69cr-q4xf-g62p
     aliases:


### PR DESCRIPTION
Commons-io v2.9.0 is a transitive dependency that is brought in under the resteasy-client-api, even the most up to date version of the 4.x.x [version stream (4.7.9)](https://mvnrepository.com/artifact/org.jboss.resteasy/resteasy-client/4.7.9.Final) contains the affected version of commons-io. This requires the upstream maintainers to implement a fix.