### PR TITLE
Added pending-upstream-fix advisory event for apache-pulsar GHSA-qh8g-58pp-2wxh

### DIFF
--- a/apache-pulsar.advisories.yaml
+++ b/apache-pulsar.advisories.yaml
@@ -47,3 +47,7 @@ advisories:
         type: pending-upstream-fix
         data:
           note: The fix version of jetty-http is >=12.0.12, requiring a large refactor; there is an issue tracking the effort https://github.com/apache/pulsar/issues/22939
+      - timestamp: 2025-01-13T21:22:02Z
+        type: pending-upstream-fix
+        data:
+          note: Attempting to patch this CVE leads to build failures, and will require an update from upstream maintainers to remediate.


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/37371