### PR TITLE
emissary: add pending-upstream-fix for CGA-5ggg-jvf3-xr5v

### DIFF
--- a/emissary.advisories.yaml
+++ b/emissary.advisories.yaml
@@ -65,6 +65,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/busyambassador
             scanner: grype
+      - timestamp: 2025-02-27T23:28:49Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE is caused by Kubernetes v1.28.x and the version of Kubernetes (v1.29.14) that remediates CVE-2025-0426 is incompatible with Emissary v3.9.1. A fix exists upstream for this CVE but is slated for the v4.0.0 release https://github.com/emissary-ingress/emissary/commit/1c96a9 Upstream maintainers must implement remediation for v3.x.x branch.
 
   - id: CGA-6x5x-2jv3-mxqp
     aliases:


### PR DESCRIPTION
Emissary v3.9.1 relies on Kubernetes v1.28.x. The version of Kubernetes (v1.29.14) that remediates CVE-2025-0426 is incompatible with Emissary v3.9.1. Upstream Emissary bumped go from v1.21.10 to v1.22.4 as well as bumped Kubernetes to v1.30.1 in commit 1c96a9df0 ("update go"), which is first tagged in Emissary v3.10.0-rc.0. The most current HEAD of Emissary uses Kubernetes v1.32.1. Upstream maintenance support of Kubernete's v1.28 ended on October 28th 2024.