### PR TITLE
add fix-not-planned events to deleted apk definitions

### DIFF
--- a/nodejs-16.advisories.yaml
+++ b/nodejs-16.advisories.yaml
@@ -31,6 +31,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-11T14:26:26Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2023-09-11'.
 
   - id: CGA-438w-pv6v-p6mh
     aliases:
@@ -183,6 +187,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-11T14:26:26Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2023-09-11'.
 
   - id: CGA-j48f-xqxh-34j7
     aliases:
@@ -245,6 +253,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-11T14:26:26Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2023-09-11'.
 
   - id: CGA-m387-qf4w-mfvr
     aliases:


### PR DESCRIPTION
These APKs are no longer available on our repositories so we should keep the house clean and marked them as fix-not-planned.