### PR TITLE
Added pending-upstream-fix event for CGA-8cc7-m97x-rcw7

### DIFF
--- a/sonarqube-10.advisories.yaml
+++ b/sonarqube-10.advisories.yaml
@@ -137,6 +137,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/modules/x-pack-inference/protobuf-java-3.21.9.jar
             scanner: grype
+      - timestamp: 2024-10-22T14:00:01Z
+        type: pending-upstream-fix
+        data:
+          note: This is a transitive dependency that is brought in as a part of elasticsearch dependency. Elasticsearch has been updated to the most recent version and so this requires a fix from upstream maintainers.
 
   - id: CGA-f3c9-jr4v-wvfr
     aliases:


### PR DESCRIPTION
Similar to other CVEs in this advisory list, this one seems to be a transitive dependency of elasticsearch, and therefore a pending-upstream-fix made the most sense. 