### PR TITLE
kubeflow-pipelines-visualization-server GHSA-f9vj-2wh5-fj8j GHSA-q34m-jh98-gwm2 advisory update

### DIFF
--- a/kubeflow-pipelines-visualization-server.advisories.yaml
+++ b/kubeflow-pipelines-visualization-server.advisories.yaml
@@ -279,6 +279,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/Werkzeug-2.1.2.dist-info/METADATA, /usr/lib/python3.10/site-packages/Werkzeug-2.1.2.dist-info/RECORD, /usr/lib/python3.10/site-packages/Werkzeug-2.1.2.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-11-14T10:14:58Z
+        type: pending-upstream-fix
+        data:
+          note: 'It is not possible to bump the version of werkzeug to 3.0.6 as even bumping from 2.1.2 to 2.2.3 is not possible, the application fails with the error: ImportError: cannot import name ''''soft_unicode'''' from ''''markupsafe’’. This requires upstream maintainers to implement.'
 
   - id: CGA-cx62-9vw2-mmpq
     aliases:
@@ -502,6 +506,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/Werkzeug-2.1.2.dist-info/METADATA, /usr/lib/python3.10/site-packages/Werkzeug-2.1.2.dist-info/RECORD, /usr/lib/python3.10/site-packages/Werkzeug-2.1.2.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2024-11-14T10:14:29Z
+        type: pending-upstream-fix
+        data:
+          note: 'It is not possible to bump the version of werkzeug to 3.0.6 as even bumping from 2.1.2 to 2.2.3 is not possible, the application fails with the error: ImportError: cannot import name ''''soft_unicode'''' from ''''markupsafe’’. This requires upstream maintainers to implement.'
 
   - id: CGA-p7rq-qffc-ch9v
     aliases:


### PR DESCRIPTION
It is not possible to bump the version of werkzeug to 3.0.6 as even bumping from 2.1.2 to 2.2.3 is not possible, the application fails with the error: ImportError: cannot import name ''''soft_unicode'''' from ''''markupsafe’’. This requires upstream maintainers to implement.