### PR TITLE
feat(advisory): keycloak GHSA-m3hp-8546-5qmr advisory pending-upsream-fix timestamp update

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -689,7 +689,7 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/keycloak/lib/lib/main/org.keycloak.keycloak-ldap-federation-26.1.0.jar
             scanner: grype
-      - timestamp: 2025-01-24T13:21:50Z
+      - timestamp: 2025-01-31T15:39:50Z
         type: pending-upstream-fix
         data:
           note: This is a known flaw in keycloak and does not yet have a remediation. Upstream maintainers must implement a fix.


### PR DESCRIPTION
The order of detection->pending-upstream-fix advisory event timestamps currently does matter when determining the latest state of an advisory.

As such the current state according to our automation for this advisory is `detection`. To fix this I am updating the timestamp of the
pending-upstream-fix to after the detection.

This will result in pending-upstream-fix being the current state for this advisory and automation will close any CVE detection issues.

The detection event was added late due to failing CI @ https://github.com/wolfi-dev/advisories/pull/11350/commits and the pending-upstream-fix added @ https://github.com/wolfi-dev/advisories/pull/11369/commits.

Signed-off-by: philroche <phil.roche@chainguard.dev>
