### PR TITLE
Various shaded spark-3.5-scala-2.1x jar advisory updates

### DIFF
--- a/spark-3.5-scala-2.12.advisories.yaml
+++ b/spark-3.5-scala-2.12.advisories.yaml
@@ -131,6 +131,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/logback-core-1.2.13.jar
             scanner: grype
+      - timestamp: 2025-01-15T12:18:35Z
+        type: pending-upstream-fix
+        data:
+          note: This logback-core dependency is brought in as a transitive dependency. These transitive dependencies from are not able to be upgraded to a higher version and require upstream maintainers to implement.
 
   - id: CGA-99gr-gpgq-pcr9
     aliases:
@@ -193,6 +197,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/logback-core-1.2.13.jar
             scanner: grype
+      - timestamp: 2025-01-15T12:18:02Z
+        type: pending-upstream-fix
+        data:
+          note: This logback-core dependency is brought in as a transitive dependency. These transitive dependencies from are not able to be upgraded to a higher version and require upstream maintainers to implement.
 
   - id: CGA-chqv-p463-57p4
     aliases:
@@ -610,6 +618,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hadoop-client-runtime-3.3.6.jar
             scanner: grype
+      - timestamp: 2025-01-15T12:16:25Z
+        type: pending-upstream-fix
+        data:
+          note: 'This dnsjava dependency is brought in as a transitive dependency via hadoop-client-runtime-3.3.4.jar. These transitive dependencies from hadoop-client-runtime-3.3.4.jar are not able to be upgraded to a higher version and require upstream maintainers to implement. '
 
   - id: CGA-x32f-h36r-79m2
     aliases:

--- a/spark-3.5-scala-2.13.advisories.yaml
+++ b/spark-3.5-scala-2.13.advisories.yaml
@@ -675,6 +675,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/python3.13/site-packages/pyspark/jars/spark-core_2.13-3.5.3.jar
             scanner: grype
+      - timestamp: 2025-01-15T12:15:35Z
+        type: pending-upstream-fix
+        data:
+          note: This jetty-servlets dependency is brought in as a transitive dependency via spark-core_2.13-3.5.4.jar. These transitive dependencies from spark-core_2.13-3.5.4.jar are not able to be upgraded to a higher version and require upstream maintainers to implement.
 
   - id: CGA-mx94-xp7q-7x32
     aliases:
@@ -916,3 +920,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/python3.13/site-packages/pyspark/jars/spark-core_2.13-3.5.3.jar
             scanner: grype
+      - timestamp: 2025-01-15T12:16:04Z
+        type: pending-upstream-fix
+        data:
+          note: 'This jetty-servlets dependency is brought in as a transitive dependency via spark-core_2.13-3.5.4.jar. These transitive dependencies from spark-core_2.13-3.5.4.jar are not able to be upgraded to a higher version and require upstream maintainers to implement. '


### PR DESCRIPTION


Advisory format:
## 1. **[GHSA-j26w-f9rq-mr2q](https://github.com/advisories/GHSA-j26w-f9rq-mr2q) / [GHSA-g8m5-722r-8whq](https://github.com/advisories/GHSA-g8m5-722r-8whq)**
- **pending-upstream-fix:** 
- This jetty-servlets dependency is brought in as a transitive dependency via spark-core_2.13-3.5.4.jar. These transitive dependencies from spark-core_2.13-3.5.4.jar are not able to be upgraded to a higher version and require upstream maintainers to implement.dev/advisories/pull/9300#issuecomment-2517650044 there is no definitive 
## 2. **GHSA-cfxw-4h78-h7fw**
- **pending-upstream-fix:**
- This dnsjava dependency is brought in as a transitive dependency via hadoop-client-runtime-3.3.4.jar. These transitive dependencies from hadoop-client-runtime-3.3.4.jar are not able to be upgraded to a higher version and require upstream maintainers to implement.

## 3. **GHSA-pr98-23f8-jwxv**
- **pending-upstream-fix:**
- This logback-core dependency is brought in as a transitive dependency. These transitive dependencies from are not able to be upgraded to a higher version and require upstream maintainers to implement.
 
