### PR TITLE
parseable: GHSA-h97m-ww89-6jmq

### DIFF
--- a/parseable.advisories.yaml
+++ b/parseable.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/parseable
             scanner: grype
+      - timestamp: 2025-01-05T10:15:50Z
+        type: pending-upstream-fix
+        data:
+          note: '''validator'' and ''openid'' transitive dependencies already on their latest version and pinned idna@0.5.0. Awaiting upstream dependencies to bump the idna to version 1.'
 
   - id: CGA-6r5w-wwq4-cx4v
     aliases:


### PR DESCRIPTION
PR ref: https://github.com/wolfi-dev/os/pull/38757

I think we can't mitigate this since its deps already on their latest version:
```
$ cargo tree -i idna@0.5.0

idna v0.5.0
└── validator v0.18.1
    └── openid v0.15.0
        └── parseable v1.6.3
```

Also tried this but no luck: (0.5.0 was hard requirement by transitive deps)

```
$ cargo update idna@0.5.0 --precise 1.0.3

    Updating crates.io index
error: failed to select a version for the requirement `idna = "^0.5"`
candidate versions found which didn't match: 1.0.3
location searched: crates.io index
required by package `validator v0.18.1`
    ... which satisfies dependency `validator = "^0.18"` (locked to 0.18.1) of package `openid v0.15.0`
    ... which satisfies dependency `openid = "^0.15.0"` (locked to 0.15.0) of package `parseable v1.6.3 (/home/user/parseable)`
```

Advisory might be needed.