### PR TITLE
git/CVE-2024-52005 advisory update

### DIFF
--- a/git.advisories.yaml
+++ b/git.advisories.yaml
@@ -20,6 +20,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-01-24T01:19:57Z
+        type: pending-upstream-fix
+        data:
+          note: An upstream fix is not yet released for git other than git-for-windows which is not applicable here.
 
   - id: CGA-3c44-9p5p-fq86
     aliases:


### PR DESCRIPTION
An upstream fix is not yet released for git other than git-for-windows which is not applicable here.