### PR TITLE
Vitess-20/GHSA-3xgq-45jj-v275

### DIFF
--- a/vitess-20.0.advisories.yaml
+++ b/vitess-20.0.advisories.yaml
@@ -148,6 +148,10 @@ advisories:
             componentType: npm
             componentLocation: /vt/web/vtadmin/node_modules/cross-spawn/package.json
             scanner: grype
+      - timestamp: 2025-01-09T15:49:09Z
+        type: pending-upstream-fix
+        data:
+          note: The cross-spawn dependency causing this CVE is brought in by npm as a transitive dependency and will need to be updated by upstream maintainers
 
   - id: CGA-rvgq-23g5-3qh3
     aliases:


### PR DESCRIPTION
The cross-spawn dependency causing this CVE is brought in by npm as a transitive dependency and will need to be updated by upstream maintainers