### PR TITLE
fix(duplicate detection events): Remove duplicate detection events where the last event is the duplicate detection event

### DIFF
--- a/az.advisories.yaml
+++ b/az.advisories.yaml
@@ -47,18 +47,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.62.0-r1
-      - timestamp: 2024-10-08T14:28:55Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: az
-            componentID: ee3f4e32631c7d46
-            componentName: setuptools
-            componentVersion: 68.0.0
-            componentType: python
-            componentLocation: /usr/share/az/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-3q54-hjw3-8927
     aliases:
@@ -91,18 +79,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.61.0-r2
-      - timestamp: 2024-10-08T14:28:46Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: az
-            componentID: 56ee46fe4e2e374d
-            componentName: certifi
-            componentVersion: 2023.7.22
-            componentType: python
-            componentLocation: /usr/share/az/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-f62w-c924-7874
     aliases:
@@ -190,18 +166,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.61.0-r1
-      - timestamp: 2024-10-08T14:28:49Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: az
-            componentID: 48c213778a6fc48e
-            componentName: urllib3
-            componentVersion: 1.26.17
-            componentType: python
-            componentLocation: /usr/share/az/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-v263-vf6g-w8hh
     aliases:
@@ -256,15 +220,3 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.60.0-r0
-      - timestamp: 2024-10-08T14:28:58Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: az
-            componentID: 3aa988217bdddab9
-            componentName: idna
-            componentVersion: "3.4"
-            componentType: python
-            componentLocation: /usr/share/az/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
-            scanner: grype

--- a/dask-gateway.advisories.yaml
+++ b/dask-gateway.advisories.yaml
@@ -249,18 +249,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 2024.1.0-r6
-      - timestamp: 2024-10-09T08:10:12Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: dask-gateway
-            componentID: 389984665fd5df57
-            componentName: urllib3
-            componentVersion: 1.26.18
-            componentType: python
-            componentLocation: /usr/share/dask-gateway/.venv/lib/python3.12/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-j4qq-j23r-522f
     aliases:

--- a/envoy-ratelimit.advisories.yaml
+++ b/envoy-ratelimit.advisories.yaml
@@ -46,18 +46,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.0_git20240220-r11
-      - timestamp: 2024-06-08T07:10:29Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: envoy-ratelimit
-            componentID: 7bc1306af33a7dbc
-            componentName: envoy-ratelimit
-            componentVersion: 0.0_git20240220-r10
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
 
   - id: CGA-8wmh-wpxv-p65f
     aliases:
@@ -100,18 +88,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.0_git20240220-r11
-      - timestamp: 2024-06-08T07:10:25Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: envoy-ratelimit
-            componentID: 7bc1306af33a7dbc
-            componentName: envoy-ratelimit
-            componentVersion: 0.0_git20240220-r10
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
 
   - id: CGA-hjxm-gh2v-4g9q
     aliases:

--- a/kpt.advisories.yaml
+++ b/kpt.advisories.yaml
@@ -139,18 +139,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.0.0_beta49-r11
-      - timestamp: 2024-09-13T10:39:19Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: kpt
-            componentID: 72ff1d39997a837b
-            componentName: stdlib
-            componentVersion: go1.22.6
-            componentType: go-module
-            componentLocation: /usr/bin/kpt
-            scanner: grype
 
   - id: CGA-fc5p-qj78-qmfv
     aliases:
@@ -173,18 +161,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.0.0_beta49-r11
-      - timestamp: 2024-09-13T10:39:05Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: kpt
-            componentID: 72ff1d39997a837b
-            componentName: stdlib
-            componentVersion: go1.22.6
-            componentType: go-module
-            componentLocation: /usr/bin/kpt
-            scanner: grype
 
   - id: CGA-fc68-864c-g67f
     aliases:
