### PR TITLE
trino/CVE-2024-34156,CVE-2024-34158,CVE-2024-34155 advisory updates

### DIFF
--- a/trino.advisories.yaml
+++ b/trino.advisories.yaml
@@ -275,6 +275,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/lib/trino/bin/darwin-amd64/launcher
             scanner: grype
+      - timestamp: 2025-01-15T08:45:12Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE is brought in as a transitive dependency under darwin-amd64 which is defined in the package-json.lock and is unable to be remediated, upstream maintainers will be required to implement the required fix.
 
   - id: CGA-7435-52pf-xmp5
     aliases:
@@ -469,6 +473,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/lib/trino/bin/darwin-amd64/launcher
             scanner: grype
+      - timestamp: 2025-01-15T08:45:59Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE is brought in as a transitive dependency under darwin-amd64 which is defined in the package-json.lock and is unable to be remediated, upstream maintainers will be required to implement the required fix.
 
   - id: CGA-cgcj-87rj-g4qm
     aliases:
@@ -487,6 +495,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/lib/trino/bin/darwin-amd64/launcher
             scanner: grype
+      - timestamp: 2025-01-15T08:47:00Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE is brought in as a transitive dependency under darwin-amd64 which is defined in the package-json.lock and is unable to be remediated, upstream maintainers will be required to implement the required fix.
 
   - id: CGA-cvrj-h7rr-r975
     aliases:


### PR DESCRIPTION
## 1. **CVE-2024-34156,CVE-2024-34158,CVE-2024-34155**
- **pending-upstream-fix:** This CVE is brought in as a transitive dependency under darwin-amd64 which is defined in the package-json.lock and is unable to be remediated, upstream maintainers will be required to implement the required fix.
