### PR TITLE
lua-5.3/CVE-2020-15945 advisory update

### DIFF
--- a/lua5.3.advisories.yaml
+++ b/lua5.3.advisories.yaml
@@ -22,6 +22,6 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
       - timestamp: 2024-11-21T16:15:31Z
-        type: pending-upstream-fix
+        type: fix-not-planned
         data:
           note: CVE affects versions lower than 5.4, Lua will not ship any fixes for Lua-5.3.

--- a/lua5.3.advisories.yaml
+++ b/lua5.3.advisories.yaml
@@ -24,4 +24,4 @@ advisories:
       - timestamp: 2024-11-21T16:15:31Z
         type: pending-upstream-fix
         data:
-          note: CVE affects versions lower than 5.4, consider upgrading to a higher version. There is no evidence of plan to not fix however there is no backport at this time.
+          note: CVE affects versions lower than 5.4, Lua will not ship any fixes for Lua-5.3.

--- a/lua5.3.advisories.yaml
+++ b/lua5.3.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-21T16:15:31Z
+        type: pending-upstream-fix
+        data:
+          note: CVE affects versions lower than 5.4, consider upgrading to a higher version. There is no evidence of plan to not fix however there is no backport at this time.


### PR DESCRIPTION
## 1. **CVE-2020-1594**
- **pending-upstream-fix:** 
- **Details:** CVE affects versions lower than 5.4, consider upgrading to a higher version. There is no evidence of plan to not fix however there is no backport at this time.