### PR TITLE
mattermost-10.2 advisory udpates

### DIFF
--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -538,7 +538,7 @@ advisories:
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used
-          note: 'This vulnerability was remediated in mattermost v7.x, Specifically, in versions 7.1.4, 7.2.1, 7.3.1, and 7.4.0. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4019'
+          note: 'This vulnerability was remediated in mattermost v7.x, Specifically, in versions 7.1.4, 7.2.1, 7.3.1, and 7.4.0. For more information, please refer to https://mattermost.com/security-updates/ and search for the ID MMSA-2022-00118 in the server tab. ' 
 
   - id: CGA-hq9q-8hrj-882q
     aliases:

--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -538,7 +538,7 @@ advisories:
         type: false-positive-determination
         data:
           type: vulnerable-code-version-not-used
-          note: 'This vulnerability was remediated in mattermost v7.x, Specifically, in versions 7.1.4, 7.2.1, 7.3.1, and 7.4.0. For more information, please refer to https://mattermost.com/security-updates/ and search for the ID MMSA-2022-00118 in the server tab. ' 
+          note: 'This vulnerability was remediated in mattermost v7.x, Specifically, in versions 7.1.4, 7.2.1, 7.3.1, and 7.4.0. For more information, please refer to https://mattermost.com/security-updates/ and search for the ID MMSA-2022-00118 in the server tab. '
 
   - id: CGA-hq9q-8hrj-882q
     aliases:

--- a/mattermost-10.2.advisories.yaml
+++ b/mattermost-10.2.advisories.yaml
@@ -534,6 +534,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2024-12-10T05:24:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: 'This vulnerability was remediated in mattermost v7.x, Specifically, in versions 7.1.4, 7.2.1, 7.3.1, and 7.4.0. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4019'
 
   - id: CGA-hq9q-8hrj-882q
     aliases:
@@ -943,3 +948,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2024-12-10T05:28:27Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability relates to one of mattermost's dependencies, ‘github.com/mholt/archiver/v3'. Mattermost is running the most recent release of this dependency - v3.5, which still contains this vulnerability.


### PR DESCRIPTION
## 1. **GHSA-hqqj-g6mv-rw46**
- **false-positive-determination, vulnerable-code-version-not-used:** 
- **Details:** This vulnerability was remediated in mattermost v7.x, Specifically, in versions 7.1.4, 7.2.1, 7.3.1, and 7.4.0. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4019

## 2. **GHSA-rhh4-rh7c-7r5v**
- **pending-upstream-fix** 
- **Details:** This vulnerability relates to one of mattermost's dependencies, ‘github.com/mholt/archiver/v3'. Mattermost is running the most recent release of this dependency - v3.5, which still contains this vulnerability.