### PR TITLE
update advisory push listener STS policy

### DIFF
--- a/.github/chainguard/advisory-push-listener.sts.yaml
+++ b/.github/chainguard/advisory-push-listener.sts.yaml
@@ -1,8 +1,8 @@
 issuer: https://accounts.google.com
 
-# staging-enforce: wolfi-gh-push-listener@staging-enforce-cd1e.iam.gserviceaccount.com (101094128262755427544)
-# prod-enforce: 
-subject_pattern: "(101094128262755427544)"
+# staging-enforce: gh-advisory-push-listener@staging-enforce-cd1e.iam.gserviceaccount.com (102452257683855765349)
+# prod-enforce: TBD 
+subject_pattern: "(102452257683855765349)"
 
 permissions:
   contents: read


### PR DESCRIPTION
The service account has changed. Update the policy to reflect the new service account details.