### PR TITLE
Adds `pending-upstream-fix advisory` for the 'q' package: GHSA-px8v-pp82-rcvr

### DIFF
--- a/q.advisories.yaml
+++ b/q.advisories.yaml
@@ -146,6 +146,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/q
             scanner: grype
+      - timestamp: 2024-12-11T23:37:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability is related to 'quic-go', one of the dependencies of the 'q' package.
+            A fix is available, but requires upgrading 'quic-go' to 'v0.48.2'. Attempting to upgrade to this version results in build failures.
+            Specifically, 'QuicConfig' may have been deprecated in favor of 'QUICConfig'.
+            Attempts to patch the likely ares of the codebase were unsuccessful, and still resulted in build failures.
+            Will require the upstream 'q' project to address in a future release.
 
   - id: CGA-frjr-28p5-8x9r
     aliases:

--- a/q.advisories.yaml
+++ b/q.advisories.yaml
@@ -153,7 +153,7 @@ advisories:
             This vulnerability is related to 'quic-go', one of the dependencies of the 'q' package.
             A fix is available, but requires upgrading 'quic-go' to 'v0.48.2'. Attempting to upgrade to this version results in build failures.
             Specifically, 'QuicConfig' may have been deprecated in favor of 'QUICConfig'.
-            Attempts to patch the likely ares of the codebase were unsuccessful, and still resulted in build failures.
+            Attempts to patch the likely areas of the codebase were unsuccessful, and still resulted in build failures.
             Will require the upstream 'q' project to address in a future release.
 
   - id: CGA-frjr-28p5-8x9r


### PR DESCRIPTION
The 'q' package depends on quic-go, which is affected by GHSA-px8v-pp82-rcvr. A fix is available in quic-go version v0.48.2 and later, however, attempts to bump this dependency and remediate have been unsuccessful.

Please see advisory description for more info.

--------

**_Once this is approved / merged, please close out this (attempted) automated PR which tried to bump the dependency:_**
 _- https://github.com/wolfi-dev/os/pull/35688_