### PR TITLE
opensearch-dashboards-2/GHSA-76p7-773f-r4q5 advisory update

### DIFF
--- a/opensearch-dashboards-2.advisories.yaml
+++ b/opensearch-dashboards-2.advisories.yaml
@@ -288,6 +288,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/share/opensearch-dashboards/node_modules/serialize-javascript/package.json
             scanner: grype
+      - timestamp: 2025-02-21T03:14:29Z
+        type: pending-upstream-fix
+        data:
+          note: 'To remediate this CVE would require a bump of two major versions from v4.x.x to v6.0.2 where breaking changes related to handling of sparse arrays (v5.0.0) and passing of URL object values (v6.0.0) need to be addressed by upstream maintainers. There is a PR open upstream regarding this CVE: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9375'
 
   - id: CGA-w95g-rrw2-66h4
     aliases:


### PR DESCRIPTION
To remediate this CVE would require a bump of two major versions from v4.x.x to v6.0.2 where breaking changes related to handling of sparse arrays (v5.0.0) and passing of URL object values (v6.0.0) need to be addressed by upstream maintainers. There is a PR open upstream regarding this CVE: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9375