### PR TITLE
fix(druid.advisories.yaml): Update pending-upstream-fix GHSA-wmcc-9vch-jmx4 timestamp to ensure it is the latest event

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -847,7 +847,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/extensions/druid-cassandra-storage/cassandra-all-1.0.8.jar
             scanner: grype
-      - timestamp: 2025-02-06T10:16:39Z
+      - timestamp: 2025-02-06T12:16:39Z
         type: pending-upstream-fix
         data:
           note: The fix version of the affected dependency cassandra-all (v3.0.31) is several major versions higher than what is currently included in druid (v1.0.8), upgrading to this version introduces breaking changes, must wait for upstream to implement a fix


### PR DESCRIPTION
Automation depends on any non detection event to have a later timestamp.

The current state is due to a human vs automation race condition and in his case the human won :)

Signed-off-by: philroche <phil.roche@chainguard.dev>
