### PR TITLE
feat(advisory): solr false-positive-determination

### DIFF
--- a/solr.advisories.yaml
+++ b/solr.advisories.yaml
@@ -120,6 +120,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/solr/server/solr-webapp/webapp/WEB-INF/lib/netty-common-4.1.111.Final.jar
             scanner: grype
+      - timestamp: 2024-11-26T18:31:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-cannot-be-controlled-by-adversary
+          note: This vulnerability is Windows-specific and cannot be exploited on Wolfi OS which is Linux-based. The vulnerable code path requires Windows file system access.
 
   - id: CGA-6rj7-2h6h-rvff
     aliases:


### PR DESCRIPTION
This is a windows specific CVE.

> This vulnerability is Windows-specific and cannot be exploited on Wolfi OS which is Linux-based. The vulnerable code path requires Windows file system access.

Signed-off-by: philroche <phil.roche@chainguard.dev>
