### PR TITLE
mattermost-10.2 GHSA-v42f-hq78-8c5m advisory update

### DIFF
--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -579,6 +579,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-12-04T14:41:29Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This vulnerability relates to v7.x of mattermost, which is several releases old. The componentVersion is also being flagged incorrectly here by some scanners. A bug has been filed upstream against Syft, and the maintainers have confirmed it''s a scanner issue. See: https://github.com/anchore/syft/issues/2980.'
 
   - id: CGA-hxh6-329f-wm9m
     aliases:

--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -580,9 +580,9 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
       - timestamp: 2024-12-04T14:41:29Z
-        type: vulnerable-code-version-not-used
-        data:
-          type: component-vulnerability-mismatch
+        type: false-positive-determination
+        data: 
+          type: vulnerable-code-version-not-used
           note: 'This vulnerability relates to versions of mattermost prior to v7.4.0, which is several releases old. Several sources tie the credit of the individual contributing to the remediation, the custom mattermost CVE ID (MMSA-2022-00124) and the CVE ID found in the National Vulnerability Database which leads to the conculsion this is caused by an overly broad CPE configuration on the NVD record causing all versions of mattermost to become flagged. '
 
   - id: CGA-hxh6-329f-wm9m

--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -580,10 +580,10 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
       - timestamp: 2024-12-04T14:41:29Z
-        type: false-positive-determination
+        type: vulnerable-code-version-not-used
         data:
           type: component-vulnerability-mismatch
-          note: 'This vulnerability relates to v7.x of mattermost, which is several releases old. The componentVersion is also being flagged incorrectly here by some scanners. A bug has been filed upstream against Syft, and the maintainers have confirmed it''s a scanner issue. See: https://github.com/anchore/syft/issues/2980.'
+          note: 'This vulnerability relates to versions of mattermost prior to v7.4.0, which is several releases old. Several sources tie the credit of the individual contributing to the remediation, the custom mattermost CVE ID (MMSA-2022-00124) and the CVE ID found in the National Vulnerability Database which leads to the conculsion this is caused by an overly broad CPE configuration on the NVD record causing all versions of mattermost to become flagged. '
 
   - id: CGA-hxh6-329f-wm9m
     aliases:

--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -581,7 +581,7 @@ advisories:
             scanner: grype
       - timestamp: 2024-12-04T14:41:29Z
         type: false-positive-determination
-        data: 
+        data:
           type: vulnerable-code-version-not-used
           note: 'This vulnerability relates to versions of mattermost prior to v7.4.0, which is several releases old. Several sources tie the credit of the individual contributing to the remediation, the custom mattermost CVE ID (MMSA-2022-00124) and the CVE ID found in the National Vulnerability Database which leads to the conculsion this is caused by an overly broad CPE configuration on the NVD record causing all versions of mattermost to become flagged. '
 

--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -579,11 +579,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
-      - timestamp: 2024-12-04T14:41:29Z
+      - timestamp: 2024-12-09T14:41:29Z
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used
-          note: 'This vulnerability relates to versions of mattermost prior to v7.4.0, which is several releases old. Several sources tie the credit of the individual contributing to the remediation, the custom mattermost CVE ID (MMSA-2022-00124) and the CVE ID found in the National Vulnerability Database which leads to the conculsion this is caused by an overly broad CPE configuration on the NVD record causing all versions of mattermost to become flagged. '
+          note: 'This vulnerability relates to versions of mattermost prior to v7.4.0, which is several releases old. Several sources tie the credit of the individual contributing to the remediation, the custom mattermost CVE ID (MMSA-2022-00124) and the CVE ID found in the National Vulnerability Database which leads to the conclusion this is caused by an overly broad CPE configuration on the NVD record causing all versions of mattermost to become flagged. '
 
   - id: CGA-hxh6-329f-wm9m
     aliases:

--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -583,7 +583,7 @@ advisories:
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used
-          note: 'This vulnerability relates to versions of mattermost prior to v7.4.0, which is several releases old. Several sources tie the credit of the individual contributing to the remediation, the custom mattermost CVE ID (MMSA-2022-00124) and the CVE ID found in the National Vulnerability Database which leads to the conclusion this is caused by an overly broad CPE configuration on the NVD record causing all versions of mattermost to become flagged. '
+          note: 'This vulnerability relates to versions of mattermost prior to v7.4.0, which is several releases old. This is caused by an overly broad CPE configuration on the NVD record, it has no version constraints, causing all versions of mattermost to become flagged. '
 
   - id: CGA-hxh6-329f-wm9m
     aliases:


### PR DESCRIPTION
## 1. **GHSA-v42f-hq78-8c5m**
- **false-positive-determination, component-vulnerability-mismatch:** 
- **Details:** This vulnerability [relates to versions of mattermost prior to v7.4.0](https://github.com/advisories/GHSA-v42f-hq78-8c5m), which is several releases old. Several sources tie the credit of the [individual contributing to the remediation](https://www.cve.org/CVERecord?id=CVE-2022-4045), the custom mattermost CVE ID (search for MMSA-2022-00124 [here](https://mattermost.com/security-updates/)) and the CVE ID found in the National Vulnerability Database which leads to the conculsion this is caused by an overly broad CPE configuration on the NVD record causing all versions of mattermost to become flagged. 