### PR TITLE
newrelic-fluent-bit-output/CVE-2024-45341/CVE-2024-45336 advisory update

### DIFF
--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: go-module
             componentLocation: /fluent-bit/bin/out_newrelic.so
             scanner: grype
+      - timestamp: 2025-02-03T21:32:04Z
+        type: pending-upstream-fix
+        data:
+          note: 'Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning: https://github.com/newrelic/newrelic-fluent-bit-output/blob/5854a3f3cffc49f251c9ef15bec714e44e7969a8/go.mod#L3 which directs to the following conversation: https://github.com/golang/go/issues/62130#issuecomment-1687335898'
 
   - id: CGA-3fw9-g448-cq83
     aliases:
@@ -151,6 +155,10 @@ advisories:
             componentType: go-module
             componentLocation: /fluent-bit/bin/out_newrelic.so
             scanner: grype
+      - timestamp: 2025-02-03T21:32:26Z
+        type: pending-upstream-fix
+        data:
+          note: 'Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning: https://github.com/newrelic/newrelic-fluent-bit-output/blob/5854a3f3cffc49f251c9ef15bec714e44e7969a8/go.mod#L3 which directs to the following conversation: https://github.com/golang/go/issues/62130#issuecomment-1687335898'
 
   - id: CGA-8mpm-9pww-j36w
     aliases:


### PR DESCRIPTION
## 1. **CVE-2024-45341/CVE-2024-45336x**
- **pending-upstream-fix:** Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning: https://github.com/newrelic/newrelic-fluent-bit-output/blob/5854a3f3cffc49f251c9ef15bec714e44e7969a8/go.mod#L3 which directs to the following conversation: https://github.com/golang/go/issues/62130#issuecomment-1687335898