### PR TITLE
Add 'pending-upstream-fix' advisory for Apache druid: GHSA-rcjc-c4pj

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -289,6 +289,14 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/lib/derby-10.14.2.0.jar
             scanner: grype
+      - timestamp: 2024-12-11T22:09:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability is related to 'derby', one of the dependencies of Apache druid.
+            A fix is available, but requires upgrading 'derby' to 'v10.17.1.0'. Attempting to upgrade druid to this version results in build failures.
+            derby v10.17.1.0 requires Java 21. Apache druid does not support currently support Java 21.
+            Ref: https://github.com/apache/druid/blob/druid-31.0.0/docs/operations/java.md
 
   - id: CGA-c5fg-gm82-jrmq
     aliases:

--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -296,7 +296,7 @@ advisories:
             This vulnerability is related to 'derby', one of the dependencies of Apache druid.
             A fix is available, but requires upgrading 'derby' to 'v10.17.1.0'. Attempting to upgrade druid to this version results in build failures.
             derby v10.17.1.0 requires Java 21. Apache druid does not support currently support Java 21.
-            Ref: https://github.com/apache/druid/blob/druid-31.0.0/docs/operations/java.md
+            Ref: https://github.com/apache/druid/blob/druid-31.0.0/docs/operations/java.md and https://db.apache.org/derby/releases/release-10_17_1_0.cgi.
 
   - id: CGA-c5fg-gm82-jrmq
     aliases:


### PR DESCRIPTION
**Adds `pending-upstream-fix` advisory for Apache druid**, specifically the `derby` dependency. See advisory description for more information.

_Separately, we're exploring a separate issue where this advisory was re-marked as detected. We've filed a separate DYDX internal issue to investigate._

----------

_**Once approved / merged, the following automated PR can be closed:**_
_- https://github.com/wolfi-dev/os/pull/35695_