### PR TITLE
feature/cve GHSA c5q2 7r4c mv6g kubernetes 1.30 rev2

### DIFF
--- a/kubernetes-1.30.advisories.yaml
+++ b/kubernetes-1.30.advisories.yaml
@@ -141,6 +141,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubeadm
             scanner: grype
+      - timestamp: 2025-01-22T10:07:57Z
+        type: pending-upstream-fix
+        data:
+          note: 'The gopkg.in/square/go-jose.v2 dependency is archived and will not be fixed as can be seen here for the advisory database: https://github.com/advisories/GHSA-c5q2-7r4c-mv6g The upstream maintainers must implement the fix. '
 
   - id: CGA-q78r-qc55-vvxc
     aliases:

--- a/kubernetes-1.30.advisories.yaml
+++ b/kubernetes-1.30.advisories.yaml
@@ -141,7 +141,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubeadm
             scanner: grype
-      - timestamp: 2025-01-22T10:07:57Z
+      - timestamp: 2025-02-04T16:17:57Z
         type: pending-upstream-fix
         data:
           note: 'The gopkg.in/square/go-jose.v2 dependency is archived and will not be fixed as can be seen here for the advisory database: https://github.com/advisories/GHSA-c5q2-7r4c-mv6g The upstream maintainers must implement the fix. '


### PR DESCRIPTION
**feat(advisory): re-apply kubernetes-1.30 GHSA-c5q2-7r4c-mv6g pending-upstream advisory backported from enterprise-advisories (#11325)**

Bump timestamp to within 3 days so CI will not block merging. The timestamp is not important in this instance.



**feat(advisory): re-apply kubernetes-1.30 GHSA-c5q2-7r4c-mv6g pending-upstream advisory backported from enterprise-advisories (#11325)**

> The gopkg.in/square/go-jose.v2 dependency is archived and will not be fixed as can be seen here fro the advisory database: https://github.com/advisories/GHSA-c5q2-7r4c-mv6g The upstream maintainers must implement the fix.

This is a copy from the enterprise-advisories to accommodate a bug in how the detection events are ordered and CVE detection issues are created.

kubernetes-1.30 is now maintained as an enterprise-packages package.

This was intially reverted in 0744bd75 to allow for testing automaiton to filter our previously added pending-upstream-fix advisories.

Testing was successful but the missing advisory is still showing up on our dashboard  -hence the re-introduction of the advisory event.

(cherry picked from commit c0851cc827a6a0e6497ed5ba12cc34550577aec5)


