### PR TITLE
pypy advisories

### DIFF
--- a/pypy-3.10.advisories.yaml
+++ b/pypy-3.10.advisories.yaml
@@ -25,4 +25,4 @@ advisories:
         type: false-positive-determination
         data:
           type: inline-mitigations-exist
-          note: Upstream patched _sha3 module with the XKCP fix for CVE-2022-37454, reference: https://github.com/python/cpython/pull/98519. Additionally, if linking Python 3.10 against OpenSSL 1.1.1 or later, the OpenSSL provided sha3 implementation will be used instead of the vulnerable bundled _sha3 XKCP module code. Reference: https://github.com/python/cpython/issues/98517#issuecomment-1287317496
+          note: Upstream patched _sha3 module with the XKCP fix for CVE-2022-37454, reference:- https://github.com/python/cpython/pull/98519. Additionally, if linking Python 3.10 against OpenSSL 1.1.1 or later, the OpenSSL provided sha3 implementation will be used instead of the vulnerable bundled _sha3 XKCP module code. Reference:- https://github.com/python/cpython/issues/98517#issuecomment-1287317496

--- a/pypy-3.10.advisories.yaml
+++ b/pypy-3.10.advisories.yaml
@@ -25,4 +25,4 @@ advisories:
         type: false-positive-determination
         data:
           type: inline-mitigations-exist
-          note: This vulnerability exploits the _sha3 module to carry out a buffer overflow attack. Upstream has applied a patch, however scanners still detect the vulnerability. The attack is mitigated by the use of openssl greater than 1.1.1 in the package.
+          note: Upstream patched _sha3 module with the XKCP fix for CVE-2022-37454, reference: https://github.com/python/cpython/pull/98519. Additionally, if linking Python 3.10 against OpenSSL 1.1.1 or later, the OpenSSL provided sha3 implementation will be used instead of the vulnerable bundled _sha3 XKCP module code. Reference: https://github.com/python/cpython/issues/98517#issuecomment-1287317496

--- a/pypy-3.10.advisories.yaml
+++ b/pypy-3.10.advisories.yaml
@@ -21,3 +21,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-03-03T14:09:46Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: This vulnerability exploits the _sha3 module to carry out a buffer overflow attack. Upstream has applied a patch, however scanners still detect the vulnerability. The attack is mitigated by the use of openssl greater than 1.1.1 in the package.

--- a/pypy-3.11.advisories.yaml
+++ b/pypy-3.11.advisories.yaml
@@ -25,4 +25,4 @@ advisories:
         type: false-positive-determination
         data:
           type: inline-mitigations-exist
-          note: Upstream patched _sha3 module with the XKCP fix for CVE-2022-37454, reference: https://github.com/python/cpython/pull/98519. Additionally, if linking Python 3.10 against OpenSSL 1.1.1 or later, the OpenSSL provided sha3 implementation will be used instead of the vulnerable bundled _sha3 XKCP module code. Reference: https://github.com/python/cpython/issues/98517#issuecomment-1287317496
+          note: Upstream patched _sha3 module with the XKCP fix for CVE-2022-37454, reference:- https://github.com/python/cpython/pull/98519. Additionally, if linking Python 3.10 against OpenSSL 1.1.1 or later, the OpenSSL provided sha3 implementation will be used instead of the vulnerable bundled _sha3 XKCP module code. Reference:- https://github.com/python/cpython/issues/98517#issuecomment-1287317496

--- a/pypy-3.11.advisories.yaml
+++ b/pypy-3.11.advisories.yaml
@@ -25,4 +25,4 @@ advisories:
         type: false-positive-determination
         data:
           type: inline-mitigations-exist
-          note: This vulnerability exploits the _sha3 module to carry out a buffer overflow attack. Upstream has applied a patch, however scanners still detect the vulnerability. The attack is mitigated by the use of openssl greater than 1.1.1 in the package.
+          note: Upstream patched _sha3 module with the XKCP fix for CVE-2022-37454, reference: https://github.com/python/cpython/pull/98519. Additionally, if linking Python 3.10 against OpenSSL 1.1.1 or later, the OpenSSL provided sha3 implementation will be used instead of the vulnerable bundled _sha3 XKCP module code. Reference: https://github.com/python/cpython/issues/98517#issuecomment-1287317496

--- a/pypy-3.11.advisories.yaml
+++ b/pypy-3.11.advisories.yaml
@@ -21,3 +21,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-03-03T14:11:29Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: This vulnerability exploits the _sha3 module to carry out a buffer overflow attack. Upstream has applied a patch, however scanners still detect the vulnerability. The attack is mitigated by the use of openssl greater than 1.1.1 in the package.


### PR DESCRIPTION
Adding false positive determinations for CVE-2022-37454 in pypy 3.10 and pypy 3.11 buffer overflow vulnerability in _sha3 module