### PR TITLE
false positive: with the component name github.com/mattermost/matterm…

### DIFF
--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -21,6 +21,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-2fwp-2237-rvm3
     aliases:
@@ -39,6 +48,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-2pq2-pcj8-vp7m
     aliases:
@@ -57,6 +75,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-2v29-7fpv-pcp2
     aliases:
@@ -75,6 +102,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-35gg-vmwh-w2gj
     aliases:
@@ -93,6 +129,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-4f74-gg83-gmj4
     aliases:
@@ -111,6 +156,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-5phr-cv2r-mmp7
     aliases:
@@ -129,6 +183,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-5rrq-fw72-w4h8
     aliases:
@@ -147,6 +210,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-5wjh-86c5-pp9g
     aliases:
@@ -165,6 +237,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-6v23-j8rc-pc43
     aliases:
@@ -183,6 +264,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-7r67-3728-67cm
     aliases:
@@ -201,6 +291,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-8fwm-7pm4-hxqx
     aliases:
@@ -219,6 +318,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-98rh-mqpp-6vcc
     aliases:
@@ -237,6 +345,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-99xc-37rc-g56w
     aliases:
@@ -255,6 +372,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-cg65-w57m-9pr3
     aliases:
@@ -273,6 +399,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-chfq-mm84-m5rw
     aliases:
@@ -291,6 +426,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-fg44-8qrw-fvxj
     aliases:
@@ -309,6 +453,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-gcwq-33q3-grc6
     aliases:
@@ -327,6 +480,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-gmj3-fwh6-qxc3
     aliases:
@@ -345,6 +507,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-gvx3-qc7w-23vg
     aliases:
@@ -381,6 +552,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-hrrx-v7pc-76g7
     aliases:
@@ -417,6 +597,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-jx85-4xrp-7393
     aliases:
@@ -435,6 +624,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-m37j-23ff-ggcc
     aliases:
@@ -453,6 +651,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-mg3v-546r-6gjv
     aliases:
@@ -471,6 +678,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-mhvg-754h-x723
     aliases:
@@ -489,6 +705,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-phmv-4jx9-p7j9
     aliases:
@@ -507,6 +732,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-pq52-32m3-7pxc
     aliases:
@@ -525,6 +759,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-pxmc-fp2q-4q6g
     aliases:
@@ -543,6 +786,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-q862-xfvv-q33j
     aliases:
@@ -561,6 +813,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-qfc9-jvrm-p2w4
     aliases:
@@ -579,6 +840,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-rjh8-378v-6q7c
     aliases:
@@ -615,6 +885,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-x4q6-7gmv-h2h3
     aliases:
@@ -633,6 +912,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-11-21T09:50:22Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability relates to v8.1.x of mattermost, which is several releases old.
+            The componentVersion is also being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue.
+            See: https://github.com/anchore/syft/issues/2980.
 
   - id: CGA-xq62-93gr-6w94
     aliases:


### PR DESCRIPTION
…ost/server/v8 is all false positive, The componentVersion is being flagged incorrectly here by some scanners.

All of these CVE are already been flagged as false positive in [mattermost-10.1](https://github.com/wolfi-dev/advisories/blob/main/mattermost-10.1.advisories.yaml) version