### PR TITLE
Adv(Pending upstream Fix): GHSA-pq2g-wx69-c263

### DIFF
--- a/dependency-track.advisories.yaml
+++ b/dependency-track.advisories.yaml
@@ -43,6 +43,12 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/dependency-track/dependency-track-bundled.jar
             scanner: grype
+      - timestamp: 2025-02-11T20:50:25Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This CVE affects json-smart versions 2.5.0 through 2.5.1, dependency-track have a dependency on json-smart @v2.5.0.
+            However, there is currently no fixed version available for this CVE. https://mvnrepository.com/artifact/net.minidev/json-smart
 
   - id: CGA-6ffw-f2qw-rxwj
     aliases:


### PR DESCRIPTION
there is currently no patched version available for this CVE