### PR TITLE
Mattermost v10.3: false-positive detections for GHSA-5m7j-6gc4-ff5g, GHSA-8j3q-gc9x-7972 and GHSA-45v9-w9fh-33j6

### DIFF
--- a/mattermost-10.3.advisories.yaml
+++ b/mattermost-10.3.advisories.yaml
@@ -179,6 +179,16 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2025-01-17T15:03:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability was only present in versions prior to 10.3 (this release). v10.3.0 was the first to remediate.
+            The componentVersion is being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue:
+            - https://github.com/anchore/syft/issues/2980
+            - https://mattermost.com/security-updates/
 
   - id: CGA-6gj8-2fvm-r6g9
     aliases:
@@ -892,6 +902,16 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2025-01-17T15:03:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability was only present in versions prior to 10.3 (this release). v10.3.0 was the first to remediate.
+            The componentVersion is being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue:
+            - https://github.com/anchore/syft/issues/2980
+            - https://mattermost.com/security-updates/
 
   - id: CGA-r72w-vv9m-6p9f
     aliases:
@@ -1045,6 +1065,16 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2025-01-17T15:03:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability was only present in versions prior to 10.3 (this release). v10.3.0 was the first to remediate.
+            The componentVersion is being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue:
+            - https://github.com/anchore/syft/issues/2980
+            - https://mattermost.com/security-updates/
 
   - id: CGA-xf9f-9r6m-r6v4
     aliases:


### PR DESCRIPTION
Adding false-positive detections for GHSA-5m7j-6gc4-ff5g, GHSA-8j3q-gc9x-7972 and GHSA-45v9-w9fh-33j6. These are not present in the v10.3 release.

They are flagged (like other matches), due to long-running grype / syft issue. See description. 