### PR TITLE
python-3.10/CVE-2024-11168 advisory update

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -35,6 +35,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-11-27T05:49:12Z
+        type: pending-upstream-fix
+        data:
+          note: 'A fix for this CVE exists upstream in the 3.12 and 3.11 branches. There is a PR open and ready for review to backport this fix to 3.10 which can be seen here: https://github.com/python/cpython/pull/126975'
 
   - id: CGA-6xpf-gwq5-cp42
     aliases:


### PR DESCRIPTION
## 1. **CVE-2024-11168**
- **pending-upstream-fix:** 
- **Details:** A fix for this CVE exists upstream in the [3.12](https://github.com/python/cpython/commit/29f348e232e82938ba2165843c448c2b291504c5) and [3.11 branches](https://github.com/python/cpython/commit/b2171a2fd41416cf68afd67460578631d755a550). There is a PR open and ready for review to backport this fix to 3.10 which can be seen here: https://github.com/python/cpython/pull/126975 