### PR TITLE
chore(datadog-agent): add pending-upstream-fix event for cve-2024-49750

### DIFF
--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -497,6 +497,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/datadog-agent/lib/python3.11/site-packages/snowflake_connector_python-3.12.1.dist-info/METADATA, /usr/share/datadog-agent/lib/python3.11/site-packages/snowflake_connector_python-3.12.1.dist-info/RECORD, /usr/share/datadog-agent/lib/python3.11/site-packages/snowflake_connector_python-3.12.1.dist-info/direct_url.json, /usr/share/datadog-agent/lib/python3.11/site-packages/snowflake_connector_python-3.12.1.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-11-06T11:09:36Z
+        type: pending-upstream-fix
+        data:
+          note: snowflake_connector_python 3.12.3 contains the fix, but that release is not yet available in the Datadog hosted Agent dependencies Python repository. See https://agent-int-packages.datadoghq.com/external/snowflake-connector-python/.
 
   - id: CGA-p4mm-jvfh-v2c4
     aliases:


### PR DESCRIPTION
Add pending-upstream-fix event for CVE-2024-49750.