### PR TITLE
raising pending-upstream-fix advisories for GHSA-5jpm-x58v-624v and GHSA-xq3w-v528-46rv

### DIFF
--- a/spark-3.5-scala-2.13.advisories.yaml
+++ b/spark-3.5-scala-2.13.advisories.yaml
@@ -227,6 +227,15 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/python3.13/site-packages/pyspark/jars/netty-codec-http-4.1.96.Final.jar
             scanner: grype
+      - timestamp: 2024-12-17T22:26:10Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to 'netty-codec-http', which is used by one of spark's other dependencies - pyspark.
+            pyspark copies a number of jar's from the spark build process, one of those being 'netty-codec-http'.
+            This has been fixed in netty > v4.1.108, and spark has upgraded to a later version in main.
+            However, attempts to backport this upgrade in this release of spark, result in build failures.
+            Awaiting for fix / backport from upstream to address this issue.
 
   - id: CGA-86x3-7p58-9qhp
     aliases:

--- a/spark-3.5-scala-2.13.advisories.yaml
+++ b/spark-3.5-scala-2.13.advisories.yaml
@@ -234,7 +234,7 @@ advisories:
             This vulnerability relates to 'netty-codec-http', which is used by one of spark's other dependencies - pyspark.
             pyspark copies a number of jar's from the spark build process, one of those being 'netty-codec-http'.
             This has been fixed in netty > v4.1.108, and spark has upgraded to a later version in main.
-            However, attempts to backport this upgrade in this release of spark, result in build failures.
+            However, attempts to backport to this release of spark, result in build failures.
             Awaiting for fix / backport from upstream to address this issue.
 
   - id: CGA-86x3-7p58-9qhp
@@ -785,6 +785,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/python3.13/site-packages/pyspark/jars/netty-common-4.1.96.Final.jar
             scanner: grype
+      - timestamp: 2024-12-17T22:26:10Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to 'netty-common', used by spark. A fixed version is available in v4.1.115.
+            Spark has upgraded to a later version in main, but attempts to backport to this release of spark, result in build failures.
+            Awaiting for fix / backport from upstream to address this issue.
 
   - id: CGA-v37r-crxx-4j4j
     aliases:


### PR DESCRIPTION
raising pending-upstream-fix advisories for GHSA-5jpm-x58v-624v and GHSA-xq3w-v528-46rv for apache spark. See advisory descriptions for more details.