### PR TITLE
Multiple spark-3.5-scala-2.13 advisories

### DIFF
--- a/spark-3.5-scala-2.13.advisories.yaml
+++ b/spark-3.5-scala-2.13.advisories.yaml
@@ -21,6 +21,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T13:26:09Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-45m6-3663-vmrw
     aliases:
@@ -39,6 +46,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T13:23:38Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-4q67-3fwg-vmq6
     aliases:
@@ -57,6 +71,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to commons-compress 1.21 included by the shaded JARs hadoop-client-runtime-3.3.4.jar. There are no newer versions of the shaded JARs available to fix the vulnerability.
+>>>>>>> Stashed changes
 
   - id: CGA-56ph-vwr9-h9cf
     aliases:
@@ -74,6 +95,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T14:07:44Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-5rrm-wv6p-5c39
     aliases:
@@ -92,6 +120,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to nimbus-jose-jwt v9.8.1 included by the shaded JAR hadoop-client-runtime-3.3.6.jar. Spark is planning an upgrade to Hadoop 3.4.0 for Spark 4.0.0, but as of today, the shaded JAR for Hadoop 3.4.0 still includes this vulnerability.
+>>>>>>> Stashed changes
 
   - id: CGA-5wh4-5p8j-33rj
     aliases:
@@ -110,6 +145,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T13:31:54Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-6hpx-mm5q-grch
     aliases:
@@ -128,6 +170,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T13:22:20Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-95rq-pqfg-9383
     aliases:
@@ -146,6 +195,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: commons-io v2.8.0 is a transitive dependency that is brought in under hadoop-client-runtime-3.3.4.jar. This requires a hadoop-client-runtime update from upstream maintainers
+>>>>>>> Stashed changes
 
   - id: CGA-9623-89qx-877m
     aliases:
@@ -164,6 +220,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T13:24:12Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-9g23-pgwc-p32g
     aliases:
@@ -200,6 +263,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to avro v1.7.7, which is a transitive dependency of the shaded JAR hadoop-client-runtime, which is used by Spark. There are no newer versions of this shaded JAR available to fix the vulnerability.
+>>>>>>> Stashed changes
 
   - id: CGA-c3mr-w98r-ch3c
     aliases:
@@ -218,6 +288,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to commons-configuration2 2.1.1 included by the shaded JARs hadoop-client-runtime-3.3.4.jar. Spark is planning an upgrade to Hadoop 3.4.0 for Spark 4.0.0, but as of today, the shaded JAR for Hadoop 3.4.0 still includes this vulnerability.
+>>>>>>> Stashed changes
 
   - id: CGA-cfpv-j2r6-pgf4
     aliases:
@@ -236,6 +313,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to protobuf-java v3.7.1 included by the hadoop-client-runtime-3.3.4.jar. There are no newer versions of these shaded JARs available to fix the vulnerability.
+>>>>>>> Stashed changes
 
   - id: CGA-f57h-4h74-xh48
     aliases:
@@ -254,6 +338,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: Updating jetty to a non-vulnerable version would require 3 major version bumps, which would be a very significant upgrade with multiple breaking changes, and should only be undertaken by the upstream maintainers.
+>>>>>>> Stashed changes
 
   - id: CGA-f7wh-q7gp-f4wq
     aliases:
@@ -272,6 +363,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to protobuf-java v3.7.1 included by the hadoop-client-runtime-3.3.4.jar. There are no newer versions of these shaded JARs available to fix the vulnerability.
+>>>>>>> Stashed changes
 
   - id: CGA-fq2m-vp93-v8gm
     aliases:
@@ -290,6 +388,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T13:25:11Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-fqjr-mqj6-7cpp
     aliases:
@@ -308,6 +413,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to protobuf-java v3.7.1 included by the hadoop-client-runtime-3.3.6.jar. There are no newer versions of these shaded JARs available to fix the vulnerability.
+>>>>>>> Stashed changes
 
   - id: CGA-g946-j9fh-xg4v
     aliases:
@@ -326,6 +438,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-api-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T14:04:34Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-api  jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-g9g9-hh8j-v9h4
     aliases:
@@ -344,6 +463,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to protobuf-java v3.7.1 included by hadoop-client-runtime-3.3.4.jar. There are no newer versions of these shaded JARs available to fix the vulnerability.
+>>>>>>> Stashed changes
 
   - id: CGA-hcx6-4xcx-96pr
     aliases:
