### PR TITLE
go-fips-1.21/CVE-2024-45341/CVE-2024-45336 advisory update

### DIFF
--- a/go-fips-1.21.advisories.yaml
+++ b/go-fips-1.21.advisories.yaml
@@ -34,6 +34,16 @@ advisories:
         data:
           fixed-version: 1.21.11-r0
 
+  - id: CGA-9w97-vx89-ff76
+    aliases:
+      - CVE-2024-45341
+      - GHSA-3f6r-qh9c-x6mm
+    events:
+      - timestamp: 2025-02-05T05:20:09Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-08-13'. Recommend upgrading to 1.22 or later.
+
   - id: CGA-gm6g-p72f-q8gp
     aliases:
       - CVE-2024-24787
@@ -43,6 +53,16 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.21.10-r0
+
+  - id: CGA-grmf-jw8h-pcgr
+    aliases:
+      - CVE-2024-45336
+      - GHSA-7wrw-r4p8-38rx
+    events:
+      - timestamp: 2025-02-05T05:20:48Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-08-13'. Recommend upgrading to 1.22 or later
 
   - id: CGA-gvmf-6jhx-2fpq
     aliases:


### PR DESCRIPTION
Advisory format:
## 1. **[GHSA-q7pp-wcgr-pffx](https://github.com/advisories/GHSA-7wrw-r4p8-38rx) / https://github.com/advisories/GHSA-3f6r-qh9c-x6mm**
- **fix-not-planned:** This package is no longer supported upstream and has reached its end of life on '2024-08-13'. Recommend upgrading to 1.22 or later. extension of the following PR: https://github.com/wolfi-dev/advisories/pull/11920