### PR TITLE
spark-3.5-scala-2.12/13/GHSA-c476-j253-5rgq advisory update

### DIFF
--- a/spark-3.5-scala-2.12.advisories.yaml
+++ b/spark-3.5-scala-2.12.advisories.yaml
@@ -219,6 +219,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hive-exec-2.3.9-core.jar
             scanner: grype
+      - timestamp: 2025-02-03T21:49:37Z
+        type: pending-upstream-fix
+        data:
+          note: 'Spark-3.5 only supports Hive 2.3.9. An initiative to upgrade Hive to a newer major version exists and is targeting the spark 4.0.0 release. This can be seen in the following PR: https://issues.apache.org/jira/browse/SPARK-44114'
 
   - id: CGA-chqv-p463-57p4
     aliases:

--- a/spark-3.5-scala-2.13.advisories.yaml
+++ b/spark-3.5-scala-2.13.advisories.yaml
@@ -705,6 +705,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/python3.13/site-packages/pyspark/jars/hive-exec-2.3.9-core.jar
             scanner: grype
+      - timestamp: 2025-02-03T21:50:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'Spark-3.5 only supports Hive 2.3.9. An initiative to upgrade Hive to a newer major version exists and is targeting the spark 4.0.0 release. This can be seen in the following PR: https://issues.apache.org/jira/browse/SPARK-44114 '
 
   - id: CGA-gxvv-v998-c384
     aliases:


### PR DESCRIPTION
## 1. **GHSA-c476-j253-5rgq**
- **pending-upstream-fix:** Spark-3.5 only supports Hive 2.3.9. An initiative to upgrade Hive to a newer major version exists and is targeting the spark 4.0.0 release. This can be seen in the following PR: https://issues.apache.org/jira/browse/SPARK-44114