### PR TITLE
Added pending-upstream-fix advisories for argocd-image-updater

### DIFF
--- a/argocd-image-updater.advisories.yaml
+++ b/argocd-image-updater.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argocd-image-updater
             scanner: grype
+      - timestamp: 2024-12-19T01:41:09Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE is caused by a 'go replace' block in the go.mod file pulling in the dependency, despite the package using the latest version as defined elsewhere in the go.mod file. An upstream patch has been submitted and merged which will remove this old dependency in future versions. See https://github.com/argoproj-labs/argocd-image-updater/pull/969
 
   - id: CGA-cjr4-f6q7-9mh7
     aliases:

--- a/argocd-image-updater.advisories.yaml
+++ b/argocd-image-updater.advisories.yaml
@@ -97,3 +97,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argocd-image-updater
             scanner: grype
+      - timestamp: 2024-12-19T02:15:53Z
+        type: pending-upstream-fix
+        data:
+          note: 'Attempting to patch this CVE via updating the affected module leads to resolution errors with other modules, therefore a patch from upstream is required to remediate this CVE. '


### PR DESCRIPTION
Advisories are based on the analysis in https://github.com/wolfi-dev/os/pull/37108#issuecomment-2545068467
I also validated the remediation attempt for GHSA-27wf-5967-98gx is not possible. 