### PR TITLE
Added advisory for kubeflow-pipelines/GHSA-c7qv-q95q-8v27

### DIFF
--- a/kubeflow-pipelines.advisories.yaml
+++ b/kubeflow-pipelines.advisories.yaml
@@ -74,6 +74,10 @@ advisories:
             componentType: npm
             componentLocation: /server/node_modules/http-proxy-middleware/package.json
             scanner: grype
+      - timestamp: 2024-10-29T20:33:56Z
+        type: pending-upstream-fix
+        data:
+          note: Attempted to remediate the CVE by bumping http-proxy-middleware to 2.0.7 (first patched version) but this resulted in build errors. Waiting on a fix from upstream.
 
   - id: CGA-2wrh-m9wq-83qx
     aliases:


### PR DESCRIPTION
Spent a while trying to get the dependency bump to work, but I ran into a variety of build failures and ultimately it'll require further work by the upstream maintainers. 
https://github.com/chainguard-dev/CVE-Dashboard/issues/14054