### PR TITLE
fix: add fix-not-planned events for EOL packages

### DIFF
--- a/ruby-3.0.advisories.yaml
+++ b/ruby-3.0.advisories.yaml
@@ -55,6 +55,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.0.0/specifications/rexml-3.2.5.gemspec
             scanner: grype
+      - timestamp: 2024-11-15T17:31:02Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-04-23'.
 
   - id: CGA-6963-c2xq-q3hq
     aliases:
@@ -105,6 +109,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.0.0/specifications/rexml-3.2.5.gemspec
             scanner: grype
+      - timestamp: 2024-11-15T17:31:02Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-04-23'.
 
   - id: CGA-c37v-v25g-6fpw
     aliases:
@@ -185,6 +193,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.0.0/specifications/rexml-3.2.5.gemspec
             scanner: grype
+      - timestamp: 2024-11-15T17:31:02Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-04-23'.
 
   - id: CGA-qfgh-66wg-vm4q
     aliases:
@@ -213,6 +225,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.0.0/specifications/rexml-3.2.5.gemspec
             scanner: grype
+      - timestamp: 2024-11-15T17:31:02Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-04-23'.
 
   - id: CGA-rm35-qqqg-4ggh
     aliases:
@@ -231,6 +247,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.0.0/specifications/rexml-3.2.5.gemspec
             scanner: grype
+      - timestamp: 2024-11-15T17:31:02Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-04-23'.
 
   - id: CGA-rwv5-454x-4xjp
     aliases:
@@ -260,3 +280,7 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.0.0/specifications/rexml-3.2.5.gemspec
             scanner: grype
+      - timestamp: 2024-11-15T17:31:02Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-04-23'.


### PR DESCRIPTION
Adding these events for ruby-3.0
