### PR TITLE
spark-3.5-scala-2.13/GHSA-g2fg-mr77-6vrm advisory update

### DIFF
--- a/spark-3.5-scala-2.13.advisories.yaml
+++ b/spark-3.5-scala-2.13.advisories.yaml
@@ -872,6 +872,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/python3.13/site-packages/pyspark/jars/libthrift-0.12.0.jar
             scanner: grype
+      - timestamp: 2024-12-20T22:38:05Z
+        type: pending-upstream-fix
+        data:
+          note: 'The version of libthrift is not able to be upgraded from .12 to .16 which can be seen in this PR: https://github.com/apache/spark/pull/46468 due to version incompatibility with the parent dependency Hive, Spark-3.5 is only able to support I Hive 2.3.9. To remediate this libthrift CVE would require Hive 2.3.10 which needs to be implemented by upstream maintainers. Upstream is targeting this to be included in the Spark-4.0 release as seen here: https://issues.apache.org/jira/browse/SPARK-47018'
 
   - id: CGA-x64f-h9cm-wv76
     aliases:


### PR DESCRIPTION
## 1. **GHSA-g2fg-mr77-6vrm**
- **pending-upstream-fix:** The version of libthrift is not able to be upgraded from .12 to .16 which can be seen in this PR: https://github.com/apache/spark/pull/46468 due to version incompatibility with the parent dependency Hive, Spark-3.5 is only able to support I Hive 2.3.9. To remediate this libthrift CVE would require Hive 2.3.10 which needs to be implemented by upstream maintainers. Upstream is targeting this to be included in the Spark-4.0 release as seen here: https://issues.apache.org/jira/browse/SPARK-47018

