### PR TITLE
Parseable package: pending-upstream-fix advisory for: GHSA-qg5g-gv98-5ffh

### DIFF
--- a/parseable.advisories.yaml
+++ b/parseable.advisories.yaml
@@ -85,6 +85,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/parseable
             scanner: grype
+      - timestamp: 2025-01-03T00:50:58Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Parseable depends on several crates, which pin to rustls v0.21.x and v0.22.x streams.
+            Upgrading rustls to v0.23.18 or later (to avail of this fix), is not possible without also upgrading these crates.
+            Attempts at upgrading the upstream crates introduces a cycle of further version updates.
 
   - id: CGA-jhg5-22p5-x752
     aliases:


### PR DESCRIPTION
Parseable package: pending-upstream-fix advisory for: GHSA-qg5g-gv98-5ffh. See advisory description for more details.

------------

_**This (attempted) CVE remediation PR needs to be closed after this advisory is merged: https://github.com/wolfi-dev/os/pull/35218**_