### PR TITLE
Re-add detection events for GHSA-xq3w-v528-46rv and GHSA-5mg8-w23w-74h3

### DIFF
--- a/flyway.advisories.yaml
+++ b/flyway.advisories.yaml
@@ -25,6 +25,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: guava-31.1-jre.jar is not part of upstream repo. It is a transitive dependendcy of /flyway/drivers/databricks-jdbc-2.6.40.jar. This is not easily fixed as databricks-jdbc is closed source.
+      - timestamp: 2025-01-16T22:38:00Z
+        type: pending-upstream-fix
+        data:
+          note: guava-31.1-jre.jar is not part of upstream repo. It is a transitive dependendcy of /flyway/drivers/databricks-jdbc-2.6.40.jar. This is not easily fixed as databricks-jdbc is closed source.
 
   - id: CGA-ww3c-v2pw-2hr3
     aliases:
@@ -44,6 +48,10 @@ advisories:
             componentLocation: /usr/share/java/flyway/drivers/databricks-jdbc-2.6.40.jar
             scanner: grype
       - timestamp: 2025-01-09T00:05:31Z
+        type: pending-upstream-fix
+        data:
+          note: netty-common-4.1.86.Final.jar is not part of upstream repo. It is a transitive dependendcy of /flyway/drivers/databricks-jdbc-2.6.40.jar. This is not easily fixed as databricks-jdbc is closed source.
+      - timestamp: 2025-01-16T22:38:00Z
         type: pending-upstream-fix
         data:
           note: netty-common-4.1.86.Final.jar is not part of upstream repo. It is a transitive dependendcy of /flyway/drivers/databricks-jdbc-2.6.40.jar. This is not easily fixed as databricks-jdbc is closed source.


### PR DESCRIPTION
Advisories added for flyway, BEFORE detection event created by automation:
 - https://github.com/wolfi-dev/advisories/pull/11227/files

Detection events added AFTER. Note these now have LATER timestamps than above:
 - https://github.com/wolfi-dev/advisories/commit/2f1493eeb389af41226ca1e0712df5f10eee2e8a

Net result - automation opening CVE remediations, as it thinks these issues are in detected state, due to timestamps. Fixes that by adding later pending-upstream-fix advisory.

Guidance has always been to not edit previous events, and add new events - which is what i've done here. 