### PR TITLE
`pending-upstream-fix` advisory for `samply` package: GHSA-h97m-ww89-6jmq

### DIFF
--- a/samply.advisories.yaml
+++ b/samply.advisories.yaml
@@ -21,6 +21,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/samply
             scanner: grype
+      - timestamp: 2025-01-05T01:51:42Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to the 'idna' dependency, and is fixed in v1.0.0 and later.
+            Attempts to upgrade 'idna' have failed, as there are multiple dependencies requiring different versions of `idna`.
+            For example, the 'url' requires idna v0.5.0, and upgrading 'url' to a newer version, results in further compatibility issues with 'reqwest'.
+            Pending fix from upstream.
 
   - id: CGA-mx8x-g2gv-8xrq
     aliases:

--- a/samply.advisories.yaml
+++ b/samply.advisories.yaml
@@ -27,7 +27,7 @@ advisories:
           note: |
             This vulnerability relates to the 'idna' dependency, and is fixed in v1.0.0 and later.
             Attempts to upgrade 'idna' have failed, as there are multiple dependencies requiring different versions of `idna`.
-            For example, the 'url' requires idna v0.5.0, and upgrading 'url' to a newer version, results in further compatibility issues with 'reqwest'.
+            For example, 'url' requires idna v0.5.0 - upgrading 'url' to a newer version, results in compatibility issues with 'reqwest'.
             Pending fix from upstream.
 
   - id: CGA-mx8x-g2gv-8xrq


### PR DESCRIPTION
`pending-upstream-fix` advisory for `samply` package: GHSA-h97m-ww89-6jmq.

Attempts to upgrade  the 'idna' dependency have failed, as there are multiple dependencies requiring different versions of idna.