### PR TITLE
Mattermost-10.0/.1 advisory updates

### DIFF
--- a/mattermost-10.0.advisories.yaml
+++ b/mattermost-10.0.advisories.yaml
@@ -270,6 +270,10 @@ advisories:
           note: |
             This vulnerability relates to one of mattermost's dependencies - 'github.com/disintegration/imaging'.
             Mattermost is running the most recent version - v1.6.2, which still contains this vulnerability.
+      - timestamp: 2024-11-18T04:35:44Z
+        type: pending-upstream-fix
+        data:
+          note: 'The issue regarding disintegration/imaging v1.6.2 where the index of the scan function in scanner.go can go out of bounds has an open PR https://github.com/disintegration/imaging/issues/165 but no implanted fix yet '
 
   - id: CGA-9w3m-rfmp-84vv
     aliases:
@@ -562,6 +566,10 @@ advisories:
           note: |
             This vulnerability relates to one of mattermost's dependencies - 'github.com/mholt/archiver/v3'.
             Mattermost is running the most recent release of this dependency - v3.5, which still contains this vulnerability.
+      - timestamp: 2024-11-18T04:31:18Z
+        type: pending-upstream-fix
+        data:
+          note: The affected component mholt/archiver/v3 does not yet have a fix version, upstream maintainers must implement this.
 
   - id: CGA-mgcg-2vpm-j7g9
     aliases:

--- a/mattermost-10.1.advisories.yaml
+++ b/mattermost-10.1.advisories.yaml
@@ -876,6 +876,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-18T04:27:36Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This was fixed in mattermost/server v7.4.0. In the relevant hackerone page: https://hackerone.com/reports/1685979  Mattermost staff say this is fixed and released on 10/17/22. Referencing the mattermost security updates page: https://mattermost.com/security-updates/ MMSA-2022-00118 was added on 10/14/22 and thanked the user in hackerone page for "contributing to this improvement" and the descriptions of the issue is the same between the two sources.'
 
   - id: CGA-x6w5-pxh7-33g3
     aliases:

--- a/mattermost-10.1.advisories.yaml
+++ b/mattermost-10.1.advisories.yaml
@@ -372,6 +372,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-18T04:35:08Z
+        type: pending-upstream-fix
+        data:
+          note: 'The issue regarding disintegration/imaging v1.6.2 where the index of the scan function in scanner.go can go out of bounds has an open PR https://github.com/disintegration/imaging/issues/165 but no implanted fix yet '
 
   - id: CGA-9x6f-q25p-wvh7
     aliases:
@@ -926,6 +930,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-18T04:32:37Z
+        type: pending-upstream-fix
+        data:
+          note: The affected component mholt/archiver/v3 does not yet have a fix version, upstream maintainers must implement this.
 
   - id: CGA-xhhh-ggvp-5w8r
     aliases:


### PR DESCRIPTION
1. GHSA-q7pp-wcgr-pffx:
The issue regarding disintegration/imaging v1.6.2 where the index of the scan function in scanner.go can go out of bounds has an open PR https://github.com/disintegration/imaging/issues/165 but no implanted fix yet

2. GHSA-rhh4-rh7c-7r5v:
The affected component mholt/archiver/v3 does not yet have a fix version, upstream maintainers must implement this.

3. GHSA-hqqj-g6mv-rw46:
This was fixed in mattermost/server v7.4.0. In the relevant hackerone page: https://hackerone.com/reports/1685979 Mattermost staff say this is fixed and released on 10/17/22. Referencing the mattermost security updates page: https://mattermost.com/security-updates/ MMSA-2022-00118 was added on 10/14/22 and thanked the user in hackerone page for "contributing to this improvement" and the descriptions of the issue is the same between the two sources.





