### PR TITLE
feat(advisory): kubeflow-pipelines-visualization-server pending upstream fix for jinja2 CVE GHSA-q2x7-8rv6-6q7h and GHSA-gmj6-6f8f-6699

### DIFF
--- a/kubeflow-pipelines-visualization-server.advisories.yaml
+++ b/kubeflow-pipelines-visualization-server.advisories.yaml
@@ -279,6 +279,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/Jinja2-2.11.3.dist-info/METADATA, /usr/lib/python3.10/site-packages/Jinja2-2.11.3.dist-info/RECORD, /usr/lib/python3.10/site-packages/Jinja2-2.11.3.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2025-01-07T12:58:57Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability is in the jinja2 package which is not a direct dependency. Attempting to upgrade jinja2 one major version to 3.1.5 to remediate the CVE results in multiple other packages needing updates: bokeh, Markupsafe, nbconvert ...- all requiring major version bumps. The result is multiple failures in itegration test due to failed python imports. As such - bumping major versions like this is a risk to functionality so I am marking this as pending-upstream-fix'
 
   - id: CGA-cwvc-2mhw-gmxh
     aliases:
@@ -744,6 +748,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/Jinja2-2.11.3.dist-info/METADATA, /usr/lib/python3.10/site-packages/Jinja2-2.11.3.dist-info/RECORD, /usr/lib/python3.10/site-packages/Jinja2-2.11.3.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2025-01-07T14:16:40Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability is in the jinja2 package which is not a direct dependency. Attempting to upgrade jinja2 one major version to 3.1.5 to remediate the CVE results in multiple other packages needing updates: bokeh, Markupsafe, nbconvert ...- all requiring major version bumps. The result is multiple failures in itegration test due to failed python imports. As such - bumping major versions like this is a risk to functionality so I am marking this as pending-upstream-fix'
 
   - id: CGA-xm82-6r9q-w4j8
     aliases:


### PR DESCRIPTION
Unable to remediate without risk to functionality

> The vulnerability is in the jinja2 package which is not a direct dependency. Attempting to upgrade jinja2 one major version to 3.1.5 to remediate the CVE results in multiple other packages needing updates: bokeh, Markupsafe, nbconvert ...- all requiring major version bumps. The result is multiple failures in itegration test due to failed python imports. As such - bumping major versions like this is a risk to functionality so I am marking this as pending-upstream-fix

Signed-off-by: philroche <phil.roche@chainguard.dev>
