### PR TITLE
imagemagick-7: updating autogenerated advisories

### DIFF
--- a/imagemagick-7.advisories.yaml
+++ b/imagemagick-7.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-12-05T21:58:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'Vulnerability was resolved upstream prior to Wolfi packaging: https://github.com/ImageMagick/ImageMagick/commit/9a069e0f2e027ec5138f998023cf9cb62c04889f'
 
   - id: CGA-6x73-qv5x-p6fr
     aliases:
@@ -39,6 +44,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-12-05T21:59:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'Vulnerability was resolved upstream prior to Wolfi packaging: https://github.com/ImageMagick/ImageMagick/commit/aa673b2e4defc7cad5bec16c4fc8324f71e531f1'
 
   - id: CGA-9cr4-38v4-33pf
     aliases:
@@ -57,6 +67,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-12-05T22:01:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'Vulnerability was resolved upstream prior to Wolfi packaging: https://github.com/ImageMagick/ImageMagick/commit/82e2049862a8b8a999e160734ad64fb6cc3b145f'
 
   - id: CGA-crjg-66qc-rqx8
     aliases:
@@ -75,6 +90,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-12-05T22:02:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'Fixed in 6.8.9.9-4 prior to ImageMagick moving to Github: https://bugzilla.redhat.com/show_bug.cgi?id=1343482'
 
   - id: CGA-vj75-557x-5qh7
     aliases:
@@ -93,3 +113,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-12-05T22:05:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'Vulnerability was resolved upstream prior to Wolfi packaging: https://github.com/ImageMagick/ImageMagick/commit/41e955984b034777903cfa61e500a0b922eb9cbd - last of a few commits made to address this CVE'


### PR DESCRIPTION
Advisory updates for new imagemagick-7 package.

Related: https://github.com/chainguard-dev/image-requests/issues/5094