@@ -362,6 +488,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/guava-24.1.1-android.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T13:41:42Z
+        type: pending-upstream-fix
+        data:
+          note: 'This relates to guava v30.1.1-jre, which is included by the shaded JARs hadoop-shaded-guava-1.1.1.jar and hadoop-client-runtime-3.3.6.jar. This dependency is required to be updated by upstream maintainers '
+>>>>>>> Stashed changes
 
   - id: CGA-hvrv-q645-jvc9
     aliases:
@@ -380,6 +513,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T13:19:55Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-j948-p6wg-rq6h
     aliases:
@@ -416,6 +556,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T13:21:43Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-pgr9-2j9x-h3gg
     aliases:
@@ -434,6 +581,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/guava-24.1.1-android.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to guava v24.1.1-android, which is included by the shaded JARs spark-network-common jar, the version is dependent on the project version and so updating the dependency to resolve this issue needs to be done by upstream maintainers.
+>>>>>>> Stashed changes
 
   - id: CGA-pm4j-36rg-wx67
     aliases:
@@ -452,6 +606,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to json-smart v1.3.2 included by the shaded JAR hadoop-client-runtime-3.3.4.jar. There are no newer versions of this shaded JAR available to fix the vulnerability.
+>>>>>>> Stashed changes
 
   - id: CGA-qmj2-q7px-44mh
     aliases:
@@ -470,6 +631,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T14:06:36Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-qrhc-cv5f-6x94
     aliases:
@@ -488,6 +656,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to commons-configuration2 2.1.1 included by the shaded JARs hadoop-client-runtime-3.3.4.jar. Spark is planning an upgrade to Hadoop 3.4.0 for Spark 4.0.0, but as of today, the shaded JAR for Hadoop 3.4.0 still includes this vulnerability.
+>>>>>>> Stashed changes
 
   - id: CGA-v37r-crxx-4j4j
     aliases:
@@ -506,6 +681,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T12:35:32Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to json-smart v1.3.2 included by the shaded JAR hadoop-client-runtime-3.3.4.jar. There are no newer versions of this shaded JAR available to fix the vulnerability. This requires upstream maintainers to implement a fix.
+>>>>>>> Stashed changes
 
   - id: CGA-wf44-r5r7-gv7f
     aliases:
@@ -524,6 +706,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+<<<<<<< Updated upstream
+=======
+      - timestamp: 2024-12-16T13:42:43Z
+        type: pending-upstream-fix
+        data:
+          note: 'The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix. '
+>>>>>>> Stashed changes
 
   - id: CGA-x64f-h9cm-wv76
     aliases:
@@ -542,3 +731,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+      - timestamp: 2024-12-16T14:03:41Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.

--- a/spark-3.5-scala-2.13.advisories.yaml
+++ b/spark-3.5-scala-2.13.advisories.yaml
@@ -21,13 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T13:26:09Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-45m6-3663-vmrw
     aliases:
@@ -46,13 +43,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T13:23:38Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-4q67-3fwg-vmq6
     aliases:
@@ -71,13 +65,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to commons-compress 1.21 included by the shaded JARs hadoop-client-runtime-3.3.4.jar. There are no newer versions of the shaded JARs available to fix the vulnerability.
->>>>>>> Stashed changes
 
   - id: CGA-56ph-vwr9-h9cf
     aliases:
@@ -95,13 +86,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T14:07:44Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-5rrm-wv6p-5c39
     aliases:
@@ -120,13 +108,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to nimbus-jose-jwt v9.8.1 included by the shaded JAR hadoop-client-runtime-3.3.6.jar. Spark is planning an upgrade to Hadoop 3.4.0 for Spark 4.0.0, but as of today, the shaded JAR for Hadoop 3.4.0 still includes this vulnerability.
->>>>>>> Stashed changes
 
   - id: CGA-5wh4-5p8j-33rj
     aliases:
@@ -145,13 +130,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T13:31:54Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-6hpx-mm5q-grch
     aliases:
@@ -170,13 +152,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T13:22:20Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-95rq-pqfg-9383
     aliases:
@@ -195,13 +174,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: commons-io v2.8.0 is a transitive dependency that is brought in under hadoop-client-runtime-3.3.4.jar. This requires a hadoop-client-runtime update from upstream maintainers
->>>>>>> Stashed changes
 
   - id: CGA-9623-89qx-877m
     aliases:
@@ -220,13 +196,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T13:24:12Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-9g23-pgwc-p32g
     aliases:
