### PR TITLE
Added advisory for falcoctl/GHSA-4f8r-qqr9-fq8j

### DIFF
--- a/falcoctl.advisories.yaml
+++ b/falcoctl.advisories.yaml
@@ -349,6 +349,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/falcoctl
             scanner: grype
+      - timestamp: 2024-10-28T17:05:14Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            falcoctl currently relies on an affected version of 'go-tuf', which looks to have been depreciated in favor of 'go-tuf/v2'.
+            There are significant changes between these releases, and attempting to upgrade results in build errors.
+            Pending fix from upstream, which will involve removing their dependency on the depreciated version.
+            Related information: https://github.com/github/advisory-database/pull/4893.
 
   - id: CGA-wg8q-f7fj-h4rv
     aliases:


### PR DESCRIPTION
Same situation as the falcoctl-fips advisory filed here: https://github.com/chainguard-dev/enterprise-advisories/commit/c64d6890f6c4661c6f8c470c45243ff1dce72ff3#diff-1b13d7402df8f8dc9019f7a794ddbb0ad73037bbac74698ac2f5150c746ceeb1

Auto-created PR with vulnerability details: https://github.com/wolfi-dev/os/pull/30501