### PR TITLE
feat(advisory): datadog-agent: GHSA-5vvg-pvhp-hv2m pending-upstream-fix

### DIFF
--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -497,6 +497,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/datadog-agent/lib/python3.11/site-packages/snowflake_connector_python-3.12.1.dist-info/METADATA, /usr/share/datadog-agent/lib/python3.11/site-packages/snowflake_connector_python-3.12.1.dist-info/RECORD, /usr/share/datadog-agent/lib/python3.11/site-packages/snowflake_connector_python-3.12.1.dist-info/direct_url.json, /usr/share/datadog-agent/lib/python3.11/site-packages/snowflake_connector_python-3.12.1.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-11-04T11:29:13Z
+        type: pending-upstream-fix
+        data:
+          note: Due to the complex way that Datadog packages and distributes dependencies, updating the package containing this vulnerability must be left to the upstream maintainers.
 
   - id: CGA-p4mm-jvfh-v2c4
     aliases:


### PR DESCRIPTION
Not possible to patch dependency given how they are distributed by datadog-agent. Therefore marking pending-upstream-fix.

> Due to the complex way that Datadog packages and distributes dependencies, updating the package containing this vulnerability must be left to the upstream maintainers.

Signed-off-by: philroche <phil.roche@chainguard.dev>
