### PR TITLE
percona-server-9.0/CVE-2021-27928 advisory update

### DIFF
--- a/percona-server-9.0.advisories.yaml
+++ b/percona-server-9.0.advisories.yaml
@@ -39,3 +39,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-01-12T00:40:30Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'CVE-2021-27928 impacts Distribution for MySQL only up to and including v8.0.28-19 and never existed in the major version 9 releases. This can be seen in the lack of cpe matching for version 9 in the NVD: https://nvd.nist.gov/vuln/detail/CVE-2021-27928#range-15316870. As well as the fact that it was remediated in March of 2021 which is before the release of the v9 version stream.'


### PR DESCRIPTION
## 1. **component-vulnerability-mismatch**
- **false-positive-determination/component-vulnerability-mismatch:**
CVE-2021-27928 impacts Distribution for MySQL only up to and including v8.0.28-19 and never existed in the major version 9 releases. This can be seen in the lack of cpe matching for version 9 in the NVD: https://nvd.nist.gov/vuln/detail/CVE-2021-27928#range-15316870. As well as the fact that it was remediated in March of 2021 which is before the release of the v9 version stream.