### PR TITLE
keycloak/GHSA-m3hp-8546-5qmr advisory update

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -673,6 +673,15 @@ advisories:
             Scanner is reporting that Keycloak v22.0.4  still vulnerable to this CVE.
             however this was fixed in an earlier version: v21.0.1. See https://github.com/advisories/GHSA-9g98-5mj6-f9mv
 
+  - id: CGA-wf5q-3c34-wwch
+    aliases:
+      - GHSA-m3hp-8546-5qmr
+    events:
+      - timestamp: 2025-01-24T13:21:50Z
+        type: pending-upstream-fix
+        data:
+          note: This is a known flaw in keycloak and does not yet have a remediation. Upstream maintainers must implement a fix.
+
   - id: CGA-x364-25j3-gjfx
     aliases:
       - GHSA-5545-r4hg-rj4m


### PR DESCRIPTION
## 1. **GHSA-m3hp-8546-5qmr**
- **pending-upstream-fix:** This is a known flaw in keycloak and does not yet have a remediation. Upstream maintainers must implement a fix.