### PR TITLE
Added pending-upstream-fix event for zookeeper-3.9/GHSA-qh8g-58pp-2wxh

### DIFF
--- a/zookeeper-3.9.advisories.yaml
+++ b/zookeeper-3.9.advisories.yaml
@@ -53,6 +53,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/zookeeper/lib/jetty-http-9.4.53.v20231009.jar
             scanner: grype
+      - timestamp: 2024-10-23T13:59:20Z
+        type: pending-upstream-fix
+        data:
+          note: Updating jetty to a non-vulnerable version would require 3 major version bumps, which would be a very significant upgrade and should only be undertaken by the upstream maintainers.
 
   - id: CGA-p5qq-x3qc-jpwx
     aliases:


### PR DESCRIPTION
Updating jetty to a non-vulnerable version would require 3 major version bumps, which would be a very significant upgrade and should only be undertaken by the upstream maintainers.