@@ -263,13 +236,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to avro v1.7.7, which is a transitive dependency of the shaded JAR hadoop-client-runtime, which is used by Spark. There are no newer versions of this shaded JAR available to fix the vulnerability.
->>>>>>> Stashed changes
 
   - id: CGA-c3mr-w98r-ch3c
     aliases:
@@ -288,13 +258,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to commons-configuration2 2.1.1 included by the shaded JARs hadoop-client-runtime-3.3.4.jar. Spark is planning an upgrade to Hadoop 3.4.0 for Spark 4.0.0, but as of today, the shaded JAR for Hadoop 3.4.0 still includes this vulnerability.
->>>>>>> Stashed changes
 
   - id: CGA-cfpv-j2r6-pgf4
     aliases:
@@ -313,13 +280,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to protobuf-java v3.7.1 included by the hadoop-client-runtime-3.3.4.jar. There are no newer versions of these shaded JARs available to fix the vulnerability.
->>>>>>> Stashed changes
 
   - id: CGA-f57h-4h74-xh48
     aliases:
@@ -338,13 +302,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: Updating jetty to a non-vulnerable version would require 3 major version bumps, which would be a very significant upgrade with multiple breaking changes, and should only be undertaken by the upstream maintainers.
->>>>>>> Stashed changes
 
   - id: CGA-f7wh-q7gp-f4wq
     aliases:
@@ -363,13 +324,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to protobuf-java v3.7.1 included by the hadoop-client-runtime-3.3.4.jar. There are no newer versions of these shaded JARs available to fix the vulnerability.
->>>>>>> Stashed changes
 
   - id: CGA-fq2m-vp93-v8gm
     aliases:
@@ -388,13 +346,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T13:25:11Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-fqjr-mqj6-7cpp
     aliases:
@@ -413,13 +368,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to protobuf-java v3.7.1 included by the hadoop-client-runtime-3.3.6.jar. There are no newer versions of these shaded JARs available to fix the vulnerability.
->>>>>>> Stashed changes
 
   - id: CGA-g946-j9fh-xg4v
     aliases:
@@ -438,13 +390,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-api-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T14:04:34Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-api  jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-g9g9-hh8j-v9h4
     aliases:
@@ -463,13 +412,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to protobuf-java v3.7.1 included by hadoop-client-runtime-3.3.4.jar. There are no newer versions of these shaded JARs available to fix the vulnerability.
->>>>>>> Stashed changes
 
   - id: CGA-hcx6-4xcx-96pr
     aliases:
@@ -488,13 +434,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/guava-24.1.1-android.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T13:41:42Z
         type: pending-upstream-fix
         data:
           note: 'This relates to guava v30.1.1-jre, which is included by the shaded JARs hadoop-shaded-guava-1.1.1.jar and hadoop-client-runtime-3.3.6.jar. This dependency is required to be updated by upstream maintainers '
->>>>>>> Stashed changes
 
   - id: CGA-hvrv-q645-jvc9
     aliases:
@@ -513,13 +456,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T13:19:55Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-j948-p6wg-rq6h
     aliases:
@@ -556,13 +496,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T13:21:43Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-pgr9-2j9x-h3gg
     aliases:
@@ -581,13 +518,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/guava-24.1.1-android.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to guava v24.1.1-android, which is included by the shaded JARs spark-network-common jar, the version is dependent on the project version and so updating the dependency to resolve this issue needs to be done by upstream maintainers.
->>>>>>> Stashed changes
 
   - id: CGA-pm4j-36rg-wx67
     aliases:
@@ -606,13 +540,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to json-smart v1.3.2 included by the shaded JAR hadoop-client-runtime-3.3.4.jar. There are no newer versions of this shaded JAR available to fix the vulnerability.
->>>>>>> Stashed changes
 
   - id: CGA-qmj2-q7px-44mh
     aliases:
@@ -631,13 +562,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T14:06:36Z
         type: pending-upstream-fix
         data:
           note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-qrhc-cv5f-6x94
     aliases:
@@ -656,13 +584,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to commons-configuration2 2.1.1 included by the shaded JARs hadoop-client-runtime-3.3.4.jar. Spark is planning an upgrade to Hadoop 3.4.0 for Spark 4.0.0, but as of today, the shaded JAR for Hadoop 3.4.0 still includes this vulnerability.
->>>>>>> Stashed changes
 
   - id: CGA-v37r-crxx-4j4j
     aliases:
