### PR TITLE
adv: pending upstream fix for aws-efs-csi-driver

### DIFF
--- a/aws-efs-csi-driver.advisories.yaml
+++ b/aws-efs-csi-driver.advisories.yaml
@@ -465,3 +465,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/aws-efs-csi-driver
             scanner: grype
+      - timestamp: 2025-02-20T07:59:14Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            To remedieate this CVE the code requires upgrading Kubernetes dependencies to v1.29.14, but doing that the build fails due to
+            missing feature flags (genericfeatures.StructuredAuthorizationConfiguration and genericfeatures.ZeroLimitedNominalConcurrencyShares) that were removed in later versions.
+            The package currently depends on k8s.io/kubernetes v1.28.15. This requires upstream changes to support newer Kubernetes API versions and feature gates.


### PR DESCRIPTION
To remediate this CVE the code requires upgrading Kubernetes dependencies to v1.29.14, but doing that the build fails due to missing feature flags (genericfeatures.StructuredAuthorizationConfiguration and genericfeatures.ZeroLimitedNominalConcurrencyShares) that were removed in later version. The package currently depends on k8s.io/kubernetes v1.28.15. This requires upstream changes to support newer Kubernetes API versions and feature gates.