### PR TITLE
build timeout in superset causing elastic build to hang

### DIFF
--- a/superset.advisories.yaml
+++ b/superset.advisories.yaml
@@ -90,6 +90,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/superset/venv/lib/python3.11/site-packages/werkzeug-3.0.3.dist-info/METADATA, /usr/share/superset/venv/lib/python3.11/site-packages/werkzeug-3.0.3.dist-info/RECORD
             scanner: grype
+      - timestamp: 2024-11-15T09:38:07Z
+        type: true-positive-determination
+        data:
+          note: 'The most recent version of superset that has been officially released is causing intermittent build failure issues that need to be resolved before it is available here. This is being actively investigated and will be resolved asap. '
 
   - id: CGA-77h5-pgh2-r2fg
     aliases:
@@ -152,6 +156,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/superset/venv/lib/python3.11/site-packages/werkzeug-3.0.3.dist-info/METADATA, /usr/share/superset/venv/lib/python3.11/site-packages/werkzeug-3.0.3.dist-info/RECORD
             scanner: grype
+      - timestamp: 2024-11-15T09:41:17Z
+        type: true-positive-determination
+        data:
+          note: The most recent version of superset that has been officially released is causing intermittent build failure issues that need to be resolved before it is available here. This is being actively investigated and will be resolved asap.
 
   - id: CGA-fvpq-c5rc-92h6
     aliases:


### PR DESCRIPTION
The issue with superset is that at times it hangs in CI for no repeatable reason. This intermittent build failure issues need to be resolved. This is being actively investigated and will be resolved asap