### PR TITLE
lerna: address several transitive dependencies

### DIFF
--- a/lerna.advisories.yaml
+++ b/lerna.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/local/lib/node_modules/lerna/node_modules/@octokit/plugin-paginate-rest/package.json
             scanner: grype
+      - timestamp: 2025-02-27T23:12:42Z
+        type: pending-upstream-fix
+        data:
+          note: Several lerna v8.2.0 dependencies (including @lerna/legacy-package-management) rely on @octokit/rest@19.0.11, which itself relies on @octokit/plugin-paginate-rest version 6.1.2 as a direct dependency. The fix versions of this dependency are several major versions higher (v9.2.2 or v11.4.1) and will require upstream maintainers to implement.
 
   - id: CGA-8hrm-r7xj-7739
     aliases:
@@ -61,6 +65,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/local/lib/node_modules/lerna/node_modules/@octokit/request/package.json
             scanner: grype
+      - timestamp: 2025-02-27T23:17:16Z
+        type: pending-upstream-fix
+        data:
+          note: Several lerna v8.2.0 dependencies (including @lerna/legacy-package-management) rely on @octokit/core version 19.0.11, which itself relies on @octokit/request version 6.2.8 as a direct dependency. The fix versions of this dependency are several major versions higher (8.4.1 or v9.2.1) and will require upstream maintainers to implement
 
   - id: CGA-8m86-gww5-8pm9
     aliases:
@@ -133,6 +141,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/local/lib/node_modules/lerna/node_modules/@octokit/request-error/package.json
             scanner: grype
+      - timestamp: 2025-02-27T23:16:43Z
+        type: pending-upstream-fix
+        data:
+          note: Several lerna v8.2.0 dependencies (including @lerna/legacy-package-management) rely on @octokit/core@19.0.11, which itself relies on @octokit/request-error version 3.0.3 as a direct dependency. The fix versions of this dependency are several major versions higher (v5.1.1 or v6.1.7) and will require upstream maintainers to implement.
 
   - id: CGA-qc6w-vg37-4pqm
     aliases:


### PR DESCRIPTION
## 1. GHSA-h5c3-5r3r-rr8q- 

**pending-upstream-fix**: Several lerna v8.2.0 dependencies (including @lerna/legacy-package-management) rely on @octokit/rest@19.0.11, which itself relies on @octokit/plugin-paginate-rest version 6.1.2 as a direct dependency. The fix versions of this dependency are several major versions higher (v9.2.2 or v11.4.1) and will require upstream maintainers to implement.

## 2. GHSA-xx4v-prfh-6cgc-

**pending-upstream-fix**: Several lerna v8.2.0 dependencies (including @lerna/legacy-package-management) rely on @octokit/rest@19.0.11, which itself relies on @octokit/request-error version 3.0.3 as a direct dependency. The fix versions of this dependency are several major versions higher (v5.1.1 or v6.1.7) and will require upstream maintainers to implement.

## 3. GHSA-rmvr-2pp2-xj38-

**pending-upstream-fix**: Several lerna v8.2.0 dependencies (including @lerna/legacy-package-management) rely on @octokit/rest version 19.0.11, which itself relies on @octokit/request version 6.2.8 as a direct dependency. The fix versions of this dependency are several major versions higher (8.4.1 or v9.2.1) and will require upstream maintainers to implement.