### PR TITLE
thingsboard/GHSA-mfj5-cf8g-g2fv:async-http-client:advisory update

### DIFF
--- a/thingsboard.advisories.yaml
+++ b/thingsboard.advisories.yaml
@@ -261,6 +261,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar
             scanner: grype
+      - timestamp: 2025-01-15T12:36:45Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE caused by async-http-client being brought in via Microsoft Azure SDK for Service Bus (version 3.6.7), which is used by ThingsBoard’s server-queue components, as a transitive dependency. This will require upstream maintainers to implement a remediation.
 
   - id: CGA-9cw3-8w4j-827w
     aliases:


### PR DESCRIPTION
## 1. **GHSA-mfj5-cf8g-g2fv**
- **pending-upstream-fix:**
- This CVE caused by async-http-client being brought in via Microsoft Azure SDK for Service Bus (version 3.6.7), which is used by ThingsBoard’s server-queue components, as a transitive dependency. This will require upstream maintainers to implement a remediation.