### PR TITLE
GHSA-xq3w-v528-46rv is a false positive for several packages

### DIFF
--- a/akhq.advisories.yaml
+++ b/akhq.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/akhq/akhq.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:00:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-6pm2-j37h-3fvw
     aliases:

--- a/apache-nifi.advisories.yaml
+++ b/apache-nifi.advisories.yaml
@@ -1393,6 +1393,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.0.0-r2
+      - timestamp: 2024-11-20T20:00:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-m9x3-8pwv-rjh3
     aliases:

--- a/cassandra-5.0.advisories.yaml
+++ b/cassandra-5.0.advisories.yaml
@@ -209,6 +209,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/netty-common-4.1.96.Final.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:00:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-jx7r-g27c-g947
     aliases:

--- a/cassandra-reaper.advisories.yaml
+++ b/cassandra-reaper.advisories.yaml
@@ -173,6 +173,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.7.0-r0
+      - timestamp: 2024-11-20T20:00:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-jpjc-49cf-82xf
     aliases:

--- a/cloudwatch-exporter.advisories.yaml
+++ b/cloudwatch-exporter.advisories.yaml
@@ -25,6 +25,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.16.0-r2
+      - timestamp: 2024-11-20T20:01:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-7p98-j4rx-8p2r
     aliases:

--- a/confluent-kafka.advisories.yaml
+++ b/confluent-kafka.advisories.yaml
@@ -137,3 +137,8 @@ advisories:
         type: fixed
         data:
           fixed-version: 8.0.0.153-r0
+      - timestamp: 2024-11-20T20:01:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.

--- a/docker-selenium.advisories.yaml
+++ b/docker-selenium.advisories.yaml
@@ -21,3 +21,8 @@ advisories:
             componentType: java-archive
             componentLocation: /external_jars/https/repo1.maven.org/maven2/io/netty/netty-common/4.1.110.Final/netty-common-4.1.110.Final.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:01:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.

--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -305,6 +305,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 31.0.0-r2
+      - timestamp: 2024-11-20T20:01:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-cpv4-g6rc-q46h
     aliases:

--- a/kafka-3.8.advisories.yaml
+++ b/kafka-3.8.advisories.yaml
@@ -47,6 +47,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/kafka/libs/netty-common-4.1.110.Final.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:01:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-r5gc-w736-v6hf
     aliases:

--- a/keycloak-operator.advisories.yaml
+++ b/keycloak-operator.advisories.yaml
@@ -76,6 +76,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 26.0.5-r1
+      - timestamp: 2024-11-20T20:01:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-gfj5-2q78-6f2f
     aliases:

--- a/kserve-modelmesh.advisories.yaml
+++ b/kserve-modelmesh.advisories.yaml
@@ -69,3 +69,8 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.12.0-r5
+      - timestamp: 2024-11-20T20:02:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.

--- a/logstash-8.advisories.yaml
+++ b/logstash-8.advisories.yaml
@@ -149,3 +149,8 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/logstash/vendor/bundle/jruby/3.1.0/gems/logstash-input-beats-6.8.4-java/vendor/jar-dependencies/io/netty/netty-common/4.1.109.Final/netty-common-4.1.109.Final.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:02:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.

--- a/management-api-for-apache-cassandra-5.0.advisories.yaml
+++ b/management-api-for-apache-cassandra-5.0.advisories.yaml
@@ -99,6 +99,11 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/management-api/datastax-mgmtapi-agent-5.0.x-0.1.0-SNAPSHOT.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:02:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-85g9-6hwh-32gx
     aliases:

--- a/neo4j.advisories.yaml
+++ b/neo4j.advisories.yaml
@@ -87,6 +87,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/neo4j/lib/netty-common-4.1.113.Final.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:02:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-gxrv-2q36-c76g
     aliases:

--- a/opensearch-2.advisories.yaml
+++ b/opensearch-2.advisories.yaml
@@ -328,3 +328,8 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/opensearch/plugins/opensearch-repository-azure/netty-common-4.1.112.Final.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:02:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.

--- a/selenium.advisories.yaml
+++ b/selenium.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/selenium/bin/selenium_server_deploy.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:02:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-c95w-hpgw-m6fm
     aliases:

--- a/sonarqube-10.advisories.yaml
+++ b/sonarqube-10.advisories.yaml
@@ -101,6 +101,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/modules/transport-netty4/netty-common-4.1.109.Final.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:03:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-7fm6-4c5m-gw2x
     aliases:

--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -589,6 +589,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/netty-common-4.1.108.Final.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:03:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-pv3f-mmpx-7xwc
     aliases:

--- a/strimzi-kafka-operator.advisories.yaml
+++ b/strimzi-kafka-operator.advisories.yaml
@@ -69,6 +69,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.44.0-r1
+      - timestamp: 2024-11-20T20:03:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-vfc8-v7wp-gpmx
     aliases:

--- a/tez.advisories.yaml
+++ b/tez.advisories.yaml
@@ -221,6 +221,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tez/lib/netty-common-4.1.100.Final.jar
             scanner: grype
+      - timestamp: 2024-11-20T20:03:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-8phm-9pxh-w42w
     aliases:

--- a/thingsboard.advisories.yaml
+++ b/thingsboard.advisories.yaml
@@ -193,6 +193,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.8.1-r3
+      - timestamp: 2024-11-20T20:03:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-crm9-p3mr-qc4q
     aliases:

--- a/trino.advisories.yaml
+++ b/trino.advisories.yaml
@@ -400,6 +400,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 464-r1
+      - timestamp: 2024-11-20T20:03:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-c35c-6qcp-r887
     aliases:

--- a/wavefront-proxy.advisories.yaml
+++ b/wavefront-proxy.advisories.yaml
@@ -241,6 +241,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 13.7-r3
+      - timestamp: 2024-11-20T20:04:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-w2q6-vjq6-xv28
     aliases:

--- a/zookeeper-3.9.advisories.yaml
+++ b/zookeeper-3.9.advisories.yaml
@@ -25,6 +25,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.9.3.2-r1
+      - timestamp: 2024-11-20T20:04:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: Vulnerability affects only Windows systems.
 
   - id: CGA-7p85-rf95-4g2p
     aliases:


### PR DESCRIPTION
It affects Windows systems specifically.

This diff was created using:

```bash
for pkg in $(wolfictl adv ls -V CVE-2024-47535 | awk '{print $1}'); do
    wolfictl adv update -p "$pkg" -V GHSA-xq3w-v528-46rv -t false-positive-determination --fp-type 'vulnerable-code-cannot-be-controlled-by-adversary' --note 'Vulnerability affects only Windows systems.';
done
```

Note that I updated all matching advisories, even ones that had been marked "fixed" previously, since the false positive status is more accurate. Let me know if this is an issue for any reason!