### PR TITLE
dependency-track/advisory update

### DIFF
--- a/dependency-track.advisories.yaml
+++ b/dependency-track.advisories.yaml
@@ -103,6 +103,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/dependency-track/dependency-track-bundled.jar
             scanner: grype
+      - timestamp: 2025-03-04T14:12:32Z
+        type: pending-upstream-fix
+        data:
+          note: 'The upstream Pebble maintainer needs to sanitize input to mitigate CVE-2025-1686. For further details, refer to the upstream issue: https://github.com/PebbleTemplates/pebble/issues/688.'
 
   - id: CGA-fjg5-9m84-p3v7
     aliases:


### PR DESCRIPTION
Updating advisory for CVE-2025-1686. 
Pebble upstream has issue created: https://github.com/PebbleTemplates/pebble/issues/688