### PR TITLE
Add Keycloak `*-g6ch` `pending-upstream-fix` Events

### DIFF
--- a/keycloak-operator.advisories.yaml
+++ b/keycloak-operator.advisories.yaml
@@ -94,6 +94,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/quarkus-app/lib/main/org.keycloak.keycloak-core-26.1.2.jar
             scanner: grype
+      - timestamp: 2025-02-27T13:09:14Z
+        type: pending-upstream-fix
+        data:
+          note: At this time there is no additional information from upstream regarding remediation.
 
   - id: CGA-fp8m-fwcf-c57x
     aliases:

--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -429,6 +429,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/keycloak/lib/lib/main/org.keycloak.keycloak-core-26.1.2.jar
             scanner: grype
+      - timestamp: 2025-02-27T13:09:14Z
+        type: pending-upstream-fix
+        data:
+          note: At this time there is no additional information from upstream regarding remediation.
 
   - id: CGA-m894-hrqw-q27v
     aliases:


### PR DESCRIPTION
CVE: [CVE-2024-4028](https://nvd.nist.gov/vuln/detail/CVE-2024-4028)
GitHub Advisory: [GHSA-q4xq-445g-g6ch](https://github.com/advisories/GHSA-q4xq-445g-g6ch)

`GHSA-q4xq-445g-g6ch` cites a CVSS `3.8` vulnerability in `keycloak-core` with versions `<= 26.1.2` impacted.

Reviewing upstream repository `keycloak/keycloak` there is not yet any movement regarding this discovery.
