### PR TITLE
pending-upstream-fix event for GHSA-pq2g-wx69-c263

### DIFF
--- a/strimzi-kafka-operator.advisories.yaml
+++ b/strimzi-kafka-operator.advisories.yaml
@@ -105,6 +105,12 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/strimzi/lib/net.minidev.json-smart-2.5.0.jar
             scanner: grype
+      - timestamp: 2025-02-11T15:11:19Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability relates to the 'kafka-agent' component, specifically, 'json-smart'.
+            The project exposes this as 'json-smart.version', but there is currently no fixed version for this CVE, v2.5.1 is the latest at the time of this event.
 
   - id: CGA-rpgv-63f6-9wq8
     aliases:


### PR DESCRIPTION
Details in advisory description. We know how to bump it, but there is no fix version available as yet.