### PR TITLE
Added pending-upstream-fix event for GHSA-78wr-2p64-hpwj

### DIFF
--- a/sonarqube-10.advisories.yaml
+++ b/sonarqube-10.advisories.yaml
@@ -79,6 +79,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/lib/extensions/sonar-javascript-plugin-10.16.0.27621-multi.jar
             scanner: grype
+      - timestamp: 2024-10-22T14:11:00Z
+        type: pending-upstream-fix
+        data:
+          note: This is a transitive dependency that is brought in through sonar plugins. These are built externally and therefore require a fix from upstream maintainers.
 
   - id: CGA-7fm6-4c5m-gw2x
     aliases:


### PR DESCRIPTION
Similar to other CVEs in this advisory list, this one seems to be a transitive dependency of brought in through multiple sonar plugins, and therefore a pending-upstream-fix made the most sense as these are built externally.