### PR TITLE
argo-workflows/CVE-2024-45341/CVE-2024-45336

### DIFF
--- a/argo-workflows.advisories.yaml
+++ b/argo-workflows.advisories.yaml
@@ -133,6 +133,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/lib/argo-workflows-ui/ui/node_modules/@esbuild/linux-x64/bin/esbuild
             scanner: grype
+      - timestamp: 2025-02-04T04:42:16Z
+        type: pending-upstream-fix
+        data:
+          note: 'This CVE is caused by esbuild which is a transitive dependency brought in under esbuild-loader. The fix exists upstream in main but has not been cut as part of a release as can be seen the the following PRs here: https://github.com/evanw/esbuild/issues/4056 and here: https://github.com/evanw/esbuild/pull/4057  Due to the transitive nature of esbuild, we must wait for upstream maintainers to cut a release of esbuild with the fix which will then be consumed by esbuild-loader.'
 
   - id: CGA-5grw-9wv6-r624
     aliases:
@@ -985,6 +989,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/lib/argo-workflows-ui/ui/node_modules/@esbuild/linux-x64/bin/esbuild
             scanner: grype
+      - timestamp: 2025-02-04T04:42:43Z
+        type: pending-upstream-fix
+        data:
+          note: 'This CVE is caused by esbuild which is a transitive dependency brought in under esbuild-loader. The fix exists upstream in main but has not been cut as part of a release as can be seen the the following PRs here: https://github.com/evanw/esbuild/issues/4056 and here: https://github.com/evanw/esbuild/pull/4057  Due to the transitive nature of esbuild, we must wait for upstream maintainers to cut a release of esbuild with the fix which will then be consumed by esbuild-loader.'
 
   - id: CGA-v62h-vh59-3hf9
     aliases:


### PR DESCRIPTION
## 1. **CVE-2024-45336/CVE-2024-45341**
- **pending-upstream-fix:** This CVE is caused by esbuild which is a transitive dependency brought in under esbuild-loader. The fix exists upstream in main but has not been cut as part of a release as can be seen the the following PRs here: https://github.com/evanw/esbuild/issues/4056 and here: https://github.com/evanw/esbuild/pull/4057 Due to the transitive nature of esbuild, we must wait for upstream maintainers to cut a release of esbuild with the fix which will then be consumed by esbuild-loader.