### PR TITLE
kubernetes-1.32: GHSA-c5q2-7r4c-mv6g pending upstream fix advisory update

### DIFF
--- a/kubernetes-1.32.advisories.yaml
+++ b/kubernetes-1.32.advisories.yaml
@@ -39,6 +39,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kube-controller-manager-1.32
             scanner: grype
+      - timestamp: 2025-01-06T13:36:44Z
+        type: pending-upstream-fix
+        data:
+          note: https://github.com/square/go-jose is deprecated, replaced with https://github.com/go-jose/go-jose. This dependency cannot be easily replaced without upstream changes due to interface requirements.
 
   - id: CGA-4g7j-5h2f-mg5h
     aliases:


### PR DESCRIPTION
Advisory update for kubernetes-1.32 for deprecated go-jose package. 