### PR TITLE
newrelic-fluent-bit-output/CVE-2025-22866 advisory update

### DIFF
--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -184,6 +184,10 @@ advisories:
           note: |
             This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
             We are not affected by this vulnerability as we do not build or support ppc64le.
+      - timestamp: 2025-02-11T16:59:00Z
+        type: pending-upstream-fix
+        data:
+          note: 'Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning: https://github.com/newrelic/newrelic-fluent-bit-output/blob/5854a3f3cffc49f251c9ef15bec714e44e7969a8/go.mod#L3 which directs to the following conversation: https://github.com/golang/go/issues/62130#issuecomment-1687335898'
 
   - id: CGA-8mpm-9pww-j36w
     aliases:


### PR DESCRIPTION
## 1. **CVE-2025-22866**
- **pending-upstream-fix:** Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning: https://github.com/newrelic/newrelic-fluent-bit-output/blob/5854a3f3cffc49f251c9ef15bec714e44e7969a8/go.mod#L3 which directs to the following conversation: https://github.com/golang/go/issues/62130#issuecomment-1687335898