### PR TITLE
py3-docker/CVE-2024-36621/CVE-2024-36623

### DIFF
--- a/py3-docker.advisories.yaml
+++ b/py3-docker.advisories.yaml
@@ -113,6 +113,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-01-15T11:35:05Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This affects the Docker Engine. The package is a client api and does not have the vulnerability in question.
 
   - id: CGA-jf7q-rjm5-7whg
     aliases:
@@ -223,6 +228,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-01-15T11:36:11Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This affects the Docker Engine. The package is a client api and does not have the vulnerability in question.
 
   - id: CGA-wqv7-w84w-3758
     aliases:


### PR DESCRIPTION
## 1. **CVE-2024-36621/CVE-2024-36623**
- **false-positive-determination:** 
    -  component-vulnerability-mismatch:
       The issue regarding disintegration/imaging v1.6.2 where the index of the scan function in scanner.go can go out of bounds has an open PR https://github.com/disintegration/imaging/issues/165 but no implanted fix yet. While the project has not been updated in a long time as seen here: https://github.com/wolfi-dev/advisories/pull/9300#issuecomment-2517650044 there is no definitive evidence that it is unsupported or archived and thus is
This is reflected in many other advisories, This affects the Docker Engine.(Moby) The package is a client api and does not have the vulnerability in question.