### PR TITLE
 kafka-3.8/GHSA-78wr-2p64-hpwj advisory update

### DIFF
--- a/kafka-3.8.advisories.yaml
+++ b/kafka-3.8.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/kafka/libs/commons-io-2.11.0.jar
             scanner: grype
+      - timestamp: 2024-10-16T08:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: The commons-io dependency is a transitive dependency that Is brought in under swagger-core which is currently kept under 2.14.0 due to the fact that this version and up drop support for jdk8. The repository is currently working on transitioning on making jdk11 the minimum version but is in the middle of that process and is not currently ready. Here is the PR regarding this https://github.com/apache/kafka/pull/17441and the project status can be found here https://issues.apache.org/jira/browse/KAFKA-12894
 
   - id: CGA-r5gc-w736-v6hf
     aliases:

--- a/kafka-3.8.advisories.yaml
+++ b/kafka-3.8.advisories.yaml
@@ -24,7 +24,7 @@ advisories:
       - timestamp: 2024-10-16T08:32:23Z
         type: pending-upstream-fix
         data:
-          note: The commons-io dependency is a transitive dependency that Is brought in under swagger-core which is currently kept under 2.14.0 due to the fact that this version and up drop support for jdk8. The repository is currently working on transitioning on making jdk11 the minimum version but is in the middle of that process and is not currently ready. Here is the PR regarding this https://github.com/apache/kafka/pull/17441and the project status can be found here https://issues.apache.org/jira/browse/KAFKA-12894
+          note: The commons-io dependency is a transitive dependency that Is brought in under swagger-core which is currently kept under 2.14.0 due to the fact that this version and up drop support for jdk8. The repository is currently working on transitioning on making jdk11 the minimum version but is in the middle of that process and is not currently ready. Here is the PR regarding this https://github.com/apache/kafka/pull/17441 and the project status can be found here https://issues.apache.org/jira/browse/KAFKA-12894
 
   - id: CGA-r5gc-w736-v6hf
     aliases:


### PR DESCRIPTION
The commons-io dependency is a transitive dependency that Is brought in under swagger-core which is currently kept under 2.14.0 due to the fact that [this version and up drop support for jdk8](https://github.com/atu-sharm/kafka/blob/04b24bb4dfe48fae2e50fb0fc2cc18f313f6f633/gradle.properties#L29). The repository is currently working on transitioning on making jdk11 the minimum version but is in the middle of that process and is not currently ready. [Here is the PR regarding this](https://github.com/apache/kafka/pull/17441) and the [project status can be found here ](https://issues.apache.org/jira/browse/KAFKA-12894)