### PR TITLE
false-positive events for CVE-2025-22866/GHSA-3whm-j4xm-rv8x

### DIFF
--- a/argo-workflows.advisories.yaml
+++ b/argo-workflows.advisories.yaml
@@ -635,6 +635,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/lib/argo-workflows-ui/ui/node_modules/@esbuild/linux-x64/bin/esbuild
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-g8hr-2vg2-m8rq
     aliases:

--- a/bazelisk.advisories.yaml
+++ b/bazelisk.advisories.yaml
@@ -121,6 +121,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/bazelisk
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-jf69-v2j8-8fg3
     aliases:

--- a/cluster-api-controller.advisories.yaml
+++ b/cluster-api-controller.advisories.yaml
@@ -41,6 +41,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cluster-api-controller
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-777f-8hmv-9m5f
     aliases:

--- a/cluster-autoscaler-1.32.advisories.yaml
+++ b/cluster-autoscaler-1.32.advisories.yaml
@@ -53,6 +53,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cluster-autoscaler
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-7fvv-qv68-g7xh
     aliases:

--- a/ferretdb.advisories.yaml
+++ b/ferretdb.advisories.yaml
@@ -94,6 +94,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/ferretdb
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-c9mp-7g38-q4j4
     aliases:

--- a/frp.advisories.yaml
+++ b/frp.advisories.yaml
@@ -170,6 +170,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/frpc
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-h5wr-4m5g-258j
     aliases:

--- a/fuse-overlayfs-snapshotter.advisories.yaml
+++ b/fuse-overlayfs-snapshotter.advisories.yaml
@@ -93,6 +93,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/containerd-fuse-overlayfs-grpc
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-8h56-m9xm-j6f2
     aliases:

--- a/helm-push.advisories.yaml
+++ b/helm-push.advisories.yaml
@@ -285,6 +285,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/libexec/helm-plugins/helm-push/bin/helm-cm-push
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-j9h6-qp5w-c863
     aliases:

--- a/hubble-ui.advisories.yaml
+++ b/hubble-ui.advisories.yaml
@@ -386,6 +386,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/backend
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-jgqh-9jcc-j3r2
     aliases:

--- a/keda-2.16.advisories.yaml
+++ b/keda-2.16.advisories.yaml
@@ -21,6 +21,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/keda
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-5m82-cxgx-fgfq
     aliases:

--- a/kubeflow-katib.advisories.yaml
+++ b/kubeflow-katib.advisories.yaml
@@ -184,6 +184,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/katib-suggestion-goptuna
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-h4px-w464-3vqf
     aliases:

--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -177,6 +177,13 @@ advisories:
             componentType: go-module
             componentLocation: /fluent-bit/bin/out_newrelic.so
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-8mpm-9pww-j36w
     aliases:

--- a/newrelic-infra-operator.advisories.yaml
+++ b/newrelic-infra-operator.advisories.yaml
@@ -193,6 +193,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/newrelic-infra-operator
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-xhxj-f5cm-473q
     aliases:

--- a/nri-discovery-kubernetes.advisories.yaml
+++ b/nri-discovery-kubernetes.advisories.yaml
@@ -100,6 +100,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/nri-discovery-kubernetes
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-f69m-q64j-rhjv
     aliases:

--- a/octo-sts.advisories.yaml
+++ b/octo-sts.advisories.yaml
@@ -162,6 +162,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/octo-sts
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-vhpj-hj5w-87p6
     aliases:

--- a/prometheus-adapter.advisories.yaml
+++ b/prometheus-adapter.advisories.yaml
@@ -83,6 +83,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/adapter
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-92m5-xf6j-mfpp
     aliases:

--- a/pulumi-kubernetes-operator.advisories.yaml
+++ b/pulumi-kubernetes-operator.advisories.yaml
@@ -239,6 +239,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pulumi-kubernetes-operator
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-h82v-45x8-34jx
     aliases:

--- a/render-template.advisories.yaml
+++ b/render-template.advisories.yaml
@@ -32,6 +32,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/render-template
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-3p3p-9vqp-544w
     aliases:

--- a/vt-cli.advisories.yaml
+++ b/vt-cli.advisories.yaml
@@ -164,6 +164,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/vt
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-pph2-458x-46jv
     aliases:

--- a/wait-for-port.advisories.yaml
+++ b/wait-for-port.advisories.yaml
@@ -239,6 +239,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/wait-for-port
             scanner: grype
+      - timestamp: 2025-02-11T:03:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
+            We are not affected by this vulnerability as we do not build or support ppc64le.
 
   - id: CGA-rv7q-jg7x-2qj4
     aliases:


### PR DESCRIPTION
Adds false-positive events for CVE-2025-22866/GHSA-3whm-j4xm-rv8x. This vulnerability is limited to the. ppc64le architecture, which we do not build or support.

