### PR TITLE
mattermost-10.1 / bulk advisory update

### DIFF
--- a/mattermost-10.1.advisories.yaml
+++ b/mattermost-10.1.advisories.yaml
@@ -21,6 +21,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:37Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-2rp7-p35g-2v7w
     aliases:
@@ -39,6 +48,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:01Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-3f4m-v5p6-9vxq
     aliases:
@@ -57,6 +75,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:41Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-3w37-xxvh-m7rq
     aliases:
@@ -75,6 +102,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:54Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-44j7-qfgg-xrpp
     aliases:
@@ -93,6 +129,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-4fw3-5gwr-6535
     aliases:
@@ -111,6 +156,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:49Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-566q-qxp6-c82v
     aliases:
@@ -129,6 +183,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:52Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-836r-vfwr-qgmc
     aliases:
@@ -147,6 +210,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-8f6x-774h-8jpj
     aliases:
@@ -183,6 +255,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:19Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-97v9-v35c-87mm
     aliases:
@@ -201,6 +282,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:25Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-9c36-qqhc-jwm3
     aliases:
@@ -219,6 +309,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:50Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-9mp5-f5xg-m6ww
     aliases:
@@ -237,6 +336,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:18Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-9v9q-jcgq-q5cq
     aliases:
@@ -273,6 +381,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:58Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-cjmw-f96p-cg27
     aliases:
@@ -291,6 +408,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:04Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-f39j-3q3r-cr3m
     aliases:
@@ -309,6 +435,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:07Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-ggp9-vp84-whpc
     aliases:
@@ -327,6 +462,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:44Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-gjw8-2vp5-7xfj
     aliases:
@@ -345,6 +489,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:43Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-gmcx-xc2h-c9vc
     aliases:
@@ -363,6 +516,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:32Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-j5fv-p73f-32xh
     aliases:
@@ -381,6 +543,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:13Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-j5xr-3x6x-c737
     aliases:
@@ -399,6 +570,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:31Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-jcm4-hv7p-w366
     aliases:
@@ -417,6 +597,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:28Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-jmv6-vqxm-fxh2
     aliases:
@@ -435,6 +624,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:25Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-jr4g-9mrg-54pm
     aliases:
@@ -453,6 +651,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:16Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-m2wx-243h-gwgp
     aliases:
@@ -471,6 +678,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:35Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-pw2g-v3cc-qwq2
     aliases:
@@ -489,6 +705,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:40Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-pxc4-w65m-33pc
     aliases:
@@ -507,6 +732,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:38Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-q6g4-2gvj-3jr8
     aliases:
@@ -525,6 +759,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:28Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-r3x9-cq8h-p7qc
     aliases:
@@ -543,6 +786,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:10Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-rw2j-f6pp-j26m
     aliases:
@@ -561,6 +813,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:47Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-whrj-vjqm-xvwr
     aliases:
@@ -579,6 +840,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:33:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-x5p5-rg7j-rpxj
     aliases:
@@ -615,6 +885,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:34Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-xc22-4c69-4m2v
     aliases:
@@ -651,3 +930,12 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-14T12:32:46Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.


### PR DESCRIPTION
This vulnerability relates to v8.1.x of mattermost, which is several releases old. The componentVersion is also being flagged incorrectly here by some scanners. A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue. See: https://github.com/anchore/syft/issues/2980.
GHSA-fx48-xv6q-6gp3
GHSA-hwjf-4667-gqwx
GHSA-4ghx-8jw8-p76q
GHSA-6mx3-9qfh-77gj
GHSA-32h7-7j94-8fc2
GHSA-3487-3j7c-7gwj
GHSA-3g35-v53r-gpxc
GHSA-jjr7-372r-cx7x
GHSA-6mvp-gh77-7vwh
GHSA-c37r-v8jx-7cv2
GHSA-w88v-pjr8-cmv2
GHSA-g376-m3h3-mj4r
GHSA-59hf-mpf8-pqjh
GHSA-85jj-c9jr-9jhx
GHSA-7v3v-984v-h74r
GHSA-762g-9p7f-mrww
GHSA-jj46-9cgh-qmfx
GHSA-7664-hcp7-f497
GHSA-jcgv-3pfq-j4hr
GHSA-vm9m-57jr-4pxh
GHSA-63cv-4pc2-4fcf
GHSA-p5pr-vm3j-jxxf
GHSA-762v-rq7q-ff97
GHSA-xp9j-8p68-9q93
GHSA-h3gq-j7p9-x3p4
GHSA-hm57-h27x-599c
GHSA-j4c3-3h73-74m9
GHSA-r833-w756-h5p2
GHSA-q7rx-w656-fwmv
GHSA-9w97-9rqx-8v4j
GHSA-xgxj-j98c-59rv
GHSA-pfw6-5rx3-xh3c