### PR TITLE
tez advisory updates

### DIFF
--- a/tez.advisories.yaml
+++ b/tez.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tez/lib/jetty-server-9.4.53.v20231009.jar
             scanner: grype
+      - timestamp: 2024-11-22T14:19:57Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
 
   - id: CGA-2hvc-45v7-8f34
     aliases:
@@ -143,6 +147,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tez/lib/avro-1.9.2.jar
             scanner: grype
+      - timestamp: 2024-11-22T14:19:03Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
 
   - id: CGA-7pfp-wfcr-cm2m
     aliases:
@@ -310,6 +318,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tez/lib/jetty-http-9.4.53.v20231009.jar
             scanner: grype
+      - timestamp: 2024-11-22T14:19:26Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
 
   - id: CGA-cxfp-ggmh-c85x
     aliases:


### PR DESCRIPTION
## 1. **GHSA-r7pg-v2c8-mfg3/GHSA-qh8g-58pp-2wxh/GHSA-g8m5-722r-8whq**
- **pending-upstream-fix:** 
- **Details:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.