### PR TITLE
flyte: CVE-2024-28180

### DIFF
--- a/flyte.advisories.yaml
+++ b/flyte.advisories.yaml
@@ -231,6 +231,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/flyte
             scanner: grype
+      - timestamp: 2025-02-09T11:31:07Z
+        type: pending-upstream-fix
+        data:
+          note: There is no fix for dependency gopkg.in/square/go-jose.v2 and a fix for this CVE would need code changes to replace the affected dependendency.
 
   - id: CGA-vxwg-j3wc-wgh9
     aliases:


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/41961

```
└── 📄 /usr/bin/flyte
        📦 gopkg.in/square/go-jose.v2 v2.6.0 (go-module)
            Medium CVE-2024-28180 GHSA-c5q2-7r4c-mv6g
```