### PR TITLE
harbor: pending fix for GHSA-9j3m-fr7q-jxfw

### DIFF
--- a/harbor-2.12.advisories.yaml
+++ b/harbor-2.12.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/harbor-jobservice
             scanner: grype
+      - timestamp: 2024-12-14T11:10:17Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability requires a new release of the Harbor. Harbor 2.12.0 is not compatible with the github.com/beego/beego/v2@v2.3.4 yet.
 
   - id: CGA-qxv3-8352-vrq5
     aliases:


### PR DESCRIPTION
Harbor 2.12.x is not compatible with github.com/beego/beego/v2@v2.3.4 yet.

* https://github.com/wolfi-dev/os/pull/36996
* https://github.com/goharbor/harbor/blob/9da38ae048a186acb022683b38bdea27dcf030e0/src/core/session/session.go#L137-L138
* https://github.com/advisories/GHSA-9j3m-fr7q-jxfw