@@ -237,18 +213,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.0.0_beta49-r11
-      - timestamp: 2024-09-13T10:39:12Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: kpt
-            componentID: 72ff1d39997a837b
-            componentName: stdlib
-            componentVersion: go1.22.6
-            componentType: go-module
-            componentLocation: /usr/bin/kpt
-            scanner: grype
 
   - id: CGA-j7q2-hg48-gqjm
     aliases:

--- a/kubeflow-centraldashboard.advisories.yaml
+++ b/kubeflow-centraldashboard.advisories.yaml
@@ -47,18 +47,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.9.1-r2
-      - timestamp: 2024-11-14T07:39:19Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: kubeflow-centraldashboard
-            componentID: 96a6cd2eae2faa3e
-            componentName: jsonpath-plus
-            componentVersion: 10.0.0
-            componentType: npm
-            componentLocation: /app/node_modules/jsonpath-plus/package.json
-            scanner: grype
 
   - id: CGA-4g7r-gq6m-3fjw
     aliases:

--- a/kubeflow-katib.advisories.yaml
+++ b/kubeflow-katib.advisories.yaml
@@ -126,18 +126,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.16.0-r12
-      - timestamp: 2024-10-09T09:03:56Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: katib-controller
-            componentID: 9cd33d13223d4747
-            componentName: requests
-            componentVersion: 2.31.0
-            componentType: python
-            componentLocation: /opt/katib/cmd/earlystopping/medianstop/v1beta1/lib/python3.10/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-c4jh-pgw7-5chh
     aliases:
@@ -188,18 +176,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.17.0-r1
-      - timestamp: 2024-10-09T09:04:05Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: katib-controller
-            componentID: 54ac3d4b1b33413c
-            componentName: setuptools
-            componentVersion: 68.0.0
-            componentType: python
-            componentLocation: /opt/katib/cmd/earlystopping/medianstop/v1beta1/lib/python3.10/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-hgm8-x79f-ghvm
     aliases:
@@ -244,18 +220,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.16.0-r9
-      - timestamp: 2024-10-09T09:04:13Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: katib-controller
-            componentID: ba8d8d4900cc575a
-            componentName: idna
-            componentVersion: "3.4"
-            componentType: python
-            componentLocation: /opt/katib/cmd/earlystopping/medianstop/v1beta1/lib/python3.10/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-j85m-373p-hxr6
     aliases:
@@ -316,18 +280,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.16.0-r13
-      - timestamp: 2024-10-09T09:03:47Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: katib-controller
-            componentID: 944292b892fbf913
-            componentName: urllib3
-            componentVersion: 1.26.17
-            componentType: python
-            componentLocation: /opt/katib/cmd/earlystopping/medianstop/v1beta1/lib/python3.10/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-p2hm-64qv-wvxw
     aliases:

--- a/kubeflow-pipelines.advisories.yaml
+++ b/kubeflow-pipelines.advisories.yaml
@@ -338,18 +338,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.2.0-r9
-      - timestamp: 2024-10-11T20:22:08Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: kubeflow-pipelines-apiserver
-            componentID: f8a080adf5cdd122
-            componentName: fast-xml-parser
-            componentVersion: 4.2.5
-            componentType: npm
-            componentLocation: /server/node_modules/fast-xml-parser/package.json
-            scanner: grype
 
   - id: CGA-6h42-qg2h-m7r9
     aliases:

--- a/mariadb-10.6.advisories.yaml
+++ b/mariadb-10.6.advisories.yaml
@@ -80,18 +80,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 10.6.17-r0
-      - timestamp: 2024-05-29T07:34:51Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: mariadb-10.6
-            componentID: d50915dad43b8ab7
-            componentName: postgresql
-            componentVersion: 9.4.1208
-            componentType: java-archive
-            componentLocation: /usr/mysql-test/plugin/connect/connect/std_data/JdbcMariaDB.jar
-            scanner: grype
 
   - id: CGA-xwh3-9v2p-54h2
     aliases:

