### PR TITLE
zookeeper-3.9/GHSA-6v67-2wr5-gvf4/GHSA-pr98-23f8-jwxv advisory update

### DIFF
--- a/zookeeper-3.9.advisories.yaml
+++ b/zookeeper-3.9.advisories.yaml
@@ -62,6 +62,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/zookeeper/lib/logback-core-1.2.13.jar
             scanner: grype
+      - timestamp: 2025-01-12T21:32:21Z
+        type: pending-upstream-fix
+        data:
+          note: 'While there is a fix that exists upstream in main, the maintainers have deliberately prevented this from being implemented in the current release and are holding it for 3.10.0 as seen here in the conversation: https://github.com/apache/zookeeper/pull/2162#issuecomment-2092233436 and the fix versions in apache’s project page being v3.10.0: https://issues.apache.org/jira/browse/ZOOKEEPER-4831'
 
   - id: CGA-c8xx-wqr2-vpgm
     aliases:

--- a/zookeeper-3.9.advisories.yaml
+++ b/zookeeper-3.9.advisories.yaml
@@ -124,6 +124,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/zookeeper/lib/logback-core-1.2.13.jar
             scanner: grype
+      - timestamp: 2025-01-12T21:28:32Z
+        type: pending-upstream-fix
+        data:
+          note: 'While there is a fix that exists upstream in main, the maintainers have deliberately prevented this from being implemented in the current release and are holding it for 3.10.0 as seen here in the conversation: https://github.com/apache/zookeeper/pull/2162#issuecomment-2092233436 and the fix versions in apache’s project page being v3.10.0: https://issues.apache.org/jira/browse/ZOOKEEPER-4831'
 
   - id: CGA-p5qq-x3qc-jpwx
     aliases:


### PR DESCRIPTION
## 1. **GHSA-6v67-2wr5-gvf4/GHSA-pr98-23f8-jwxv**
- **pending-upstream-fix:**
While there is a fix that exists upstream in main, the maintainers have deliberately prevented this from being implemented in the current release and are holding it for 3.10.0 as seen here in the conversation: https://github.com/apache/zookeeper/pull/2162#issuecomment-2092233436 and the fix versions in apache’s project page being v3.10.0: https://issues.apache.org/jira/browse/ZOOKEEPER-4831