### PR TITLE
argo cd advisory updates

### DIFF
--- a/argo-cd-2.13.advisories.yaml
+++ b/argo-cd-2.13.advisories.yaml
@@ -64,6 +64,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/local/bin/argocd
             scanner: grype
+      - timestamp: 2025-02-03T22:58:47Z
+        type: pending-upstream-fix
+        data:
+          note: The gitops-engine@v0.7.3 has breaking changes, upstream maintainers will have to address required changes from version v0.7.1-0.20250129155113-faf5a4e5c37d.'
 
   - id: CGA-gc77-5phf-vxm8
     aliases:

--- a/argocd-image-updater.advisories.yaml
+++ b/argocd-image-updater.advisories.yaml
@@ -108,6 +108,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argocd-image-updater
             scanner: grype
+      - timestamp: 2025-02-03T22:59:28Z
+        type: pending-upstream-fix
+        data:
+          note: The gitops-engine@v0.7.3 has breaking changes, upstream maintainers will have to address required changes from version v0.7.1-0.20250129155113-faf5a4e5c37d.'
 
   - id: CGA-cjr4-f6q7-9mh7
     aliases:


### PR DESCRIPTION
advisory updates for https://github.com/advisories/GHSA-274v-mgcv-cm8j for argo-cd and argocd-image-updater