### PR TITLE
 nvidia-container-toolkit.advisories CVE-2024-0134 advisory update

### DIFF
--- a/nvidia-container-toolkit.advisories.yaml
+++ b/nvidia-container-toolkit.advisories.yaml
@@ -120,6 +120,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-26T12:40:16Z
+        type: pending-upstream-fix
+        data:
+          note: 'This package currently is facing upstream build issues which can be seen here: https://github.com/NVIDIA/nvidia-container-toolkit/issues/49#issuecomment-2471252708 We will not be able to remediate this CVE until this is addressed as the vulnerability does not come from a dependency but rather the parent package itself.'
 
   - id: CGA-qr4q-976m-gxf8
     aliases:


### PR DESCRIPTION
## 1. **CVE-2024-0134**
- **pending-upstream-fix:** 
- **Details:** This package currently is facing upstream build issues which can be seen here: https://github.com/NVIDIA/nvidia-container-toolkit/issues/49#issuecomment-2471252708 We will not be able to remediate this CVE until this is addressed as the vulnerability does not come from a dependency but rather the parent package itself.