### PR TITLE
wasmcloud package - pending-upstream-fix for GHSA-qg5g-gv98-5ffh

### DIFF
--- a/wasmcloud.advisories.yaml
+++ b/wasmcloud.advisories.yaml
@@ -168,7 +168,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: |
-            This vulnerability relates to the 'rustls' dependency.
             WasmCloud depends on several crates, which pin to rustls v0.21.x and v0.22.x streams.
             Upgrading rustls to v0.23.18 or later (to avail of this fix), is not possible without also upgrading these crates.
             Attempts at upgrading the upstream crates introduces a cycle of further version updates.

--- a/wasmcloud.advisories.yaml
+++ b/wasmcloud.advisories.yaml
@@ -164,6 +164,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/wasmcloud
             scanner: grype
+      - timestamp: 2025-01-03T00:24:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to the 'rustls' dependency.
+            WasmCloud depends on several crates, which pin to rustls v0.21.x and v0.22.x streams.
+            Upgrading rustls to v0.23.18 or later (to avail of this fix), is not possible without also upgrading these crates.
+            Attempts at upgrading the upstream crates introduces a cycle of further version updates.
 
   - id: CGA-qpj4-gwrp-pjfc
     aliases:


### PR DESCRIPTION
Add pending-upstream-fix advisory for wasmcloud package, related to the rustls versions in use. Re: GHSA-qg5g-gv98-5ffh.

-------------

This (attempted) CVE remediation PR needs to be closed after this advisory is merged: https://github.com/wolfi-dev/os/pull/35904