@@ -681,13 +606,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T12:35:32Z
         type: pending-upstream-fix
         data:
           note: This relates to json-smart v1.3.2 included by the shaded JAR hadoop-client-runtime-3.3.4.jar. There are no newer versions of this shaded JAR available to fix the vulnerability. This requires upstream maintainers to implement a fix.
->>>>>>> Stashed changes
 
   - id: CGA-wf44-r5r7-gv7f
     aliases:
@@ -706,13 +628,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/assembly/target/scala-2.13/jars/hadoop-client-runtime-3.3.4.jar
             scanner: grype
-<<<<<<< Updated upstream
-=======
       - timestamp: 2024-12-16T13:42:43Z
         type: pending-upstream-fix
         data:
           note: 'The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix. '
->>>>>>> Stashed changes
 
   - id: CGA-x64f-h9cm-wv76
     aliases:


### PR DESCRIPTION
## 1. **GHSA-4265-ccf5-phj5**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-runtime` jar. This requires upstream maintainers to implement a fix.
- **Details:** `commons-compress` version 1.21 included in `hadoop-client-runtime-3.3.4.jar` is affected. There are no newer versions of the shaded JARs available to fix the vulnerability.

## 2. **GHSA-4gg5-vx3j-xwc7**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-runtime` jar. This requires upstream maintainers to implement a fix.
- **Details:** `protobuf-java` version 3.7.1 included in `hadoop-client-runtime-3.3.4.jar` is affected. There are no newer versions of the shaded JARs available to fix the vulnerability.

## 3. **GHSA-4g9r-vxhx-9pgx**
- **pending-upstream-fix:** This relates to `commons-compress` version 1.21 included by the shaded JARs `hadoop-client-runtime-3.3.4.jar`. There are no newer versions of the shaded JARs available to fix the vulnerability.
- **Details:** `commons-compress` version 1.21 is a transitive dependency requiring a fix by upstream maintainers.

## 4. **GHSA-58qw-p7qm-5rvh**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-runtime` jar. This requires upstream maintainers to implement a fix.
- **Details:** `jetty-xml` version 9.4.43.v20210629 included in `hadoop-client-runtime-3.3.4.jar` is affected.

## 5. **GHSA-gvpg-vgmx-xg6w**
- **pending-upstream-fix:** This relates to `nimbus-jose-jwt` version 9.8.1 included by the shaded JAR `hadoop-client-runtime-3.3.6.jar`. Spark is planning an upgrade to Hadoop 3.4.0 for Spark 4.0.0, but as of today, the shaded JAR for Hadoop 3.4.0 still includes this vulnerability.
- **Details:** Updating the dependency requires action from upstream maintainers.

## 6. **GHSA-3f7h-mf4q-vrm4**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-runtime` jar. This requires upstream maintainers to implement a fix.
- **Details:** `woodstox-core` version 5.3.0 included in `hadoop-client-runtime-3.3.4.jar` is affected.

## 7. **GHSA-r7pg-v2c8-mfg3**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-runtime` jar. This requires upstream maintainers to implement a fix.
- **Details:** `avro` version 1.7.7 included in `hadoop-client-runtime-3.3.4.jar` is affected.

## 8. **GHSA-78wr-2p64-hpwj**
- **pending-upstream-fix:** `commons-io` version 2.8.0 is a transitive dependency brought in under `hadoop-client-runtime-3.3.4.jar`. This requires an update by upstream maintainers.
- **Details:** The dependency is outdated and requires an update from the Hadoop maintainers.

## 9. **GHSA-h4h5-3hr4-j3g2**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-runtime` jar. This requires upstream maintainers to implement a fix.
- **Details:** `protobuf-java` version 3.7.1 included in `hadoop-client-runtime-3.3.4.jar` is affected.
## 10. **GHSA-8qv5-68g4-248j**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-runtime` jar. This requires upstream maintainers to implement a fix.
- **Details:** `scala-library` version 2.13.8 included in `hadoop-client-runtime-3.3.4.jar` is affected.

## 11. **GHSA-rhrv-645h-fjfh**
- **pending-upstream-fix:** This relates to `avro` version 1.7.7, which is a transitive dependency of the shaded JAR `hadoop-client-runtime`. There are no newer versions of this shaded JAR available to fix the vulnerability.
- **Details:** Updating the dependency requires action from upstream maintainers.

## 12. **GHSA-xjp4-hw94-mvp5**
- **pending-upstream-fix:** This relates to `commons-configuration2` version 2.1.1 included by the shaded JARs `hadoop-client-runtime-3.3.4.jar`. Spark is planning an upgrade to Hadoop 3.4.0 for Spark 4.0.0, but as of today, the shaded JAR for Hadoop 3.4.0 still includes this vulnerability.
- **Details:** Dependency update is pending from upstream maintainers.

