### PR TITLE
Package: wash - Adding pending-upstream-fix advisory for 'lexical-core'

### DIFF
--- a/wash.advisories.yaml
+++ b/wash.advisories.yaml
@@ -42,6 +42,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/wash
             scanner: grype
+      - timestamp: 2024-11-01T11:58:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This CVE relates to THE 'lexical-core' dependency, and a fix is available in v1.0 and later.
+            Attempts to upgrade this dependency result in build failures. There are other dependencies which require lexical-core v0.8.0 or lower.
+            Pending fix from upstream.
 
   - id: CGA-rrxp-vx65-hrrv
     aliases:


### PR DESCRIPTION
Adding pending-upstream-fix advisory for 'lexical-core'. Attempts to bump this manually have been unsuccessful:

```
error: failed to select a version for the requirement `lexical-core = ">=0.6, <0.8"` uses=rust/cargobump
```

Other dependencies in the project depend on an older versio of lexical-core. We'll need upstream to address