### PR TITLE
solr/GHSA-4g8c-wm8x-jfhw adv update

### DIFF
--- a/solr.advisories.yaml
+++ b/solr.advisories.yaml
@@ -389,6 +389,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/solr/server/solr-webapp/webapp/WEB-INF/lib/netty-handler-4.1.114.Final.jar
             scanner: grype
+      - timestamp: 2025-02-13T22:05:03Z
+        type: pending-upstream-fix
+        data:
+          note: 'The fix for this CVE exists as an open PR upstream, it has not been approved by the maintainers. Once this is approved and lands we will be able to remediate. PR can be seen here: https://github.com/apache/solr/pull/3074'
 
   - id: CGA-w87x-27xx-x97v
     aliases:


### PR DESCRIPTION
The fix for this CVE exists as an open PR upstream, it has not been approved by the maintainers. Once this is approved and lands we will be able to remediate. PR can be seen here: https://github.com/apache/solr/pull/3074