### PR TITLE
apache-tika-3.0: CVE-2024-6763 => pending upstream

### DIFF
--- a/apache-tika-3.0.advisories.yaml
+++ b/apache-tika-3.0.advisories.yaml
@@ -29,6 +29,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.0.0-r9
+      - timestamp: 2025-02-04T18:52:08Z
+        type: pending-upstream-fix
+        data:
+          note: 'Attempting to patch this CVE leads to JAR dependency mismatch, and will require an update from upstream maintainers to remediate. '
 
   - id: CGA-pqmq-rmg6-cmrc
     aliases:


### PR DESCRIPTION
The version bump to fix CVE-2024-6763 wasn't successful, and we are reverting it here https://github.com/wolfi-dev/os/pull/41225