### PR TITLE
gitlab-cng-17.8/GHSA-9hf4-67fc-4vf4/GHSA-hxx2-7vcw-mqr3 advisory updates

### DIFF
--- a/gitlab-cng-17.8.advisories.yaml
+++ b/gitlab-cng-17.8.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.2.0/specifications/puma-5.6.8.gemspec
             scanner: grype
+      - timestamp: 2025-01-24T12:53:33Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability relates to the GitLab dependency: [gem] puma @ 5.6.8  GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues.  deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.'
 
   - id: CGA-6pf3-r9mj-v4mg
     aliases:
@@ -39,6 +43,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.2.0/specifications/sinatra-2.2.4.gemspec
             scanner: grype
+      - timestamp: 2025-01-24T12:53:33Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability relates to the GitLab dependency: [gem] sinatra @ 2.2.4, GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues.  deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.'
 
   - id: CGA-rm3q-v7gh-5h4w
     aliases:


### PR DESCRIPTION
## 1. **GHSA-9hf4-67fc-4vf4**
- **pending-upstream-fix:** This vulnerability relates to the GitLab dependency: [gem] puma @ 5.6.8 GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues. deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html
## 2. **GHSA-hxx2-7vcw-mqr3**
- **pending-upstream-fix:** This vulnerability relates to the GitLab dependency: [gem] sinatra @ 2.2.4, GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues. deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.