### PR TITLE
spark-3.5/GHSA-r7pg-v2c8-mfg3 advisory update

### DIFF
--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -283,6 +283,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/avro-1.11.3.jar
             scanner: grype
+      - timestamp: 2024-10-19T21:05:09Z
+        type: pending-upstream-fix
+        data:
+          note: The commons-io dependency that exists in the spark-3.5 package and related subpackages is brought in as transitive from hadoop-client-runtime-3.3.6.jar. This dependency is not able to be upgraded to a higher version and requires upstream maintainers to implement.
 
   - id: CGA-c7jc-pc4g-5wpx
     aliases:


### PR DESCRIPTION
The commons-io dependency that exists in the spark-3.5 package and related subpackages is brought in as transitive from hadoop-client-runtime-3.3.6.jar. This dependency is not able to be upgraded to a higher version and requires upstream maintainers to implement.