### PR TITLE
`pending-upstream-fix` advisory for `convco` package: GHSA-h97m-ww89-6jmq

### DIFF
--- a/convco.advisories.yaml
+++ b/convco.advisories.yaml
@@ -21,3 +21,11 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/convco
             scanner: grype
+      - timestamp: 2025-01-05T02:08:01Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to the 'idna' dependency, and is fixed in v1.0.0 and later.
+            Attempts to upgrade 'idna' have failed, as there are multiple dependencies requiring different versions of `idna`.
+            One such example is 'url'. Attempts to upgrade 'url' to a version compatible with idna v1.0.0 result in additional build failures.
+            Pending fix from upstream.


### PR DESCRIPTION
`pending-upstream-fix` advisory for convco package, related to the idna dependency, re: GHSA-h97m-ww89-6jmq.

There are multiple dependencies on different versions of idna. Attempting to upgrade idna causes build issues. Attempts to upgrade those dependencies to newer versions compatible with v1.0.0 of idna, results in additional failures.