### PR TITLE
false-positive advisories for mattermost v10.3

### DIFF
--- a/mattermost-10.3.advisories.yaml
+++ b/mattermost-10.3.advisories.yaml
@@ -75,6 +75,16 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2025-01-15T22:37:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability was fixed in mattermost v9.11.16, and is not present in v10.
+            The componentVersion is being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue:
+            - https://github.com/anchore/syft/issues/2980
+            - https://mattermost.com/security-updates/
 
   - id: CGA-3ccq-q4hh-w64f
     aliases:
@@ -196,6 +206,16 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2025-01-15T22:37:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability was fixed in mattermost v10.0.4, and is not present in v10.3.
+            The componentVersion is being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue:
+            - https://github.com/anchore/syft/issues/2980
+            - https://mattermost.com/security-updates/
 
   - id: CGA-6w63-cc2h-xccf
     aliases:
@@ -854,6 +874,16 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2025-01-15T22:37:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability was fixed in mattermost v10.3.0, and is not present in v10.3.1 or later.
+            The componentVersion is being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue:
+            - https://github.com/anchore/syft/issues/2980
+            - https://mattermost.com/security-updates/
 
   - id: CGA-r9pm-6pj9-gp2p
     aliases:


### PR DESCRIPTION
## Background
There is a long-running issue where Syft is flagging the wrong componentVersion when scanning mattermost with Grype:
- https://github.com/anchore/syft/issues/2980

## Advisories created

- GHSA-q8fg-cp3q-5jwm - false positive (due to above)
- GHSA-7rgp-4j56-fm79 - false positive (due to above)
- GHSA-2549-xh72-qrpm - false positive (due to above)