### PR TITLE
Updating advisories - rancher-agent-2.10

### DIFF
--- a/rancher-agent-2.10.advisories.yaml
+++ b/rancher-agent-2.10.advisories.yaml
@@ -57,6 +57,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/agent
             scanner: grype
+      - timestamp: 2024-12-16T20:40:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-present
+          note: govulncheck analysis shows that the github.com/docker/docker golang package is not used by the rancher-agent binary as there are no symbols referenced for the vulnerable code.
 
   - id: CGA-ppx7-757f-46h3
     aliases:
@@ -75,6 +80,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/agent
             scanner: grype
+      - timestamp: 2024-12-16T21:11:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-present
+          note: govulncheck analysis shows that the github.com/docker/docker golang package is not used by the rancher-agent binary as there are no symbols referenced for the vulnerable code.
 
   - id: CGA-rmh4-52mg-g8pr
     aliases:
@@ -93,3 +103,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/agent
             scanner: grype
+      - timestamp: 2024-12-16T21:07:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-present
+          note: govulncheck analysis shows that the github.com/docker/docker golang package is not used by the rancher-agent binary as there are no symbols referenced for the vulnerable code.


### PR DESCRIPTION
false positive determination - github.com/docker/docker@v20.10.27+incompatible: https://github.com/advisories/GHSA-v23v-6jw2-98fq
https://github.com/advisories/GHSA-mq39-4gv4-mvpx
https://github.com/advisories/GHSA-xw73-rw38-6vjc