### PR TITLE
python-3.10/11/CVE-2025-0938 advisory update

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -35,6 +35,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-02-06T09:40:24Z
+        type: pending-upstream-fix
+        data:
+          note: 'Backport fix for python-3.10 regarding this CVE is open upstream and will be implemented when approved by maintainers. PR: https://github.com/python/cpython/pull/129529'
 
   - id: CGA-5rff-g8cr-cwrw
     aliases:

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -248,6 +248,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-02-06T09:44:57Z
+        type: pending-upstream-fix
+        data:
+          note: 'Backport fix for python-3.11 regarding this CVE is open upstream and will be implemented when approved by maintainers. PR: https://github.com/python/cpython/pull/129528'
 
   - id: CGA-q4qf-pg6x-433p
     aliases:


### PR DESCRIPTION
## 1. **CVE-2025-0938**
- **pending-upstream-fix:** 
- Backport fix for python-3.10/11 regarding this CVE is open upstream and will be implemented when approved by maintainers.
python-3.10:https://github.com/python/cpython/pull/129529
python-3.11:https://github.com/python/cpython/pull/129528