### PR TITLE
spark-3.5-scala-2.13: derby and jackson-mapper-asl advisory updates

### DIFF
--- a/spark-3.5-scala-2.13.advisories.yaml
+++ b/spark-3.5-scala-2.13.advisories.yaml
@@ -299,6 +299,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/python3.13/site-packages/pyspark/jars/jackson-mapper-asl-1.9.13.jar
             scanner: grype
+      - timestamp: 2025-01-17T11:23:37Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to jackson-mapper-asl, which is no longer maintained. Apache Spark has taken actions to remove their own dependency on the library, however a transitive dependency (ranger), still requires it. Waiting for upstream https://issues.apache.org/jira/browse/NIFI-11659.
 
   - id: CGA-95rq-pqfg-9383
     aliases:
@@ -555,6 +559,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/python3.13/site-packages/pyspark/jars/jackson-mapper-asl-1.9.13.jar
             scanner: grype
+      - timestamp: 2025-01-17T11:21:23Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to jackson-mapper-asl, which is no longer maintained. Apache Spark has taken actions to remove their own dependency on the library, however a transitive dependency (ranger), still requires it. Waiting for upstream https://issues.apache.org/jira/browse/NIFI-11659.
 
   - id: CGA-g9g9-hh8j-v9h4
     aliases:
@@ -595,6 +603,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/python3.13/site-packages/pyspark/jars/derby-10.14.2.0.jar
             scanner: grype
+      - timestamp: 2025-01-16T18:08:57Z
+        type: pending-upstream-fix
+        data:
+          note: This relates to 'derby'. Various fixes where committed to main branch in Dec 2023 but we are waiting for a release to be created with these changes. https://github.com/apache/spark/pull/44174
 
   - id: CGA-hcx6-4xcx-96pr
     aliases:


### PR DESCRIPTION
## 1. **CGA-93w3-x4hw-7w7g**
- **Pending Upstream Fix:**  
  This relates to `jackson-mapper-asl`, which is no longer maintained. Apache Spark has taken actions to remove their own dependency on the library; however, a transitive dependency (`ranger`) still requires it. Waiting for upstream: [NIFI-11659](https://issues.apache.org/jira/browse/NIFI-11659).

## 2. **CGA-g9g4-vq86-q338**
- **Pending Upstream Fix:**  
  This relates to `jackson-mapper-asl`, which is no longer maintained. Apache Spark has taken actions to remove their own dependency on the library; however, a transitive dependency (`ranger`) still requires it. Waiting for upstream: [NIFI-11659](https://issues.apache.org/jira/browse/NIFI-11659).

## 3. **CGA-gxvv-v998-c384**
- **Pending Upstream Fix:**  
  This relates to `derby`. Various fixes were committed to the main branch in December 2023, but we are waiting for a release to include these changes: [Apache Spark PR #44174](https://github.com/apache/spark/pull/44174).
