### PR TITLE
Spark: Add pending-upstream-fix for GHSA-rj7p-rfgp-852x

### DIFF
--- a/spark-3.5-scala-2.13.advisories.yaml
+++ b/spark-3.5-scala-2.13.advisories.yaml
@@ -251,7 +251,7 @@ advisories:
           note: |
             This vulnerability relates to the 'libthrift' used by spark. A fixed version is available in v0.13.0.
             Upstream have upgraded to a fixed version in the main branch, but not back ported this to spark v3.
-            Attempting to upgrade this dependency in spark v3 results in build failures, specifically compatability issues with the 'maven-shade-plugin'.
+            Attempting to upgrade this dependency in spark v3 results in build failures, specifically compatibility issues with the 'maven-shade-plugin'.
             Separate attempts to update the maven-shade-plugin to a later version in parallel, did not resolve the issue.
             Awaiting for fix / backport from upstream to address this issue.
 

--- a/spark-3.5-scala-2.13.advisories.yaml
+++ b/spark-3.5-scala-2.13.advisories.yaml
@@ -245,6 +245,15 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/python3.13/site-packages/pyspark/jars/libthrift-0.12.0.jar
             scanner: grype
+      - timestamp: 2024-12-17T17:51:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to the 'libthrift' used by spark. A fixed version is available in v0.13.0.
+            Upstream have upgraded to a fixed version in the main branch, but not back ported this to spark v3.
+            Attempting to upgrade this dependency in spark v3 results in build failures, specifically compatability issues with the 'maven-shade-plugin'.
+            Separate attempts to update the maven-shade-plugin to a later version in parallel, did not resolve the issue.
+            Awaiting for fix / backport from upstream to address this issue.
 
   - id: CGA-93w3-x4hw-7w7g
     aliases:


### PR DESCRIPTION
Add pending-upstream-fix for GHSA-rj7p-rfgp-852x, which relates to the libthrift dependency, which we are unable to bump without resulting build issues. See advisory description.