### PR TITLE
add fix-not-planned events to deleted apk definitions

### DIFF
--- a/go-1.21.advisories.yaml
+++ b/go-1.21.advisories.yaml
@@ -28,6 +28,15 @@ advisories:
         data:
           type: vulnerable-code-not-in-execution-path
 
+  - id: CGA-466j-hmf8-m8wc
+    aliases:
+      - CVE-2024-34158
+    events:
+      - timestamp: 2024-11-06T10:17:51Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-08-13'.
+
   - id: CGA-4gm6-937v-989c
     aliases:
       - CVE-2023-45288
@@ -37,6 +46,15 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.21.9-r0
+
+  - id: CGA-52r8-8g54-gjgg
+    aliases:
+      - CVE-2024-34156
+    events:
+      - timestamp: 2024-11-06T10:17:51Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-08-13'.
 
   - id: CGA-8gf2-r7xv-f9fj
     aliases:
@@ -92,6 +110,15 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.21.11-r0
+
+  - id: CGA-j7pp-6hgh-f252
+    aliases:
+      - CVE-2024-34155
+    events:
+      - timestamp: 2024-11-06T10:17:51Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-08-13'.
 
   - id: CGA-mgmp-mqhw-32mw
     aliases:

--- a/redis-7.0.advisories.yaml
+++ b/redis-7.0.advisories.yaml
@@ -15,6 +15,15 @@ advisories:
           type: component-vulnerability-mismatch
           note: This is a Debian-specific issue and does not affect Wolfi.
 
+  - id: CGA-5rq8-r8w6-vhc6
+    aliases:
+      - CVE-2024-31227
+    events:
+      - timestamp: 2024-11-06T10:17:51Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-07-29'.
+
   - id: CGA-6wgh-jwmf-w7vc
     aliases:
       - CVE-2022-3647
@@ -25,17 +34,6 @@ advisories:
         data:
           type: vulnerability-record-analysis-contested
           note: The vulnerability is disputed upstream, indicating that this is expected behavior.
-
-  - id: CGA-q3mv-qj35-6666
-    aliases:
-      - CVE-2022-3734
-      - GHSA-4x76-2j9h-q9r9
-    events:
-      - timestamp: 2023-08-31T17:52:09Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: This is a disputed CVE entry that does not actually affect Redis.
 
   - id: CGA-9pfh-3fqr-fg4v
     aliases:
@@ -58,3 +56,32 @@ advisories:
         type: fixed
         data:
           fixed-version: 7.0.15-r0
+
+  - id: CGA-m455-vx46-f9p4
+    aliases:
+      - CVE-2024-31449
+    events:
+      - timestamp: 2024-11-06T10:17:51Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-07-29'.
+
+  - id: CGA-q3mv-qj35-6666
+    aliases:
+      - CVE-2022-3734
+      - GHSA-4x76-2j9h-q9r9
+    events:
+      - timestamp: 2023-08-31T17:52:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: This is a disputed CVE entry that does not actually affect Redis.
+
+  - id: CGA-xv6c-5784-gcv2
+    aliases:
+      - CVE-2024-31228
+    events:
+      - timestamp: 2024-11-06T10:17:51Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-07-29'.


### PR DESCRIPTION
This events are added to no longer scanned APKs due to its removal from our package repositories. That also means we don't have a way to fix the CVEs.