### PR TITLE
advisories for pgadmin4-17

### DIFF
--- a/pgadmin4-17.advisories.yaml
+++ b/pgadmin4-17.advisories.yaml
@@ -9,72 +9,47 @@ advisories:
       - CVE-2022-25881
       - GHSA-rc47-6667-2j5j
     events:
-      - timestamp: 2025-01-08T15:59:08Z
-        type: detection
+      - timestamp: 2025-01-08T16:28:37Z
+        type: pending-upstream-fix
         data:
-          type: manual
-      - timestamp: 2025-01-08T16:18:05Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Package.json for the node_module is not part of upstream repo. This is not easily fixed since it is 4th level node dependency
+          note: /pgadmin4/web/node_modules/bin-wrapper/node_modules/got/package.json is not part of upstream repo. This is not easily fixed, since it is 4th level node dependency
 
   - id: CGA-3w74-99f8-qmqq
     aliases:
       - CVE-2022-33987
       - GHSA-pfrx-2q88-qq97
     events:
-      - timestamp: 2025-01-08T15:57:19Z
-        type: detection
+      - timestamp: 2025-01-08T16:39:41Z
+        type: pending-upstream-fix
         data:
-          type: manual
-      - timestamp: 2025-01-08T16:12:47Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Package.json for the node_module is not part of upstream repo. This is not easily fixed since it is 4th level node dependency
+          note: /pgadmin4/web/node_modules/bin-wrapper/node_modules/http-cache-semantics/package.json is not part of upstream repo. This is not easily fixed, since it is 4th level node dependency.
 
   - id: CGA-54w5-w6mm-rmfh
     aliases:
       - CVE-2021-3795
       - GHSA-44c6-4v22-4mhx
     events:
-      - timestamp: 2025-01-08T16:00:58Z
-        type: detection
+      - timestamp: 2025-01-08T16:42:35Z
+        type: pending-upstream-fix
         data:
-          type: manual
-      - timestamp: 2025-01-08T16:20:45Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Package.json for the node_module is not part of upstream repo. This is not easily fixed since it is 4th level node dependency
+          note: /pgadmin4/web/node_modules/find-versions/node_modules/semver-regex/package.json is not present in upstream repo. This is not easily fixed, since it is 4th level node dependency
 
   - id: CGA-85r4-j7j3-wvjr
     aliases:
       - CVE-2021-43307
       - GHSA-4x5v-gmq8-25ch
     events:
-      - timestamp: 2025-01-08T16:01:18Z
-        type: detection
+      - timestamp: 2025-01-08T16:43:40Z
+        type: pending-upstream-fix
         data:
-          type: manual
-      - timestamp: 2025-01-08T16:21:16Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Package.json for the node_module is not part of upstream repo. This is not easily fixed since it is 4th level node dependency
+          note: /pgadmin4/web/node_modules/find-versions/node_modules/semver-regex/package.json is not present in upstream repo. This is not easily fixed, since it is 4th level node dependency
 
   - id: CGA-jq87-w9cc-867m
     aliases:
       - CVE-2024-21538
       - GHSA-3xgq-45jj-v275
     events:
-      - timestamp: 2025-01-08T16:00:27Z
-        type: detection
+      - timestamp: 2025-01-08T16:41:16Z
+        type: pending-upstream-fix
         data:
-          type: manual
-      - timestamp: 2025-01-08T16:19:01Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Package.json for the node_module is not part of upstream repo. This is not easily fixed since it is 4th level node dependency
+          note: /pgadmin4/web/node_modules/execa/node_modules/cross-spawn/package.json is not present in upstream repo. This is not easily fixed, since it is 4th level node dependency

--- a/pgadmin4-17.advisories.yaml
+++ b/pgadmin4-17.advisories.yaml
@@ -1,0 +1,55 @@
+schema-version: 2.0.2
+
+package:
+  name: pgadmin4-17
+
+advisories:
+  - id: CGA-3452-24wq-2pm3
+    aliases:
+      - CVE-2022-25881
+      - GHSA-rc47-6667-2j5j
+    events:
+      - timestamp: 2025-01-08T15:59:08Z
+        type: detection
+        data:
+          type: manual
+
+  - id: CGA-3w74-99f8-qmqq
+    aliases:
+      - CVE-2022-33987
+      - GHSA-pfrx-2q88-qq97
+    events:
+      - timestamp: 2025-01-08T15:57:19Z
+        type: detection
+        data:
+          type: manual
+
+  - id: CGA-54w5-w6mm-rmfh
+    aliases:
+      - CVE-2021-3795
+      - GHSA-44c6-4v22-4mhx
+    events:
+      - timestamp: 2025-01-08T16:00:58Z
+        type: detection
+        data:
+          type: manual
+
+  - id: CGA-85r4-j7j3-wvjr
+    aliases:
+      - CVE-2021-43307
+      - GHSA-4x5v-gmq8-25ch
+    events:
+      - timestamp: 2025-01-08T16:01:18Z
+        type: detection
+        data:
+          type: manual
+
+  - id: CGA-jq87-w9cc-867m
+    aliases:
+      - CVE-2024-21538
+      - GHSA-3xgq-45jj-v275
+    events:
+      - timestamp: 2025-01-08T16:00:27Z
+        type: detection
+        data:
+          type: manual

--- a/pgadmin4-17.advisories.yaml
+++ b/pgadmin4-17.advisories.yaml
@@ -13,6 +13,11 @@ advisories:
         type: detection
         data:
           type: manual
+      - timestamp: 2025-01-08T16:18:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Package.json for the node_module is not part of upstream repo. This is not easily fixed since it is 4th level node dependency
 
   - id: CGA-3w74-99f8-qmqq
     aliases:
@@ -23,6 +28,11 @@ advisories:
         type: detection
         data:
           type: manual
+      - timestamp: 2025-01-08T16:12:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Package.json for the node_module is not part of upstream repo. This is not easily fixed since it is 4th level node dependency
 
   - id: CGA-54w5-w6mm-rmfh
     aliases:
@@ -33,6 +43,11 @@ advisories:
         type: detection
         data:
           type: manual
+      - timestamp: 2025-01-08T16:20:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Package.json for the node_module is not part of upstream repo. This is not easily fixed since it is 4th level node dependency
 
   - id: CGA-85r4-j7j3-wvjr
     aliases:
@@ -43,6 +58,11 @@ advisories:
         type: detection
         data:
           type: manual
+      - timestamp: 2025-01-08T16:21:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Package.json for the node_module is not part of upstream repo. This is not easily fixed since it is 4th level node dependency
 
   - id: CGA-jq87-w9cc-867m
     aliases:
@@ -53,3 +73,8 @@ advisories:
         type: detection
         data:
           type: manual
+      - timestamp: 2025-01-08T16:19:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Package.json for the node_module is not part of upstream repo. This is not easily fixed since it is 4th level node dependency


### PR DESCRIPTION
- These CVEs come from `node_modules` not present in the upstream repo and are 4th level node dependency.