### PR TITLE
feat(advisory): kubernetes-1.30 GHSA-c5q2-7r4c-mv6g pending-upstream advisory backported from enterprise-advisories

### DIFF
--- a/kubernetes-1.30.advisories.yaml
+++ b/kubernetes-1.30.advisories.yaml
@@ -141,6 +141,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubeadm
             scanner: grype
+      - timestamp: 2025-01-22T10:07:57Z
+        type: pending-upstream-fix
+        data:
+          note: 'The gopkg.in/square/go-jose.v2 dependency is archived and will not be fixed as can be seen here for the advisory database: https://github.com/advisories/GHSA-c5q2-7r4c-mv6g The upstream maintainers must implement the fix. '
 
   - id: CGA-q78r-qc55-vvxc
     aliases:


### PR DESCRIPTION
> The gopkg.in/square/go-jose.v2 dependency is archived and will not be fixed as can be seen here fro the advisory database: https://github.com/advisories/GHSA-c5q2-7r4c-mv6g The upstream maintainers must implement the fix.

This is a copy from the enterprise-advisories to accommodate a bug in how the detection events are ordered and CVE detection issues are created.

kubernetes-1.30 is now maintained as an enterprise-packages package.

Signed-off-by: philroche <phil.roche@chainguard.dev>
