### PR TITLE
Revert "feat(advisory): kubernetes-1.30 GHSA-c5q2-7r4c-mv6g pending-upstream advisory backported from enterprise-advisories"

### DIFF
--- a/kubernetes-1.30.advisories.yaml
+++ b/kubernetes-1.30.advisories.yaml
@@ -141,10 +141,6 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubeadm
             scanner: grype
-      - timestamp: 2025-01-22T10:07:57Z
-        type: pending-upstream-fix
-        data:
-          note: 'The gopkg.in/square/go-jose.v2 dependency is archived and will not be fixed as can be seen here for the advisory database: https://github.com/advisories/GHSA-c5q2-7r4c-mv6g The upstream maintainers must implement the fix. '
 
   - id: CGA-q78r-qc55-vvxc
     aliases:


### PR DESCRIPTION
Reverts wolfi-dev/advisories#11325

reverting so we can validate the fix