### PR TITLE
feat(advisory): apache-nifi: GHSA-4gc7-5j7h-4qph pending-upstream-fix

### DIFF
--- a/apache-nifi.advisories.yaml
+++ b/apache-nifi.advisories.yaml
@@ -1089,6 +1089,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/nifi/nifi-toolkit-current/lib/spring-context-5.3.39.jar
             scanner: grype
+      - timestamp: 2024-10-30T11:44:12Z
+        type: pending-upstream-fix
+        data:
+          note: Patched version 5.3.41 is not available publicly. It is only available through Sring Enterprise support - see https://spring.io/security/cve-2024-38820
 
   - id: CGA-h8j8-9v3w-chjj
     aliases:


### PR DESCRIPTION
No publicly available patched version of spring-context available. Therefore marking pending-upstream-fix.

> Patched version 5.3.41 is not available publicly.
> It is only available through Sring Enterprise support - see https://spring.io/security/cve-2024-38820

Signed-off-by: philroche <phil.roche@chainguard.dev>
