### PR TITLE
pending-upstream-fix advisory for xh package: GHSA-h97m-ww89-6jmq

### DIFF
--- a/xh.advisories.yaml
+++ b/xh.advisories.yaml
@@ -42,6 +42,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/xh
             scanner: grype
+      - timestamp: 2025-01-05T01:19:39Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This CVE relates to THE 'idna' dependency, and a fix is available in v1.0.0 and later.
+            There are multiple crates in this project depending on multiple versions of 'idna'.
+            Attempting to upgrade the oldest 'idna' crate, as well as dependent packages, results in build failures.
+            Pending fix from upstream.
 
   - id: CGA-6x75-6gj7-pp2r
     aliases:


### PR DESCRIPTION
Raising `pending-upstream-fix` advisory for GHSA-h97m-ww89-6jmq, related to the `idna` crate. The xh package has multiple dependencies that rrquire different versions of idna.

Attempts at upgrading the oldest (to remediate this CVE), result in additional dependencies needing upgraded (such as cookie_store). Attempting to upgrade those results in similar dependency issues. Will require a fix from upstream.