### PR TITLE
go-1.21/advisory updates

### DIFF
--- a/go-1.21.advisories.yaml
+++ b/go-1.21.advisories.yaml
@@ -120,6 +120,15 @@ advisories:
         data:
           note: This package is no longer supported upstream and has reached its end of life on '2024-08-13'.
 
+  - id: CGA-m598-4r4v-x4rh
+    aliases:
+      - CVE-2024-45341
+    events:
+      - timestamp: 2025-02-04T22:35:38Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-08-13'. Recommend upgrading to 1.22 or later
+
   - id: CGA-mgmp-mqhw-32mw
     aliases:
       - CVE-2024-24791
@@ -129,6 +138,15 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.21.12-r0
+
+  - id: CGA-rhvq-cvg5-3fmh
+    aliases:
+      - CVE-2024-45336
+    events:
+      - timestamp: 2025-02-04T22:37:49Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-08-13'. Recommend upgrading to 1.22 or later
 
   - id: CGA-wpgg-99hr-xrpq
     aliases:


### PR DESCRIPTION
CVE-2024-45336, CVE-2024-45341 advisory update

go 1.21 is EOL