### PR TITLE
neo4j: Raising `pending-upstream-fix` advisory for: GHSA-qh8g-58pp-2wxh

### DIFF
--- a/neo4j.advisories.yaml
+++ b/neo4j.advisories.yaml
@@ -133,7 +133,7 @@ advisories:
           note: |
             This vulnerability relates to the 'jetty-http' dependency, which is fixed in v12.0.12 and later.
             Unfortunately, we are not able to remediate this CVE, as bumping this dependency version results in build failures.
-            Specifically, there are version conflicts between the various jetty dependencies. Attempting to bump the related netty dependencies to the same version, results in different build issues.
+            Specifically, there are version conflicts between the various jetty dependencies. Attempting to bump the related dependencies to the same version, results in different build issues.
             Another component: 'jetty-servlet', has also been relocated to a new location in maven central: https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlet. This requires additional code changes.
             All attempts were made to chain up the required changes, but to no avail. Pending fix from upstream.
 


### PR DESCRIPTION
_Related CVE remediation PR: https://github.com/wolfi-dev/os/pull/32618_

Unfortunately we are unable to remediate this CVE, and we'll require a fix to be applied upstream. Raising as `pending-upstream-fix`. See advisory description in this PR for more information. 