### PR TITLE
percona-server-9/CVE-2020-26542 advisory update

### DIFF
--- a/percona-server-9.0.advisories.yaml
+++ b/percona-server-9.0.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-01-12T00:22:13Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'CVE-2020-26542 impacts Distribution for MySQL 8.0.20 specifically when using Percona XtraDB Cluster, this vulnerability impacts a version (8.0.20) not used here and was resolved on 2020-10-22 as seen here: https://docs.percona.com/percona-distribution-for-mysql/8.0/release-notes-pxc-v8.0.20.upd2.html '
 
   - id: CGA-w4hw-wmrf-r7rf
     aliases:


### PR DESCRIPTION
## 1. **[CVE-2020-26542](https://github.com/chainguard-dev/CVE-Dashboard/issues/16395)**
- **false-positive-determination/component-vulnerability-mismatch:** [CVE-2020-26542](https://github.com/chainguard-dev/CVE-Dashboard/issues/16395) impacts Distribution for MySQL 8.0.20 specifically when using Percona XtraDB Cluster, this vulnerability impacts a version (8.0.20) not used here and was resolved on 2020-10-22 as seen here: https://docs.percona.com/percona-distribution-for-mysql/8.0/release-notes-pxc-v8.0.20.upd2.html