--- a/mariadb-11.2.advisories.yaml
+++ b/mariadb-11.2.advisories.yaml
@@ -48,18 +48,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 11.2.3-r2
-      - timestamp: 2024-05-29T07:20:09Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: mariadb-11.2
-            componentID: ebe7eb9d77233c6a
-            componentName: postgresql
-            componentVersion: 9.4.1208
-            componentType: java-archive
-            componentLocation: /usr/mariadb-test/plugin/connect/connect/std_data/JdbcMariaDB.jar
-            scanner: grype
 
   - id: CGA-63j7-vh89-wc5p
     aliases:
@@ -82,18 +70,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 11.2.3-r2
-      - timestamp: 2024-05-29T07:20:12Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: mariadb-11.2
-            componentID: ebe7eb9d77233c6a
-            componentName: postgresql
-            componentVersion: 9.4.1208
-            componentType: java-archive
-            componentLocation: /usr/mariadb-test/plugin/connect/connect/std_data/JdbcMariaDB.jar
-            scanner: grype
 
   - id: CGA-fqv6-m5xf-9wf3
     aliases:
@@ -116,15 +92,3 @@ advisories:
         type: fixed
         data:
           fixed-version: 11.2.3-r2
-      - timestamp: 2024-05-29T07:20:10Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: mariadb-11.2
-            componentID: ebe7eb9d77233c6a
-            componentName: postgresql
-            componentVersion: 9.4.1208
-            componentType: java-archive
-            componentLocation: /usr/mariadb-test/plugin/connect/connect/std_data/JdbcMariaDB.jar
-            scanner: grype

--- a/prism.advisories.yaml
+++ b/prism.advisories.yaml
@@ -25,15 +25,3 @@ advisories:
         type: fixed
         data:
           fixed-version: 5.11.2-r1
-      - timestamp: 2024-11-13T08:22:42Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: prism
-            componentID: 470d5fe5bd1a0885
-            componentName: jsonpath-plus
-            componentVersion: 10.0.1
-            componentType: npm
-            componentLocation: /usr/src/prism/node_modules/jsonpath-plus/package.json
-            scanner: grype

--- a/py3-cassandra-medusa.advisories.yaml
+++ b/py3-cassandra-medusa.advisories.yaml
@@ -73,18 +73,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.20.1-r0
-      - timestamp: 2024-10-09T09:07:02Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: py3-cassandra-medusa-compat
-            componentID: 4a1331d7b5ac2a38
-            componentName: idna
-            componentVersion: "3.4"
-            componentType: python
-            componentLocation: /home/cassandra/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-4xx2-v3vc-q5x8
     aliases:
@@ -107,18 +95,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.21.0-r2
-      - timestamp: 2024-10-09T09:06:49Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: py3-cassandra-medusa-compat
-            componentID: a8cae5ffd1054d8b
-            componentName: requests
-            componentVersion: 2.31.0
-            componentType: python
-            componentLocation: /home/cassandra/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-5r79-xjw3-j928
     aliases:
@@ -167,18 +143,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.21.0-r4
-      - timestamp: 2024-10-09T09:06:43Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: py3-cassandra-medusa-compat
-            componentID: 54e769283cc83be1
-            componentName: urllib3
-            componentVersion: 1.26.17
-            componentType: python
-            componentLocation: /home/cassandra/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-692f-82fw-6r2x
     aliases:
@@ -357,18 +321,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.21.0-r6
-      - timestamp: 2024-10-09T09:06:56Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: py3-cassandra-medusa-compat
-            componentID: e405f6a31c93dac9
-            componentName: setuptools
-            componentVersion: 68.0.0
-            componentType: python
-            componentLocation: /home/cassandra/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-fq42-7695-jqrp
     aliases:
