### PR TITLE
go-1.21/CVE-2025-22866 advisory update

### DIFF
--- a/go-1.21.advisories.yaml
+++ b/go-1.21.advisories.yaml
@@ -31,6 +31,7 @@ advisories:
   - id: CGA-466j-hmf8-m8wc
     aliases:
       - CVE-2024-34158
+      - GHSA-j7vj-rw65-4v26
     events:
       - timestamp: 2024-11-06T10:17:51Z
         type: fix-not-planned
@@ -50,6 +51,7 @@ advisories:
   - id: CGA-52r8-8g54-gjgg
     aliases:
       - CVE-2024-34156
+      - GHSA-crqm-pwhx-j97f
     events:
       - timestamp: 2024-11-06T10:17:51Z
         type: fix-not-planned
@@ -114,6 +116,7 @@ advisories:
   - id: CGA-j7pp-6hgh-f252
     aliases:
       - CVE-2024-34155
+      - GHSA-8xfx-rj4p-23jm
     events:
       - timestamp: 2024-11-06T10:17:51Z
         type: fix-not-planned
@@ -123,6 +126,7 @@ advisories:
   - id: CGA-m598-4r4v-x4rh
     aliases:
       - CVE-2024-45341
+      - GHSA-3f6r-qh9c-x6mm
     events:
       - timestamp: 2025-02-04T22:35:38Z
         type: fix-not-planned
@@ -142,11 +146,22 @@ advisories:
   - id: CGA-rhvq-cvg5-3fmh
     aliases:
       - CVE-2024-45336
+      - GHSA-7wrw-r4p8-38rx
     events:
       - timestamp: 2025-02-04T22:37:49Z
         type: fix-not-planned
         data:
           note: This package is no longer supported upstream and has reached its end of life on '2024-08-13'. Recommend upgrading to 1.22 or later
+
+  - id: CGA-rwm2-hp7c-7gfv
+    aliases:
+      - CVE-2025-22866
+      - GHSA-3whm-j4xm-rv8x
+    events:
+      - timestamp: 2025-02-21T03:22:58Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life on '2024-08-13'
 
   - id: CGA-wpgg-99hr-xrpq
     aliases:


### PR DESCRIPTION
This package is no longer supported upstream and has reached its end of life on '2024-08-13'