### PR TITLE
Added pending-upstream-fix advisory for tez/GHSA-4g8c-wm8x-jfhw

### DIFF
--- a/tez.advisories.yaml
+++ b/tez.advisories.yaml
@@ -125,6 +125,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tez/lib/netty-handler-4.1.100.Final.jar
             scanner: grype
+      - timestamp: 2025-02-13T22:00:50Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability is part of a transitive dependency (hadoop) and will require a fix from upstream to remediate. '
 
   - id: CGA-3v5c-372f-h5wh
     aliases:


### PR DESCRIPTION
Follow on from https://github.com/wolfi-dev/os/pull/42467 to remediate the remaining instance from a transitive dependency (hadoop) 