### PR TITLE
firefox/CVE-2011-3389/CVE-2019-7317 advisory updates

### DIFF
--- a/firefox.advisories.yaml
+++ b/firefox.advisories.yaml
@@ -589,6 +589,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-18T09:40:11Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This CVE was resolved as a part of Firefox 67 in May 21, 2019 as can be seen here: https://www.mozilla.org/en-US/security/advisories/mfsa2019-13/'
 
   - id: CGA-6qf4-569p-77v2
     aliases:
@@ -1299,6 +1304,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-18T09:42:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: 'Firefox claimed on September 27, 2011 that Firefox itself is not vulnerable to this attack. While Firefox does use TLS 1.0 (the version of TLS with this weakness), the technical details of the attack require the ability to completely control the content of connections originating in the browser which Firefox does not allow. More details can be found here: https://blog.mozilla.org/security/2011/09/27/attack-against-tls-protected-communications/'
 
   - id: CGA-m358-hfx5-32f4
     aliases:


### PR DESCRIPTION
1. GHSA-m96g-x499-p5f9
This CVE was resolved as a part of Firefox 67 in May 21, 2019 as can be seen here: https://www.mozilla.org/en-US/security/advisories/mfsa2019-13/
2. GHSA-rhch-pcq2-7gp3
Firefox claimed on September 27, 2011 that Firefox itself is not vulnerable to this attack. While Firefox does use TLS 1.0 (the version of TLS with this weakness), the technical details of the attack require the ability to completely control the content of connections originating in the browser which Firefox does not allow. More details can be found here: https://blog.mozilla.org/security/2011/09/27/attack-against-tls-protected-communications/