### PR TITLE
feat(advisory): dotty pending-upstream-fix for GHSA-rgv9-q543-rqg4

### DIFF
--- a/dotty.advisories.yaml
+++ b/dotty.advisories.yaml
@@ -211,6 +211,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/scala/bin/scala-cli.jar
             scanner: grype
+      - timestamp: 2025-01-03T17:37:51Z
+        type: pending-upstream-fix
+        data:
+          note: CVE is present in /usr/share/scala/bin/scala-cli.jar which is downloaded during build from https://github.com/VirtusLab/scala-cli/releases. It is not a direct dependency so we must wait for both github.com/VirtusLab/scala-cli to update and release and then github.com/scala/scala3 to consume this new scala-cli release.
 
   - id: CGA-vp72-9pp9-434m
     aliases:


### PR DESCRIPTION
> CVE is present in /usr/share/scala/bin/scala-cli.jar which is downloaded during build from https://github.com/VirtusLab/scala-cli/releases. It is not a direct dependency so we must wait for both github.com/VirtusLab/scala-cli to update and release and then github.com/scala/scala3 to consume this new scala-cli release.

Signed-off-by: philroche <phil.roche@chainguard.dev>
