### PR TITLE
bind-9.18.33/advisory update

### DIFF
--- a/bind.advisories.yaml
+++ b/bind.advisories.yaml
@@ -545,6 +545,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-02-03T22:37:02Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'Vulnerbility affects versions 9.18.0 -> 9.18.32. Vulnerability was fixed in 9.18.33 per: https://kb.isc.org/docs/cve-2024-12705'
 
   - id: CGA-r5cx-vp7m-x957
     aliases:


### PR DESCRIPTION
false positive determination for GHSA-gf34-2fpp-vmc4/CVE-2024-12705