### PR TITLE
confluent-common-docker/GHSA-78wr-2p64-hpwj advisory update

### DIFF
--- a/confluent-common-docker.advisories.yaml
+++ b/confluent-common-docker.advisories.yaml
@@ -83,6 +83,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cp-base-new/docker-utils-jar-with-dependencies.jar
             scanner: grype
+      - timestamp: 2024-10-21T02:28:15Z
+        type: pending-upstream-fix
+        data:
+          note: The commons-io dependency is a transitive dependency that is being brought in under docker-utils-jar-with-dependencies.jar and this must be updated by upstream maintainers.
 
   - id: CGA-gw4m-4mj9-6g69
     aliases:


### PR DESCRIPTION
The commons-io dependency is a transitive dependency that is being brought in under docker-utils-jar-with-dependencies.jar and this must be updated by upstream maintainers.