### PR TITLE
go-fips-1.21/CVE-2024-34158/CVE-2024-34155/CVE-2024-34156 advisory update

### DIFF
--- a/go-fips-1.21.advisories.yaml
+++ b/go-fips-1.21.advisories.yaml
@@ -14,6 +14,16 @@ advisories:
         data:
           fixed-version: 1.21.12-r0
 
+  - id: CGA-3xjh-5r55-6p7r
+    aliases:
+      - CVE-2024-34158
+      - GHSA-j7vj-rw65-4v26
+    events:
+      - timestamp: 2024-10-18T08:28:30Z
+        type: fix-not-planned
+        data:
+          note: Go v1.21 is EOL and will not longer receive CVE remediation.
+
   - id: CGA-965g-h4c8-4689
     aliases:
       - CVE-2024-24789
@@ -43,6 +53,26 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.21.11-r0
+
+  - id: CGA-gvr5-rpp2-vq48
+    aliases:
+      - CVE-2024-34155
+      - GHSA-8xfx-rj4p-23jm
+    events:
+      - timestamp: 2024-10-18T08:23:53Z
+        type: fix-not-planned
+        data:
+          note: Go v1.21 is EOL and will not longer receive CVE remediation.
+
+  - id: CGA-px59-jvw9-5289
+    aliases:
+      - CVE-2024-34156
+      - GHSA-crqm-pwhx-j97f
+    events:
+      - timestamp: 2024-10-18T08:29:37Z
+        type: fix-not-planned
+        data:
+          note: Go v1.21 is EOL and will not longer receive CVE remediation.
 
   - id: CGA-vp32-ch3h-3qrp
     aliases:


### PR DESCRIPTION
Go v1.21 is EOL and will not longer receive CVE remediation. The reason this is being update is due to the fact that it is still being used in [Request 1398 ](https://github.com/jamie-albert/images-private/blob/9c8e4c386a197188e15ffd46166253aff273a4f9/images/request-1398/configs/main.tf#L25) and [Request 1400](https://github.com/jamie-albert/images-private/blob/9c8e4c386a197188e15ffd46166253aff273a4f9/images/request-1400/configs/main.tf#L25). go-fips-1.21 [was deleted here ](https://github.com/wolfi-dev/os/commit/ba9cc8e826befff34e4f3d59dd0203e599b61ef0)