## 13. **GHSA-g5ww-5jh7-63cx**
- **pending-upstream-fix:** This relates to `protobuf-java` version 3.7.1 included by the `hadoop-client-runtime-3.3.4.jar`. There are no newer versions of these shaded JARs available to fix the vulnerability.
- **Details:** Fix requires upstream maintainers to release an updated version.

## 14. **GHSA-qh8g-58pp-2wxh**
- **pending-upstream-fix:** Updating `jetty-http` to a non-vulnerable version would require three major version bumps. This is a significant upgrade with multiple breaking changes, which should be undertaken only by upstream maintainers.
- **Details:** `jetty-http` version 9.4.43.v20210629 included in `hadoop-client-runtime-3.3.4.jar` is affected.

## 15. **GHSA-wrvw-hg22-4m67**
- **pending-upstream-fix:** This relates to `protobuf-java` version 3.7.1 included by the `hadoop-client-runtime-3.3.4.jar`. There are no newer versions of these shaded JARs available to fix the vulnerability.
- **Details:** The dependency requires an update from upstream maintainers.

## 16. **GHSA-cgp8-4m63-fhh5**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-runtime` jar. This requires upstream maintainers to implement a fix.
- **Details:** `commons-net` version 3.6 included in `hadoop-client-runtime-3.3.4.jar` is affected.

## 17. **GHSA-77rm-9x9h-xj3g**
- **pending-upstream-fix:** This relates to `protobuf-java` version 3.7.1 included by the `hadoop-client-runtime-3.3.6.jar`. There are no newer versions of these shaded JARs available to fix the vulnerability.
- **Details:** Dependency update is required from upstream maintainers.

## 18. **GHSA-f5fw-25gw-5m92**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-api` jar. This requires upstream maintainers to implement a fix.
- **Details:** `hadoop-common` version 3.3.4 included in `hadoop-client-api-3.3.4.jar` is affected.

## 19. **GHSA-735f-pc8j-v9w8**
- **pending-upstream-fix:** This relates to `protobuf-java` version 3.7.1 included by `hadoop-client-runtime-3.3.4.jar`. There are no newer versions of these shaded JARs available to fix the vulnerability.
- **Details:** The dependency requires an update from upstream maintainers.

## 20. **GHSA-7g45-4rm6-3mm3**
- **pending-upstream-fix:** This relates to `guava` version 30.1.1-jre, which is included by the shaded JARs `hadoop-shaded-guava-1.1.1.jar` and `hadoop-client-runtime-3.3.6.jar`. This dependency is required to be updated by upstream maintainers.
- **Details:** `guava` version 24.1.1-android included in `hadoop-client-runtime-3.3.4.jar` is affected.

## 21. **GHSA-rgv9-q543-rqg4**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-runtime` jar. This requires upstream maintainers to implement a fix.
- **Details:** `jackson-databind` version 2.12.7 included in `hadoop-client-runtime-3.3.4.jar` is affected.

## 22. **GHSA-r978-9m6m-6gm6**
- **pending-upstream-fix:** No specific update details are available. Dependency is included in the project and requires upstream maintainers to resolve.
- **Details:** `zookeeper` version 3.7.2 included in `hadoop-client-runtime-3.3.4.jar` is affected.

## 23. **GHSA-hmr7-m48g-48f6**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the `hadoop-client-runtime` jar. This requires upstream maintainers to implement a fix.
- **Details:** `jetty-http` version 9.4.43.v20210629 included in `hadoop-client-runtime-3.3.4.jar` is affected.

## 24. **GHSA-5mg8-w23w-74h3**
- **pending-upstream-fix:** This relates to `guava` version 24.1.1-android, which is included by the shaded JARs `spark-network-common.jar`. The version is dependent on the project version and so updating the dependency to resolve this issue needs to be done by upstream maintainers.
- **Details:** `guava` version 24.1.1-android included in `spark-network-common.jar` is affected.

## 25. **GHSA-fg2v-w576-w4v3**
- **pending-upstream-fix:** This relates to `json-smart` version 1.3.2 included by the shaded JAR `hadoop-client-runtime-3.3.4.jar`. There are no newer versions of this shaded JAR available to fix the vulnerability.
- **Details:** Dependency update is required from upstream maintainers.

