### PR TITLE
Add Keycloak 26.1.2 `pending-upstream-fix` Event

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -322,6 +322,15 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/keycloak/lib/lib/main/io.quarkus.quarkus-rest-3.15.3.jar
             scanner: grype
+      - timestamp: 2025-02-26T18:43:55Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability impacts Keycloak dependency quarkus-rest version 3.15.3 and is resolved
+            in 3.18.2. Due to breaking changes between these versions a resolution by the upstream is required.
+            This work is currently underway and slated for release in Keycloak version 26.2.0:
+            - https://github.com/keycloak/keycloak/issues/37056
+            - https://github.com/keycloak/keycloak/issues?q=state%3Aopen%20label%3A%22release%2F26.2.0%22
 
   - id: CGA-gc9r-7467-m772
     aliases:


### PR DESCRIPTION
CVE: [CVE-2025-1247](https://github.com/advisories/GHSA-phg3-gv66-q38x)
GitHub Advisory: [GHSA-phg3-gv66-q38x](https://github.com/advisories/GHSA-phg3-gv66-q38x)

`GHSA-phg3-gv66-q38x` cites a CVSS `8.3` vulnerability in `quarkus-rest` with versions `< 3.18.2` impacted.

Keycloak version `26.1.2` currently depends on impacted `quarkus-rest` version `3.15.3`. Attempts to bump `quarkus-rest` to a remediated version results in unresolvable breaking changes.

Reviewing upstream repository `keycloak/keycloak` this CVE will be resolved in upcoming release `26.2.0`:
- https://github.com/keycloak/keycloak/issues/37056
- https://github.com/keycloak/keycloak/issues?q=state%3Aopen%20label%3A%22release%2F26.2.0%22