### PR TITLE
Added pending-upstream-fix advisories for keycloak GHSA-4g8c-wm8x-jfhw and GHSA-389x-839f-4rhxw and GHSA-389x-839f-4rhx

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -189,15 +189,6 @@ advisories:
           type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20223
 
-  - id: CGA-78pc-x38c-7p9v
-    aliases:
-      - GHSA-f4v7-3mww-9gc2
-    events:
-      - timestamp: 2025-01-14T09:36:52Z
-        type: fixed
-        data:
-          fixed-version: 26.0.8-r0
-
   - id: CGA-75hc-h3fm-76g3
     aliases:
       - CVE-2025-24970

--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -189,6 +189,15 @@ advisories:
           type: component-vulnerability-mismatch
           note: CVE is being considered by the community a false positive. See https://github.com/keycloak/keycloak/issues/20223
 
+  - id: CGA-78pc-x38c-7p9v
+    aliases:
+      - GHSA-f4v7-3mww-9gc2
+    events:
+      - timestamp: 2025-01-14T09:36:52Z
+        type: fixed
+        data:
+          fixed-version: 26.0.8-r0
+
   - id: CGA-75hc-h3fm-76g3
     aliases:
       - CVE-2025-24970
@@ -213,16 +222,7 @@ advisories:
       - timestamp: 2025-02-24T21:53:24Z
         type: pending-upstream-fix
         data:
-          note: 'Remediation attempts lead to several build failures and will require work from upstream maintainers to fix. '
-
-  - id: CGA-78pc-x38c-7p9v
-    aliases:
-      - GHSA-f4v7-3mww-9gc2
-    events:
-      - timestamp: 2025-01-14T09:36:52Z
-        type: fixed
-        data:
-          fixed-version: 26.0.8-r0
+          note: Remediation attempts lead to several build failures and will require work from upstream maintainers to fix.
 
   - id: CGA-7q9x-5jxh-8vw6
     aliases:
@@ -645,7 +645,7 @@ advisories:
       - timestamp: 2025-02-24T21:53:52Z
         type: pending-upstream-fix
         data:
-          note: 'Remediation attempts lead to several build failures and will require work from upstream maintainers to fix. '
+          note: Remediation attempts lead to several build failures and will require work from upstream maintainers to fix.
 
   - id: CGA-v4c7-87qg-mw2m
     aliases:

--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -219,6 +219,19 @@ advisories:
         type: fixed
         data:
           fixed-version: 26.1.2-r1
+      - timestamp: 2025-02-24T21:53:24Z
+        type: pending-upstream-fix
+        data:
+          note: 'Remediation attempts lead to several build failures and will require work from upstream maintainers to fix. '
+
+  - id: CGA-78pc-x38c-7p9v
+    aliases:
+      - GHSA-f4v7-3mww-9gc2
+    events:
+      - timestamp: 2025-01-14T09:36:52Z
+        type: fixed
+        data:
+          fixed-version: 26.0.8-r0
 
   - id: CGA-7q9x-5jxh-8vw6
     aliases:
@@ -638,6 +651,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/keycloak/lib/lib/main/io.netty.netty-common-4.1.115.Final.jar
             scanner: grype
+      - timestamp: 2025-02-24T21:53:52Z
+        type: pending-upstream-fix
+        data:
+          note: 'Remediation attempts lead to several build failures and will require work from upstream maintainers to fix. '
 
   - id: CGA-v4c7-87qg-mw2m
     aliases:


### PR DESCRIPTION
https://github.com/chainguard-dev/CVE-Dashboard/issues/19379
https://github.com/chainguard-dev/CVE-Dashboard/issues/19340