### PR TITLE
Advisory for zellij package: GHSA-c2f5-jxjv-2hh8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+.codegpt

--- a/zellij.advisories.yaml
+++ b/zellij.advisories.yaml
@@ -217,7 +217,7 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zellij
             scanner: grype
-      - timestamp: 2025-01-027T10:54:22Z
+      - timestamp: 2025-01-02T11:05:49Z
         type: false-positive-determination
         data:
           type: vulnerable-code-not-included-in-package

--- a/zellij.advisories.yaml
+++ b/zellij.advisories.yaml
@@ -217,6 +217,16 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zellij
             scanner: grype
+      - timestamp: 2025-01-027T10:54:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to the 'wasmtime' dependency, used by zellij.
+            This only affects windows. zellij does not support windows, and neither does our Chainguard package builds.
+            Upstream maintainers are working at upgrading this dependency in any event. Ref:
+             - https://github.com/advisories/GHSA-c2f5-jxjv-2hh8
+             - https://github.com/zellij-org/zellij/pull/3902#issuecomment-2565894058
 
   - id: CGA-wwr7-2chc-98v2
     aliases:


### PR DESCRIPTION
This vulnerability relates to the wasmtime dependency. A fixed version is available but upstream are yet to upgrade. This vulnerability only affects windows, which is indicated in:
- https://github.com/advisories/GHSA-c2f5-jxjv-2hh8

Neither zellij, nor ourselves support windows

-----------

**Close this PR once merged**: https://github.com/wolfi-dev/os/pull/35025
