### PR TITLE
gitlab-cng-17.5/GHSA-hxx2-7vcw-mqr3

### DIFF
--- a/gitlab-cng-17.5.advisories.yaml
+++ b/gitlab-cng-17.5.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.2.0/specifications/sinatra-2.2.4.gemspec
             scanner: grype
+      - timestamp: 2024-11-14T14:45:24Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability relates to the GitLab dependency: sinatra, which appears to not yet have a fix version  GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues.  deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.'
 
   - id: CGA-h2q3-6vxp-8cp5
     aliases:


### PR DESCRIPTION
This sinatra CVE does not have a fix version and the below is guidance for the non go module dependency advisories for gitlab