### PR TITLE
akhq/apache-nifi/opensearch-2/sonarqube-10/json-smart advisory updates

### DIFF
--- a/akhq.advisories.yaml
+++ b/akhq.advisories.yaml
@@ -84,6 +84,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/akhq/akhq.jar
             scanner: grype
+      - timestamp: 2025-02-12T15:35:21Z
+        type: pending-upstream-fix
+        data:
+          note: 'The dependency causing this CVE, json-smart, is a transitive dependency which has not released a fix version. Due to its transitive nature, a fix requires a release version to be cut and published to the maven repository. '
 
   - id: CGA-f489-vh6m-4x4f
     aliases:

--- a/apache-nifi.advisories.yaml
+++ b/apache-nifi.advisories.yaml
@@ -1798,6 +1798,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/nifi/nifi-current/lib/nifi-azure-nar-2.2.0.nar
             scanner: grype
+      - timestamp: 2025-02-12T15:35:48Z
+        type: pending-upstream-fix
+        data:
+          note: 'The dependency causing this CVE, json-smart, is a transitive dependency which has not released a fix version. Due to its transitive nature, a fix requires a release version to be cut and published to the maven repository. '
 
   - id: CGA-vp49-2674-66w8
     aliases:

--- a/opensearch-2.advisories.yaml
+++ b/opensearch-2.advisories.yaml
@@ -281,6 +281,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/opensearch/plugins/opensearch-repository-azure/json-smart-2.5.1.jar
             scanner: grype
+      - timestamp: 2025-02-12T15:36:33Z
+        type: pending-upstream-fix
+        data:
+          note: 'The dependency causing this CVE, json-smart, is a transitive dependency which has not released a fix version. Due to its transitive nature, a fix requires a release version to be cut and published to the maven repository. '
 
   - id: CGA-qv2v-jxhc-34v4
     aliases:

--- a/sonarqube-10.advisories.yaml
+++ b/sonarqube-10.advisories.yaml
@@ -388,6 +388,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/modules/x-pack-security/json-smart-2.5.1.jar
             scanner: grype
+      - timestamp: 2025-02-12T15:37:11Z
+        type: pending-upstream-fix
+        data:
+          note: 'The dependency causing this CVE, json-smart, is a transitive dependency which has not released a fix version. Due to its transitive nature, a fix requires a release version to be cut and published to the maven repository. '
 
   - id: CGA-xg3g-4h7j-5c3r
     aliases:


### PR DESCRIPTION
## 1. **GHSA-pq2g-wx69-c263**
- **pending-upstream-fix:** 
- The dependency causing this CVE, json-smart, is a transitive dependency which has not released a fix version. Due to its transitive nature, a fix requires a release version to be cut and published to the maven repository. 