### PR TITLE
Added pending-upstream-fix advisory event for apache-tika-3.0 GHSA-qh8g-58pp-2wxh

### DIFF
--- a/apache-tika-3.0.advisories.yaml
+++ b/apache-tika-3.0.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tika-server-standard-3.0.0.jar
             scanner: grype
+      - timestamp: 2025-01-13T20:51:48Z
+        type: pending-upstream-fix
+        data:
+          note: 'Attempting to patch this CVE leads to build failures, and will require an update from upstream maintainers to remediate. '


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/38403#issuecomment-2588179614
https://github.com/chainguard-dev/CVE-Dashboard/issues/18046