### PR TITLE
mattermost-10.2 GHSA-q7pp-wcgr-pffx advisory update

### DIFF
--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -867,6 +867,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-12-04T14:34:45Z
+        type: pending-upstream-fix
+        data:
+          note: The issue regarding disintegration/imaging v1.6.2 where the index of the scan function in scanner.go can go out of bounds has an open PR https://github.com/disintegration/imaging/issues/165 but no implanted fix yet
 
   - id: CGA-rm6h-vjp2-82j3
     aliases:


### PR DESCRIPTION
## 1. **GHSA-q7pp-wcgr-pffx**
- **pending-upstream-fix:** 
- **Details:** The issue regarding disintegration/imaging v1.6.2 where the index of the scan function in scanner.go can go out of bounds has an open PR https://github.com/disintegration/imaging/issues/165 but no implanted fix yet