### PR TITLE
lychee/GHSA-h97m-ww89-6jmq advisory update

### DIFF
--- a/lychee.advisories.yaml
+++ b/lychee.advisories.yaml
@@ -42,3 +42,7 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/lychee
             scanner: grype
+      - timestamp: 2025-01-30T06:44:53Z
+        type: pending-upstream-fix
+        data:
+          note: 'Fix version of Idna (v1.0.0) is not compatible with the required transitive dependency trust-dns-proto as even the most recent version (v0.23.2) only accepts up to minor version 0.4.0 and so upstream maintainers must implement an update '


### PR DESCRIPTION
## 1. **GHSA-h97m-ww89-6jmq**
- **pending-upstream-fix:** 
- Fix version of Idna (v1.0.0) is not compatible with the required transitive dependency trust-dns-proto as even the most recent version (v0.23.2) only accepts up to minor version 0.4.0 and so upstream maintainers must implement an update