### PR TITLE
pending-upstream-fix advisories for various packages

### DIFF
--- a/pixi.advisories.yaml
+++ b/pixi.advisories.yaml
@@ -105,3 +105,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/pixi
             scanner: grype
+      - timestamp: 2024-12-07T19:57:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            pixi currently depends on multiple versions of hashbrown - v12.x , v14.x and v15.x.
+            We can't bump the earlier versions to the latest v15.x streams, as the project explicitly depends on multiple versions.
+            Waiting for fix from upstream. Ref: https://github.com/prefix-dev/pixi/blob/656ecd6c38c4808a1415623b18c853d4c2a0c4a1/Cargo.lock#L1847-L1867

--- a/qdrant.advisories.yaml
+++ b/qdrant.advisories.yaml
@@ -20,6 +20,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/qdrant
             scanner: grype
+      - timestamp: 2024-12-08T08:52:38Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            qdrant currently depends on multiple versions of pprof - v0.12.x and v0.13.x.
+            Remediating this vulnerability would require removing dependencies on the older versions.
+            Given that multiple versions are intentionally defined, waiting for upstream to upgrade this dependency.
+            Ref: https://github.com/qdrant/qdrant/blob/v1.12.4/Cargo.lock#L4476-L4519
 
   - id: CGA-c6v5-62wh-j5x5
     aliases:
@@ -99,6 +107,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/qdrant
             scanner: grype
+      - timestamp: 2024-12-08T08:52:38Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            qdrant currently depends on multiple versions of rustls - v0.21.x, v0.22.x and v0.23.x.
+            Remediating this vulnerability would require removing dependencies on the older versions.
+            Given multiple versions are intentionally defined, waiting for upstream to upgrade this dependency.
+            Ref: https://github.com/qdrant/qdrant/blob/v1.12.4/Cargo.lock#L4476-L4519
 
   - id: CGA-v422-6gmm-2v22
     aliases:
@@ -116,6 +132,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/qdrant
             scanner: grype
+      - timestamp: 2024-12-08T08:49:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            qdrant currently depends on multiple versions of hashbrown - v12.x , v14.x and v15.x.
+            Remediating this vulnerability would require removing dependencies on the older versions.
+            Given that multiple versions are intentionally defined, waiting for upstream to upgrade this dependency.
+            Waiting for fix from upstream. Ref: https://github.com/qdrant/qdrant/blob/v1.12.4/Cargo.lock#L2479-L2499
 
   - id: CGA-vghx-m9qr-wvfv
     aliases:

--- a/starship.advisories.yaml
+++ b/starship.advisories.yaml
@@ -20,6 +20,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/starship
             scanner: grype
+      - timestamp: 2024-12-07T19:57:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            starship currently depends on multiple versions of hashbrown - v12.x , v14.x and v15.x.
+            We can't bump the earlier versions to the latest v15.x streams, as the project explicitly depends on multiple versions.
+            Waiting for fix from upstream. Ref: https://github.com/starship/starship/blob/v1.21.1/Cargo.lock#L1490-L1510
 
   - id: CGA-685m-5372-7jmp
     aliases:

--- a/wadm.advisories.yaml
+++ b/wadm.advisories.yaml
@@ -20,6 +20,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/wadm
             scanner: grype
+      - timestamp: 2024-12-07T19:57:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            wadm currently depends on two versions of hashbrown - v12.x and v15.x.
+            We can't bump v12.x to remediate this CVE, as the project explicitly depends on it.
+            Waiting for fix from upstream. Ref: https://github.com/wasmCloud/wadm/blob/v0.18.0/Cargo.lock#L1084-L1094.
 
   - id: CGA-fx37-952j-3xmc
     aliases:

--- a/ztunnel-1.24.advisories.yaml
+++ b/ztunnel-1.24.advisories.yaml
@@ -37,6 +37,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/ztunnel
             scanner: grype
+      - timestamp: 2024-12-07T19:57:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            ztunnel currently depends on multiple versions of hashbrown - v12.x , v14.x and v15.x.
+            We can't bump the earlier versions to the latest v15.x streams, as the project explicitly depends on multiple versions.
+            Waiting for fix from upstream. Ref: https://github.com/istio/ztunnel/blob/1.24.1/Cargo.lock#L1095-L1119
 
   - id: CGA-ww5r-3x7r-r6p7
     aliases:


### PR DESCRIPTION
pending-upstream-fix advisories for GHSA-wwq9-3cpr-mm53 across multiple packages. Unfortunately we cannot remediate these as the packages depend on multiple versions of hashbrown, including the older affected versions.

Similarly, pending-upstream-fix advisories for GHSA-wwq9-3cpr-mm53/GHSA-qg5g-gv98-5ffh/GHSA-gw5w-5j7f-jmjj, related to the qdrant package.