### PR TITLE
Added pending upstream fix events for dependency-track GHSA-6v67-2wr5-gvf4 and GHSA-pr98-23f8-jwxv

### DIFF
--- a/dependency-track.advisories.yaml
+++ b/dependency-track.advisories.yaml
@@ -98,6 +98,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/dependency-track/dependency-track-bundled.jar
             scanner: grype
+      - timestamp: 2025-01-09T20:40:08Z
+        type: pending-upstream-fix
+        data:
+          note: This is a transitive dependency brought in by us.springett:alpine-server, which has already been updated to the latest version. Therefore, upstream maintainers must release a fix to remediate this CVE.
 
   - id: CGA-jxr7-jj8p-xpfm
     aliases:
@@ -116,6 +120,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/dependency-track/dependency-track-bundled.jar
             scanner: grype
+      - timestamp: 2025-01-09T20:37:49Z
+        type: pending-upstream-fix
+        data:
+          note: This is a transitive dependency brought in by us.springett:alpine-server, which has already been updated to the latest version. Therefore, upstream maintainers must release a fix to remediate this CVE.
 
   - id: CGA-ppj7-32h7-rr4m
     aliases:


### PR DESCRIPTION
https://github.com/chainguard-dev/CVE-Dashboard/issues/17848
https://github.com/chainguard-dev/CVE-Dashboard/issues/17829