### PR TITLE
linux-pam/CVE-2024-10041 advisory update

### DIFF
--- a/linux-pam.advisories.yaml
+++ b/linux-pam.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-18T09:26:11Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE in linux-pam needs to be addressed by upstream maintainers as the required changes to remediate this issue are beyond our current scope.


### PR DESCRIPTION
This CVE in linux-pam needs to be addressed by upstream maintainers as the required changes to remediate this issue are beyond our current scope.