### PR TITLE
pending-upstream-fix for CVE-2024-56323, GHSA-32q6-rr98-cjqv

### DIFF
--- a/grafana-11.4.advisories.yaml
+++ b/grafana-11.4.advisories.yaml
@@ -168,3 +168,14 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/grafana
             scanner: grype
+      - timestamp: 2025-01-16T13:16:58Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to the openfga dependency, and is fixed in v1.8.3 and later.
+            Upstream is still using an older version and has not upgraded yet.
+            Attempts to upgrade to v1.8.3 introduce build issues, specifically around the zanzana component, likely introduced by a datastore change in v1.6.1 of openfga.
+            The main branch may include refactors to accommodate this, but these haven't been released.
+            Main is still several versions behind the CVE fixed version.
+            - https://github.com/openfga/openfga/releases/tag/v1.6.1
+            - https://github.com/grafana/grafana/pull/94485/files


### PR DESCRIPTION
pending-upstream-fix advisory created for CVE-2024-56323 / GHSA-32q6-rr98-cjqv.

Upgrading to the fixed version of openfga introduces build failures. It looks like an earlier version of openfga introduced breaking changes. Grafana may have made some changes to accommodate this, but they are not in a release yet, and main branch is still several versions behind the fixed version.