### PR TITLE
GHSA-2vpq-fh52-j3wv/CVE-2025-24793 advisory update

### DIFF
--- a/airflow.advisories.yaml
+++ b/airflow.advisories.yaml
@@ -376,6 +376,10 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/lib/python3.12/site-packages/snowflake_connector_python-3.12.4.dist-info/METADATA, /opt/airflow/lib/python3.12/site-packages/snowflake_connector_python-3.12.4.dist-info/RECORD, /opt/airflow/lib/python3.12/site-packages/snowflake_connector_python-3.12.4.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2025-02-04T19:15:15Z
+        type: pending-upstream-fix
+        data:
+          note: 'supported python version is 3.12.x, upgrading to 3.13.x causes breaking changes. upstream maintainer will have to upgrade to newer version of python to address the issue. '
 
   - id: CGA-95r3-gmgc-pcqh
     aliases:

--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -918,3 +918,7 @@ advisories:
             componentType: python
             componentLocation: /opt/datadog-agent/embedded/lib/python3.12/site-packages/snowflake_connector_python-3.12.1.dist-info/METADATA, /opt/datadog-agent/embedded/lib/python3.12/site-packages/snowflake_connector_python-3.12.1.dist-info/RECORD, /opt/datadog-agent/embedded/lib/python3.12/site-packages/snowflake_connector_python-3.12.1.dist-info/direct_url.json, /opt/datadog-agent/embedded/lib/python3.12/site-packages/snowflake_connector_python-3.12.1.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2025-02-04T19:09:41Z
+        type: pending-upstream-fix
+        data:
+          note: 'supported python version is 3.12.x, upgrading to 3.13.x causes breaking changes. upstream maintainer will have to upgrade to newer version of python to address the issue. '


### PR DESCRIPTION
advisory updates for datadog-agent and airflow