### PR TITLE
Add advisories for wash package: GHSA-h97m-ww89-6jmq, GHSA-g98v-hv3f-hcfr

### DIFF
--- a/wash.advisories.yaml
+++ b/wash.advisories.yaml
@@ -43,6 +43,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/wash
             scanner: grype
+      - timestamp: 2025-01-04T22:48:02Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to the 'idna' dependency. A fix is available in v1.0.0 and later.
+            Multiple crates used by this project depend on older versions of 'idna'.
+            Attempts to upgrade 'idna' to v1.0.0, and related dependencies were not successful. Waiting for fix from upstream.
 
   - id: CGA-8jhv-f5ch-84pg
     aliases:

--- a/wash.advisories.yaml
+++ b/wash.advisories.yaml
@@ -208,6 +208,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/wash
             scanner: grype
+      - timestamp: 2025-01-04T23:00:12Z
+        type: fix-not-planned
+        data:
+          note: On windows, atty dereferences a potentially unaligned pointer.  In practice however, the pointer won't be unaligned unless a custom global allocator is used. However the atty package seems to be unmaintained.
 
   - id: CGA-x6r2-g5c2-44p2
     aliases:


### PR DESCRIPTION
1. Add pending-upstream-fix advisory for GHSA-h97m-ww89-6jmq, which relates to the idna crate used by the wash package.

2. Add fix-not-planned for GHSA-g98v-hv3f-hcfr. We've already multiple packages with the same advisory, this was largely a copy/paste here, as is also applicable to wash.



