### PR TITLE
feat(advisory): dotty pending-upstream-fix for GHSA-jjjh-jjxp-wpff, GHSA-735f-pc8j-v9w8, GHSA-8wh2-6qhj-h7j9 and GHSA-7r82-7xv7-xcpj

### DIFF
--- a/dotty.advisories.yaml
+++ b/dotty.advisories.yaml
@@ -109,6 +109,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/scala/bin/scala-cli.jar
             scanner: grype
+      - timestamp: 2025-01-03T18:16:51Z
+        type: pending-upstream-fix
+        data:
+          note: CVE is present in /usr/share/scala/bin/scala-cli.jar which is downloaded during build from https://github.com/VirtusLab/scala-cli/releases. It is not a direct dependency so we must wait for both github.com/VirtusLab/scala-cli to update and release and then github.com/scala/scala3 to consume this new scala-cli release.
 
   - id: CGA-8qcm-chp8-h5q8
     aliases:
@@ -127,6 +131,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/scala/bin/scala-cli.jar
             scanner: grype
+      - timestamp: 2025-01-03T18:16:51Z
+        type: pending-upstream-fix
+        data:
+          note: CVE is present in /usr/share/scala/bin/scala-cli.jar which is downloaded during build from https://github.com/VirtusLab/scala-cli/releases. It is not a direct dependency so we must wait for both github.com/VirtusLab/scala-cli to update and release and then github.com/scala/scala3 to consume this new scala-cli release.
 
   - id: CGA-g664-j68v-pmw2
     aliases:
@@ -229,6 +237,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/scala/bin/scala-cli.jar
             scanner: grype
+      - timestamp: 2025-01-03T18:16:51Z
+        type: pending-upstream-fix
+        data:
+          note: CVE is present in /usr/share/scala/bin/scala-cli.jar which is downloaded during build from https://github.com/VirtusLab/scala-cli/releases. It is not a direct dependency so we must wait for both github.com/VirtusLab/scala-cli to update and release and then github.com/scala/scala3 to consume this new scala-cli release.
 
   - id: CGA-vrf9-252r-qxvx
     aliases:
@@ -247,6 +259,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/scala/bin/scala-cli.jar
             scanner: grype
+      - timestamp: 2025-01-03T18:16:51Z
+        type: pending-upstream-fix
+        data:
+          note: CVE is present in /usr/share/scala/bin/scala-cli.jar which is downloaded during build from https://github.com/VirtusLab/scala-cli/releases. It is not a direct dependency so we must wait for both github.com/VirtusLab/scala-cli to update and release and then github.com/scala/scala3 to consume this new scala-cli release.
 
   - id: CGA-whvj-j3x7-6cwh
     aliases:


### PR DESCRIPTION
> CVE is present in /usr/share/scala/bin/scala-cli.jar which is downloaded during build from https://github.com/VirtusLab/scala-cli/releases. It is not a direct dependency so we must wait for both github.com/VirtusLab/scala-cli to update and release and then github.com/scala/scala3 to consume this new scala-cli release.

Signed-off-by: philroche <phil.roche@chainguard.dev>
