### PR TITLE
Added EOL advisory for grafana-11.0/GHSA-29wx-vh33-7x7r

### DIFF
--- a/grafana-11.0.advisories.yaml
+++ b/grafana-11.0.advisories.yaml
@@ -4,6 +4,15 @@ package:
   name: grafana-11.0
 
 advisories:
+  - id: CGA-2cw3-r5h4-3v75
+    aliases:
+      - GHSA-29wx-vh33-7x7r
+    events:
+      - timestamp: 2024-11-18T19:54:07Z
+        type: fix-not-planned
+        data:
+          note: This package has reached its end of life and is no longer supported by Chainguard.
+
   - id: CGA-8mj5-qc52-76qf
     aliases:
       - CVE-2024-35255


### PR DESCRIPTION
Following the same path as https://github.com/chainguard-dev/enterprise-advisories/pull/6724