### PR TITLE
pending-upstream-fix advisory for tealdeer package: GHSA-h97m-ww89-6jmq

### DIFF
--- a/tealdeer.advisories.yaml
+++ b/tealdeer.advisories.yaml
@@ -21,6 +21,14 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/tldr
             scanner: grype
+      - timestamp: 2025-01-05T12:31:11Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to the 'idna' dependency, and is fixed in v1.0.0 and later.
+            Attempts to upgrade 'idna' have failed, as there are multiple dependencies requiring different versions of `idna`.
+            For example, the 'url' requires idna v0.5.0, and upgrading 'url' to a newer version, results in further compatibility issues with 'reqwest'.
+            Pending fix from upstream.
 
   - id: CGA-9484-g85q-227p
     aliases:


### PR DESCRIPTION
pending-upstream-fix advisory for tealdeer package, related to idna package, re: GHSA-h97m-ww89-6jmq