### PR TITLE
add advisory for debezium-connector-spanner

### DIFF
--- a/debezium-connector-spanner-3.0.advisories.yaml
+++ b/debezium-connector-spanner-3.0.advisories.yaml
@@ -39,3 +39,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/debezium/debezium-connector-spanner/guava-31.1-jre.jar
             scanner: grype
+      - timestamp: 2024-11-19T10:51:35Z
+        type: pending-upstream-fix
+        data:
+          note: Bumping the guava dependency to 32.x resulting build failure on 3.0.2 release.


### PR DESCRIPTION
Applying the following patch with `pombump` resulting build failure, so awaiting upstream fix.

```
# Mitigates CVE-2020-8908 and CVE-2023-2976
- groupId: com.google.guava
  artifactId: guava
  version: 32.1.2-jre
```