### PR TITLE
cassandra-reaper: Transitive dependency requires upstream update

### DIFF
--- a/cassandra-reaper.advisories.yaml
+++ b/cassandra-reaper.advisories.yaml
@@ -209,6 +209,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/local/lib/cassandra-reaper.jar
             scanner: grype
+      - timestamp: 2024-10-24T16:10:44Z
+        type: pending-upstream-fix
+        data:
+          note: 'Resolving requires the io.dropwizard dependency to update the jetty-servlet dependency to 9.4.54 or newer.'
 
   - id: CGA-qjrq-jr26-67w4
     aliases:


### PR DESCRIPTION
Eclipse Jetty has a denial of service vulnerability that is fixed in 9.4.54 for org.eclipse.jetty:jetty-servlets. This dependency is brought in by io.dropwizard. The 2.1.x stream of io.dropwizard has not had an update in almost a year and no additional commits have been added since.

Discovered via `mvn dependency:tree` and looking for jetty-servlets which was only used by io.dropwizard.