@@ -434,18 +386,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.21.0-r5
-      - timestamp: 2024-10-09T09:06:36Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: py3-cassandra-medusa-compat
-            componentID: 7880600fe2638322
-            componentName: certifi
-            componentVersion: 2023.7.22
-            componentType: python
-            componentLocation: /home/cassandra/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-mg75-rw8r-52jj
     aliases:

--- a/reflex.advisories.yaml
+++ b/reflex.advisories.yaml
@@ -87,18 +87,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.5.5-r0
-      - timestamp: 2024-10-09T03:39:06Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: reflex
-            componentID: e21c8c116860b5d3
-            componentName: urllib3
-            componentVersion: 1.26.18
-            componentType: python
-            componentLocation: /usr/lib/python3.12/site-packages/pip/_vendor/vendor.txt
-            scanner: grype
 
   - id: CGA-8r5m-26r9-62wr
     aliases:

--- a/superset.advisories.yaml
+++ b/superset.advisories.yaml
@@ -29,18 +29,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 4.0.2-r5
-      - timestamp: 2024-11-15T10:41:37Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: superset
-            componentID: 9ff00e92387c094b
-            componentName: flask-appbuilder
-            componentVersion: 4.4.1
-            componentType: python
-            componentLocation: /usr/share/superset/venv/lib/python3.11/site-packages/Flask_AppBuilder-4.4.1.dist-info/METADATA, /usr/share/superset/venv/lib/python3.11/site-packages/Flask_AppBuilder-4.4.1.dist-info/RECORD, /usr/share/superset/venv/lib/python3.11/site-packages/Flask_AppBuilder-4.4.1.dist-info/top_level.txt
-            scanner: grype
 
   - id: CGA-37xg-qrch-w8h8
     aliases:

--- a/tez.advisories.yaml
+++ b/tez.advisories.yaml
@@ -73,18 +73,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.10.4-r1
-      - timestamp: 2024-11-20T08:37:40Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: tez
-            componentID: 992974ad1e1f9e48
-            componentName: jackson-mapper-asl
-            componentVersion: 1.9.2
-            componentType: java-archive
-            componentLocation: /usr/share/java/tez/lib/jackson-mapper-asl-1.9.2.jar
-            scanner: grype
 
   - id: CGA-2w4w-28wc-pp53
     aliases:
@@ -177,18 +165,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.10.4-r1
-      - timestamp: 2024-11-20T08:37:47Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: tez
-            componentID: 992974ad1e1f9e48
-            componentName: jackson-mapper-asl
-            componentVersion: 1.9.2
-            componentType: java-archive
-            componentLocation: /usr/share/java/tez/lib/jackson-mapper-asl-1.9.2.jar
-            scanner: grype
 
   - id: CGA-7wc9-mhwq-jwvr
     aliases:

--- a/trino.advisories.yaml
+++ b/trino.advisories.yaml
@@ -235,18 +235,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 437-r0
-      - timestamp: 2024-10-14T09:25:40Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: trino
-            componentID: 69ee01355bb1a36f
-            componentName: json-path
-            componentVersion: 2.8.0
-            componentType: java-archive
-            componentLocation: /usr/lib/trino/lib/json-path-2.8.0.jar
-            scanner: grype
 
   - id: CGA-6gcx-2g6m-pvm8
     aliases:

--- a/zed.advisories.yaml
+++ b/zed.advisories.yaml
@@ -25,18 +25,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.147.2-r0
-      - timestamp: 2024-12-08T10:06:30Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: zed
-            componentID: bdef8932e3fd953c
-            componentName: tungstenite
-            componentVersion: 0.19.0
-            componentType: rust-crate
-            componentLocation: /usr/libexec/zed
-            scanner: grype
 
   - id: CGA-53v4-w8mg-37qg
     aliases:


### PR DESCRIPTION
I see no reason for these to be created as duplicates as the previous event was a fixed event or a pending-upstream-fix advisory

Signed-off-by: philroche <phil.roche@chainguard.dev>
