### PR TITLE
pending-upstream-fix advisory for GHSA-c2f5-jxjv-2hh8

### DIFF
--- a/zellij.advisories.yaml
+++ b/zellij.advisories.yaml
@@ -199,6 +199,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zellij
             scanner: grype
+      - timestamp: 2024-11-07T23:00:36Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to dependency: wasmtime, and a fixed version is available: v25.0.0.
+            Unfortunately, we are not able to upgrade to the fixed version of wasmtime, as this results in build errors.
+            There are other dependencies which depend on an older wasmtime version. Waiting for upstream to fix.
 
   - id: CGA-wwr7-2chc-98v2
     aliases:

--- a/zellij.advisories.yaml
+++ b/zellij.advisories.yaml
@@ -199,7 +199,7 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zellij
             scanner: grype
-      - timestamp: 2024-11-07T23:00:36Z
+      - timestamp: 2024-12-07T20:54:00Z
         type: pending-upstream-fix
         data:
           note: |


### PR DESCRIPTION
pending-upstream-fix advisory for GHSA-c2f5-jxjv-2hh8, which we are not able to remediate. There are other dependencies which are not compatible with the latest version.