### PR TITLE
Added pending-upstream-fix advisories for argocd-image-updater-fips CVEs

### DIFF
--- a/argocd-image-updater.advisories.yaml
+++ b/argocd-image-updater.advisories.yaml
@@ -101,6 +101,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argocd-image-updater
             scanner: grype
+      - timestamp: 2025-01-10T20:09:22Z
+        type: pending-upstream-fix
+        data:
+          note: Attempting to patch this CVE via updating the affected module leads to resolution errors with other modules, therefore a patch from upstream is required to remediate this CVE.
 
   - id: CGA-fghq-cmj5-4jgc
     aliases:
@@ -119,6 +123,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argocd-image-updater
             scanner: grype
+      - timestamp: 2025-01-10T20:09:31Z
+        type: pending-upstream-fix
+        data:
+          note: Attempting to patch this CVE via updating the affected module leads to resolution errors with other modules, therefore a patch from upstream is required to remediate this CVE.
 
   - id: CGA-hrx6-hvq8-xj45
     aliases:
@@ -137,6 +145,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argocd-image-updater
             scanner: grype
+      - timestamp: 2025-01-10T20:07:00Z
+        type: pending-upstream-fix
+        data:
+          note: Attempting to patch this CVE via updating the affected module leads to resolution errors with other modules, therefore a patch from upstream is required to remediate this CVE.
 
   - id: CGA-pv28-fqqh-4xj7
     aliases:


### PR DESCRIPTION
https://github.com/chainguard-dev/CVE-Dashboard/issues/17922
https://github.com/chainguard-dev/CVE-Dashboard/issues/17923
https://github.com/chainguard-dev/CVE-Dashboard/issues/17925