### PR TITLE
Advisory(PUF): Mark SonarQube-19 CVE GHSA-4g8c-wm8x-jfhw as pending upstream fix

### DIFF
--- a/sonarqube-10.advisories.yaml
+++ b/sonarqube-10.advisories.yaml
@@ -250,6 +250,12 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/modules/transport-netty4/netty-handler-4.1.115.Final.jar
             scanner: grype
+      - timestamp: 2024-10-11T04:48:18Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This is a compiled jar that is brought in as a transitive dependency of elasticsearch dependency.
+            Elasticsearch has been updated to the most recent version and so this requires a fix from upstream maintainers.
 
   - id: CGA-g9h5-gx89-c9v8
     aliases:


### PR DESCRIPTION
- Added a 'pending-upstream-fix' advisory for 'netty-handler-4.1.115.Final.jar' in SonarQube 10.
- This JAR is a transitive dependency of Elasticsearch