### PR TITLE
libreoffice-25.2: add pending-upstream-fix to CVE-2012-5639 advisory

### DIFF
--- a/libreoffice-25.2.advisories.yaml
+++ b/libreoffice-25.2.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-02-07T19:39:34Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE has been addressed in OpenOffice which LibreOffice is forked from but has not been fixed in LibreOffice. The feature changes required to remediate this CVE must be implemented by upstream maintainers.


### PR DESCRIPTION
This follows the resolution of this advisory in the other LibreOffice version streams.