### PR TITLE
tileserver-gl/GHSA-rhx6-c78j-4q9w

### DIFF
--- a/tileserver-gl.advisories.yaml
+++ b/tileserver-gl.advisories.yaml
@@ -43,3 +43,7 @@ advisories:
             componentType: npm
             componentLocation: /usr/src/app/node_modules/path-to-regexp/package.json
             scanner: grype
+      - timestamp: 2024-12-26T20:01:21Z
+        type: pending-upstream-fix
+        data:
+          note: 'This CVE is not able to be remediated at this time as upgrading to path-to-regexp v0.1.12 introduces breaking changes. v0.1.12 is an attempt to fix backtracking (again) seen here: https://github.com/pillarjs/path-to-regexp/releases/tag/v0.1.12 this causes internal test failures that were remediated in v0.1.10: https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-9wv6-86v2-598j Upstream maintainers of tileserver-gl need to fix the regex used in their internal testing to remediate. '


### PR DESCRIPTION
This CVE is not able to be remediated at this time as upgrading to path-to-regexp v0.1.12 introduces breaking changes. v0.1.12 is an attempt to fix backtracking (again) [seen here ](https://github.com/pillarjs/path-to-regexp/releases/tag/v0.1.12)this causes internal test failures that [were remediated in v0.1.10](https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-9wv6-86v2-598j) Upstream maintainers of tileserver-gl need to fix the regex used in their internal testing to remediate. More information can be seen here: https://github.com/chainguard-dev/enterprise-packages/pull/11547