### PR TITLE
re-add advisory with later timestamp than the detection event

### DIFF
--- a/flyway.advisories.yaml
+++ b/flyway.advisories.yaml
@@ -77,3 +77,7 @@ advisories:
         type: pending-upstream-fix
         data:
           note: guava-31.1-jre.jar is not part of upstream repo. It is a transitive dependendcy of /flyway/drivers/databricks-jdbc-2.6.40.jar. This is not easily fixed as databricks-jdbc is closed source.
+      - timestamp: 2025-01-17T14:34:22Z
+        type: pending-upstream-fix
+        data:
+          note: guava-31.1-jre.jar is not part of upstream repo. It is a transitive dependendcy of /flyway/drivers/databricks-jdbc-2.6.40.jar. This is not easily fixed as databricks-jdbc is closed source.


### PR DESCRIPTION
pending-upstream-fix was raised before detection event, so timestamps clash and detection is seen as newer by CVE ticket creation.