### PR TITLE
Gitlab Bulk Update For Gems: 1 Issue

### DIFF
--- a/gitlab-cng-17.6.advisories.yaml
+++ b/gitlab-cng-17.6.advisories.yaml
@@ -39,6 +39,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.2.0/specifications/puma-5.6.8.gemspec
             scanner: grype
+      - timestamp: 2024-12-17T14:16:21Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability relates to a GitLab gem dependency. GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues. Deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.'
 
   - id: CGA-vvw2-vc5h-cmrj
     aliases:
@@ -57,3 +61,7 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.2.0/specifications/sinatra-2.2.4.gemspec
             scanner: grype
+      - timestamp: 2024-12-17T14:16:21Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability relates to a GitLab gem dependency. GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues. Deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.'


### PR DESCRIPTION
For gitlab gems we are using a standardized note due to inability to bump these dependencies.

Updated dependencies:
GHSA-9hf4-67fc-4vf4
GHSA-hxx2-7vcw-mqr3