### PR TITLE
Added advisory for mattermost-10.1-CVE-2022-4045

### DIFF
--- a/mattermost-10.1.advisories.yaml
+++ b/mattermost-10.1.advisories.yaml
@@ -165,6 +165,15 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-12T22:32:31Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |
+            This vulnerability relates to v7.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-8hf8-jcx4-7qwf
     aliases:


### PR DESCRIPTION
This adds a false positive event as this is the same issue previously documented here: https://github.com/wolfi-dev/advisories/pull/8472

Relevant detection issue: https://github.com/chainguard-dev/CVE-Dashboard/issues/14797