### PR TITLE
Added false positive advisory events for solr 9.8.0 (GHSA-4p5m-gvpf-f3x5 and GHSA-68r2-fwcg-qpm8)

### DIFF
--- a/solr.advisories.yaml
+++ b/solr.advisories.yaml
@@ -182,6 +182,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/solr/server/solr-webapp/webapp/WEB-INF/lib/solr-core-9.8.0-SNAPSHOT.jar
             scanner: grype
+      - timestamp: 2025-01-28T19:23:25Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The scanner is not recognizing 9.8.0-SNAPSHOT as a version containing the fix, despite the latest 9.8.0 version being built as part of the package and containing the fix.
 
   - id: CGA-99pp-9g3p-rqqh
     aliases:
@@ -216,6 +221,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/solr/server/solr-webapp/webapp/WEB-INF/lib/solr-core-9.8.0-SNAPSHOT.jar
             scanner: grype
+      - timestamp: 2025-01-28T19:27:51Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: The scanner is not recognizing 9.8.0-SNAPSHOT as a version containing the fix, despite the latest 9.8.0 version being built as part of the package and containing the fix.
 
   - id: CGA-cpx3-q2rm-vq9w
     aliases:


### PR DESCRIPTION
https://github.com/chainguard-dev/CVE-Dashboard/issues/18344
https://github.com/chainguard-dev/CVE-Dashboard/issues/18346

Pretty sure these are false positives as the package is already up to 9.8.0, which is the fixed version. 
```
🔎 Scanning "/tmp/packages.wolfi.dev-os-x86_64-solr-9.8.0-r0.apk2499216938"
├── 📄 /usr/share/java/solr/server/solr-webapp/webapp/WEB-INF/lib/solr-core-9.8.0-SNAPSHOT.jar
│       📦 solr-core 9.8.0-SNAPSHOT (java-archive)
│           Medium CVE-2024-52012 GHSA-4p5m-gvpf-f3x5 fixed in 9.8.0
│           High CVE-2025-24814 GHSA-68r2-fwcg-qpm8 fixed in 9.8.0
```