### PR TITLE
traefik-3.2/GHSA-c5q2-7r4c-mv6g advisory update

### DIFF
--- a/traefik-3.2.advisories.yaml
+++ b/traefik-3.2.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/traefik
             scanner: grype
+      - timestamp: 2024-11-14T10:18:30Z
+        type: pending-upstream-fix
+        data:
+          note: 'The gopkg.in/square/go-jose.v2 dependency is archived and will not be fixed as can be seen here fro the advisory database: https://github.com/advisories/GHSA-c5q2-7r4c-mv6g The upstream maintainers must implement the fix. '
 
   - id: CGA-pw97-9g4p-mg7w
     aliases:


### PR DESCRIPTION
The gopkg.in/square/go-jose.v2 dependency is archived and will not be fixed as can be seen here fro the advisory database: https://github.com/advisories/GHSA-c5q2-7r4c-mv6g The upstream maintainers must implement the fix.