### PR TITLE
libreOffice CVE-2012-5639 advisory update

### DIFF
--- a/libreoffice-24.8.advisories.yaml
+++ b/libreoffice-24.8.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-13T05:16:34Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE has been addressed in OpenOffice which LibreOffice is forked from but has not been fixed in LibreOffice. The feature changes required to remediate this CVE must be implemented by upstream maintainers.


### PR DESCRIPTION
his CVE has been addressed in OpenOffice which LibreOffice is forked from but has not been fixed in LibreOffice. The feature changes required to remediate this CVE must be implemented by upstream maintainers. There is an interesting lwn article that talks about this CVE: [The odd saga of CVE-2012-5639](https://lwn.net/Articles/957219/)