### PR TITLE
kafka-3.8/3.9 GHSA-qh8g-58pp-2wxh advisory update

### DIFF
--- a/kafka-3.8.advisories.yaml
+++ b/kafka-3.8.advisories.yaml
@@ -74,6 +74,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: Updating jetty to a non-vulnerable version would require 3 major version bumps, which would be a very significant upgrade with multiple breaking changes, and should only be undertaken by the upstream maintainers.
+      - timestamp: 2024-12-10T05:11:12Z
+        type: pending-upstream-fix
+        data:
+          note: Remediating this CVE requires dropping support for JDK11 which is why the changes are not being back ported from the main branch into version branches 3.8 and 3.9. This will be fixed in the kafka-4.0.0 release which is targeted in to land in late January 2025.
 
   - id: CGA-v299-46f5-9x4h
     aliases:

--- a/kafka-3.9.advisories.yaml
+++ b/kafka-3.9.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/kafka/libs/jetty-http-9.4.56.v20240826.jar
             scanner: grype
+      - timestamp: 2024-12-10T05:12:17Z
+        type: pending-upstream-fix
+        data:
+          note: Remediating this CVE requires dropping support for JDK11 which is why the changes are not being back ported from the main branch into version branches 3.8 and 3.9. This will be fixed in the kafka-4.0.0 release which is targeted in to land in late January 2025.
 
   - id: CGA-xpg8-pwc5-69x9
     aliases:


### PR DESCRIPTION
After investigation the remediation for this CVE is incredibly involved and [requires dropping support for JDK11](https://issues.apache.org/jira/browse/KAFKA-16096) This is why the changes are slated for kafka-4.0.0 release which is targeted in late January. Last required implementation PR https://github.com/apache/kafka/pull/16754 is actually being built in their CI right now