### PR TITLE
kubeflow-pipelines-visualization-server/GHSA-cjgq-5qmw-rcj6 advisory update

### DIFF
--- a/kubeflow-pipelines-visualization-server.advisories.yaml
+++ b/kubeflow-pipelines-visualization-server.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/keras-2.15.0.dist-info/METADATA, /usr/lib/python3.10/site-packages/keras-2.15.0.dist-info/RECORD, /usr/lib/python3.10/site-packages/keras-2.15.0.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2025-01-16T20:33:24Z
+        type: fix-not-planned
+        data:
+          note: 'Kubeflow would have to replace or remove Keras. Vulneribility is with all Keras versions. Upstream Keras maintainer has no plan to fix at this time. https://github.com/keras-team/keras/issues/20766'
 
   - id: CGA-2pv2-w6q3-fxxh
     aliases:


### PR DESCRIPTION
no fixed planned created for [CVE-2024-55459](https://github.com/advisories/GHSA-cjgq-5qmw-rcj6)/[https://github.com/advisories/GHSA-cjgq-5qmw-rcj6](https://github.com/advisories/GHSA-cjgq-5qmw-rcj6). 

upstream maintainer of Keras does not plan on fixing issue: https://github.com/keras-team/keras/issues/20766