### PR TITLE
GHSA-29qp-crvh-w22m: add previously missed true-positive-determination events

### DIFF
--- a/argo-rollouts.advisories.yaml
+++ b/argo-rollouts.advisories.yaml
@@ -106,3 +106,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubectl-argo-rollouts
             scanner: grype
+      - timestamp: 2025-01-31T18:14:03Z
+        type: true-positive-determination
+        data:
+          note: "Awaiting release of fix by upstream dependency yamux: https://github.com/hashicorp/yamux/pull/143"

--- a/gitlab-runner-17.8.advisories.yaml
+++ b/gitlab-runner-17.8.advisories.yaml
@@ -20,3 +20,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gitlab-runner
             scanner: grype
+      - timestamp: 2025-01-31T18:14:03Z
+        type: true-positive-determination
+        data:
+          note: "Awaiting release of fix by upstream dependency yamux: https://github.com/hashicorp/yamux/pull/143"

--- a/sftpgo.advisories.yaml
+++ b/sftpgo.advisories.yaml
@@ -42,3 +42,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/sftpgo
             scanner: grype
+      - timestamp: 2025-01-31T18:14:03Z
+        type: true-positive-determination
+        data:
+          note: "Awaiting release of fix by upstream dependency yamux: https://github.com/hashicorp/yamux/pull/143"

--- a/velero-plugin-for-microsoft-azure.advisories.yaml
+++ b/velero-plugin-for-microsoft-azure.advisories.yaml
@@ -64,3 +64,7 @@ advisories:
             componentType: go-module
             componentLocation: /plugins/velero-plugin-for-microsoft-azure
             scanner: grype
+      - timestamp: 2025-01-31T18:14:03Z
+        type: true-positive-determination
+        data:
+          note: "Awaiting release of fix by upstream dependency yamux: https://github.com/hashicorp/yamux/pull/143"


### PR DESCRIPTION
My script failed to append to files where this was the last advisory.