### PR TITLE
Adding pending-upstream-fix advisories for GHSA-9mcr-873m-xcxp and GHSA-qg5g-gv98-5ffh

### DIFF
--- a/zed.advisories.yaml
+++ b/zed.advisories.yaml
@@ -37,6 +37,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/libexec/zed
             scanner: grype
+      - timestamp: 2024-12-09T11:23:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            zed has dependencies which rely on different versions of tungstenite.
+            Remediating this vulnerability would require removing dependencies on the older versions.
+            Given multiple versions are intentionally defined, waiting for upstream to remediate.
+            Ref: https://github.com/zed-industries/zed/blob/v0.164.2/Cargo.lock#L13377-L13450
 
   - id: CGA-53v4-w8mg-37qg
     aliases:
@@ -140,6 +148,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/libexec/zed
             scanner: grype
+      - timestamp: 2024-12-09T11:23:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            zed has dependencies which rely on different versions of rustls.
+            Remediating this vulnerability would require removing dependencies on the older versions.
+            Given multiple versions are intentionally defined, waiting for upstream to remediate.
+            Ref: https://github.com/zed-industries/zed/blob/v0.164.2/Cargo.lock#L10507-L10543
 
   - id: CGA-g8r9-vv23-f4jf
     aliases:


### PR DESCRIPTION
Adding pending-upstream-fix advisories for GHSA-9mcr-873m-xcxp and GHSA-qg5g-gv98-5ffh.

zed has multiple versions of the affected dependency defined, mapped to different components depending on that version stream. See note and link in advisory description.

**CLOSE LINKED PR's when this is merged (see below)**