### PR TITLE
tez/GHSA-6v67-2wr5-gvf4 advisory update

### DIFF
--- a/tez.advisories.yaml
+++ b/tez.advisories.yaml
@@ -194,6 +194,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tez/lib/logback-core-1.2.10.jar
             scanner: grype
+      - timestamp: 2025-01-24T07:54:09Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency logback-core that is causing this CVE is a transitive dependency that is brought in via multiple parent dependencies, we are unable to update to fix version and requires upstream maintainers to update parent dependencies.
 
   - id: CGA-7pfp-wfcr-cm2m
     aliases:


### PR DESCRIPTION
The dependency logback-core that is causing this CVE is a transitive dependency that is brought in via multiple parent dependencies, we are unable to update to fix version and requires upstream maintainers to update parent dependencies