### PR TITLE
spark-3.5/GHSA-78wr-2p64-hpwj advisory update

### DIFF
--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -195,6 +195,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hadoop-client-runtime-3.3.6.jar
             scanner: grype
+      - timestamp: 2024-10-16T01:46:38Z
+        type: pending-upstream-fix
+        data:
+          note: commons-io v2.8.0 is a transitive dependency that is brought in under hadoop-client-runtime-3.3.6.jar. This requires a hadoop-client-runtime update from upstream maintainers
 
   - id: CGA-5v9q-v7xh-qmf9
     aliases:


### PR DESCRIPTION
commons-io v2.8.0 is a transitive dependency that is brought in under hadoop-client-runtime-3.3.6.jar. This requires a hadoop-client-runtime update from upstream maintainers