### PR TITLE
vitess-21.0/GHSA-3xgq-45jj-v275 advisory update

### DIFF
--- a/vitess-21.0.advisories.yaml
+++ b/vitess-21.0.advisories.yaml
@@ -37,6 +37,10 @@ advisories:
             componentType: npm
             componentLocation: /vt/web/vtadmin/node_modules/npm/node_modules/cross-spawn/package.json
             scanner: grype
+      - timestamp: 2025-01-24T10:11:50Z
+        type: pending-upstream-fix
+        data:
+          note: The cross-spawn dependency causing this CVE is brought in by npm as a transitive dependency and will need to be updated by upstream maintainers
 
   - id: CGA-892h-wqw6-wxg5
     aliases:


### PR DESCRIPTION
The cross-spawn dependency causing this CVE is brought in by npm as a transitive dependency and will need to be updated by upstream maintainers