### PR TITLE
openssl: update CVE-2024-13176 advisory to fixed

### DIFF
--- a/openssl.advisories.yaml
+++ b/openssl.advisories.yaml
@@ -113,6 +113,10 @@ advisories:
         type: detection
         data:
           type: manual
+      - timestamp: 2025-01-22T12:39:18Z
+        type: fixed
+        data:
+          fixed-version: 3.4.0-r6
 
   - id: CGA-97q5-67vw-m89f
     aliases:


### PR DESCRIPTION
...now that we have landed the fix in the openssl package, let's mark that in the advisory.