### PR TITLE
airflow GHSA-q34m-jh98-gwm2/GHSA-f9vj-2wh5-fj8j advisories

### DIFF
--- a/airflow.advisories.yaml
+++ b/airflow.advisories.yaml
@@ -234,6 +234,10 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/venv/lib/python3.12/site-packages/Werkzeug-2.2.3.dist-info/METADATA, /opt/airflow/venv/lib/python3.12/site-packages/Werkzeug-2.2.3.dist-info/RECORD, /opt/airflow/venv/lib/python3.12/site-packages/Werkzeug-2.2.3.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-11-13T04:46:12Z
+        type: pending-upstream-fix
+        data:
+          note: 'Fixed versions of Werkzeug (v2.3.8 and above) are not compatible with the current version of apache airflow. There is an open PR in airflow addressing this that will natively support Werkzeug v2.3.8 (https://github.com/apache/airflow/pull/36052) '
 
   - id: CGA-8f64-fgpv-jxj2
     aliases:
@@ -296,6 +300,10 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/venv/lib/python3.12/site-packages/Werkzeug-2.2.3.dist-info/METADATA, /opt/airflow/venv/lib/python3.12/site-packages/Werkzeug-2.2.3.dist-info/RECORD, /opt/airflow/venv/lib/python3.12/site-packages/Werkzeug-2.2.3.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-11-13T04:47:26Z
+        type: pending-upstream-fix
+        data:
+          note: 'Fixed versions of Werkzeug (v2.3.8 and above) are not compatible with the current version of apache airflow. There is an open PR in airflow addressing this that will natively support Werkzeug v2.3.8 (https://github.com/apache/airflow/pull/36052) '
 
   - id: CGA-f4qg-9fw4-8247
     aliases:


### PR DESCRIPTION
Fixed versions of Werkzeug (v2.3.8 and above) are not compatible with the current version of apache airflow. There is an open PR in airflow addressing this that will natively support Werkzeug v2.3.8 (https://github.com/apache/airflow/pull/36052)