### PR TITLE
Mattermost v10.3: 'false-positive' advisory for: GHSA-w6xh-c82w-h997

### DIFF
--- a/mattermost-10.3.advisories.yaml
+++ b/mattermost-10.3.advisories.yaml
@@ -130,6 +130,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mattermost
             scanner: grype
+      - timestamp: 2025-01-18T20:52:56Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |-
+            This vulnerability was fixed in v10.1.4 and later.  The componentVersion is being flagged incorrectly here by some scanners.
+            A bug has been filed upstream against Syft, and the maintainers have confirmed it's a scanner issue:
+            - https://github.com/anchore/syft/issues/2980
+            - https://mattermost.com/security-updates/
 
   - id: CGA-4wf7-23gj-4hvm
     aliases:


### PR DESCRIPTION
Mattermost v10.3: 'false-positive' advisory for: GHSA-w6xh-c82w-h997.

_Long-standing Syft issue that causes grype to return false positives for mattermost package: https://github.com/anchore/syft/issues/2980._