### PR TITLE
Advisories for flyway-11.1.1

### DIFF
--- a/flyway.advisories.yaml
+++ b/flyway.advisories.yaml
@@ -1,0 +1,35 @@
+schema-version: 2.0.2
+
+package:
+  name: flyway
+
+advisories:
+  - id: CGA-jhcq-22wf-r4wv
+    aliases:
+      - CVE-2020-8908
+      - GHSA-5mg8-w23w-74h3
+    events:
+      - timestamp: 2025-01-09T00:02:01Z
+        type: pending-upstream-fix
+        data:
+          note: guava-31.1-jre.jar is not part of upstream repo. It is a transitive dependendcy of /flyway/drivers/databricks-jdbc-2.6.40.jar. This is not easily fixed as databricks-jdbc is closed source.
+
+  - id: CGA-ww3c-v2pw-2hr3
+    aliases:
+      - CVE-2024-47535
+      - GHSA-xq3w-v528-46rv
+    events:
+      - timestamp: 2025-01-09T00:05:31Z
+        type: pending-upstream-fix
+        data:
+          note: netty-common-4.1.86.Final.jar is not part of upstream repo. It is a transitive dependendcy of /flyway/drivers/databricks-jdbc-2.6.40.jar. This is not easily fixed as databricks-jdbc is closed source.
+
+  - id: CGA-wwr8-cf96-jh4v
+    aliases:
+      - CVE-2023-2976
+      - GHSA-7g45-4rm6-3mm3
+    events:
+      - timestamp: 2025-01-09T00:04:11Z
+        type: pending-upstream-fix
+        data:
+          note: guava-31.1-jre.jar is not part of upstream repo. It is a transitive dependendcy of /flyway/drivers/databricks-jdbc-2.6.40.jar. This is not easily fixed as databricks-jdbc is closed source.


### PR DESCRIPTION
These CVEs come from `guava-31.1-jre.jar` and `netty-common-4.1.86.Final.jar`, which are not present in the upstream repo. They are transitive dependencies of the parent dependency `databricks-jdbc-2.6.40.jar`, which is closed source from databricks.