### PR TITLE
CVE-2019-3826/advisory update all packages

### DIFF
--- a/amazon-cloudwatch-agent-operator.advisories.yaml
+++ b/amazon-cloudwatch-agent-operator.advisories.yaml
@@ -39,6 +39,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/manager
             scanner: grype
+      - timestamp: 2025-03-04T17:56:00Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-hx53-29r5-p52v
     aliases:

--- a/amazon-cloudwatch-agent.advisories.yaml
+++ b/amazon-cloudwatch-agent.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/config-translator
             scanner: grype
+      - timestamp: 2025-03-04T17:57:41Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-9gxf-mw59-grhv
     aliases:

--- a/certificate-transparency.advisories.yaml
+++ b/certificate-transparency.advisories.yaml
@@ -203,6 +203,11 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
+      - timestamp: 2025-03-04T17:57:49Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-pj9h-x4rj-mvm4
     aliases:

--- a/cloud-sql-proxy.advisories.yaml
+++ b/cloud-sql-proxy.advisories.yaml
@@ -152,6 +152,11 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
+      - timestamp: 2025-03-04T17:57:56Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-pcfg-c64m-9rp4
     aliases:

--- a/cortex.advisories.yaml
+++ b/cortex.advisories.yaml
@@ -424,6 +424,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cortex
             scanner: grype
+      - timestamp: 2025-03-04T17:58:04Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-wp25-m83f-pj7c
     aliases:

--- a/fluent-bit-plugin-loki.advisories.yaml
+++ b/fluent-bit-plugin-loki.advisories.yaml
@@ -107,6 +107,11 @@ advisories:
             componentType: go-module
             componentLocation: /fluent-bit/bin/out_grafana_loki.so
             scanner: grype
+      - timestamp: 2025-03-04T17:58:12Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-c5rp-h7pq-pjj8
     aliases:

--- a/gatekeeper-3.12.advisories.yaml
+++ b/gatekeeper-3.12.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: gatekeeper-3.12
 
 advisories:
+  - id: CGA-4jxp-pqx7-2wh9
+    aliases:
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2023-12-20T05:10:32Z
+        type: fixed
+        data:
+          fixed-version: 3.12.0-r10
+
   - id: CGA-7m2j-34vv-259p
     aliases:
       - CVE-2019-3826
@@ -14,6 +24,11 @@ advisories:
         data:
           type: vulnerable-code-not-in-execution-path
           note: This CVE affects the Prometheus UI (Javascript) and not the Go code
+      - timestamp: 2025-03-04T17:58:20Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-9fj5-95wq-fvv4
     aliases:
@@ -26,50 +41,27 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Go vulndb has marked this code NOT_IMPORTABLE.
 
-  - id: CGA-rh73-qrqq-h4h3
+  - id: CGA-fwxr-pj95-qhp7
     aliases:
-      - CVE-2023-39325
-      - GHSA-4374-p667-p6c8
+      - CVE-2024-24785
+      - GHSA-j6m3-gc37-6r6q
     events:
-      - timestamp: 2023-10-16T21:02:05Z
+      - timestamp: 2024-03-12T07:05:16Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: gatekeeper-3.12
+            componentID: 6485a559e6ed1f9a
+            componentName: stdlib
+            componentVersion: go1.21.5
+            componentType: go-module
+            componentLocation: /usr/bin/manager
+            scanner: grype
+      - timestamp: 2024-03-12T07:06:11Z
         type: fixed
         data:
-          fixed-version: 3.12.0-r6
-
-  - id: CGA-qvpc-m8j7-qwg7
-    aliases:
-      - CVE-2023-3978
-      - GHSA-2wrh-6pvc-2jm9
-    events:
-      - timestamp: 2023-10-16T21:02:23Z
-        type: fixed
-        data:
-          fixed-version: 3.12.0-r6
-
-  - id: CGA-qj23-2j5c-346p
-    aliases:
-      - CVE-2023-44487
-      - GHSA-m425-mq94-257g
-      - GHSA-qppj-fm5r-hxr3
-    events:
-      - timestamp: 2023-10-16T21:02:44Z
-        type: fixed
-        data:
-          fixed-version: 3.12.0-r6
-      - timestamp: 2023-11-06T22:59:34Z
-        type: fixed
-        data:
-          fixed-version: 3.12.0-r8
-
-  - id: CGA-rqx3-9jjw-vx9v
-    aliases:
-      - CVE-2023-45142
-      - GHSA-rcjv-mgp8-qvmr
-    events:
-      - timestamp: 2023-10-23T12:04:06Z
-        type: fixed
-        data:
-          fixed-version: 3.12.0-r7
+          fixed-version: 3.12.0-r11
 
   - id: CGA-g39q-97qm-89qh
     aliases:
@@ -81,89 +73,6 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
-
-  - id: CGA-hxj7-v8pc-h734
-    aliases:
-      - CVE-2023-45284
-      - GHSA-rq3x-83w4-p28c
-    events:
-      - timestamp: 2023-11-07T19:27:29Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
-  - id: CGA-qx3h-7mxx-r8xv
-    aliases:
-      - CVE-2023-45288
-      - GHSA-4v7x-pqxf-cx7m
-    events:
-      - timestamp: 2024-04-12T08:28:09Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: gatekeeper-3.12
-            componentID: 40dd04d6db52e064
-            componentName: stdlib
-            componentVersion: go1.22.1
-            componentType: go-module
-            componentLocation: /usr/bin/manager
-            scanner: grype
-
-  - id: CGA-hfmv-9hhp-5pwg
-    aliases:
-      - CVE-2023-45289
-      - GHSA-32ch-6x54-q4h9
-    events:
-      - timestamp: 2024-03-12T07:05:09Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: gatekeeper-3.12
-            componentID: 6485a559e6ed1f9a
-            componentName: stdlib
-            componentVersion: go1.21.5
-            componentType: go-module
-            componentLocation: /usr/bin/manager
-            scanner: grype
-      - timestamp: 2024-03-12T07:06:12Z
-        type: fixed
-        data:
-          fixed-version: 3.12.0-r11
-
-  - id: CGA-p562-3cfw-rv2w
-    aliases:
-      - CVE-2023-45290
-      - GHSA-rr6r-cfgf-gc6h
-    events:
-      - timestamp: 2024-03-12T07:05:11Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: gatekeeper-3.12
-            componentID: 6485a559e6ed1f9a
-            componentName: stdlib
-            componentVersion: go1.21.5
-            componentType: go-module
-            componentLocation: /usr/bin/manager
-            scanner: grype
-      - timestamp: 2024-03-12T07:06:07Z
-        type: fixed
-        data:
-          fixed-version: 3.12.0-r11
-
-  - id: CGA-4jxp-pqx7-2wh9
-    aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
-    events:
-      - timestamp: 2023-12-20T05:10:32Z
-        type: fixed
-        data:
-          fixed-version: 3.12.0-r10
 
   - id: CGA-h77j-hj9f-qhvg
     aliases:
@@ -187,6 +96,104 @@ advisories:
         data:
           fixed-version: 3.12.0-r11
 
+  - id: CGA-hfmv-9hhp-5pwg
+    aliases:
+      - CVE-2023-45289
+      - GHSA-32ch-6x54-q4h9
+    events:
+      - timestamp: 2024-03-12T07:05:09Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: gatekeeper-3.12
+            componentID: 6485a559e6ed1f9a
+            componentName: stdlib
+            componentVersion: go1.21.5
+            componentType: go-module
+            componentLocation: /usr/bin/manager
+            scanner: grype
+      - timestamp: 2024-03-12T07:06:12Z
+        type: fixed
+        data:
+          fixed-version: 3.12.0-r11
+
+  - id: CGA-hxj7-v8pc-h734
+    aliases:
+      - CVE-2023-45284
+      - GHSA-rq3x-83w4-p28c
+    events:
+      - timestamp: 2023-11-07T19:27:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-p562-3cfw-rv2w
+    aliases:
+      - CVE-2023-45290
+      - GHSA-rr6r-cfgf-gc6h
+    events:
+      - timestamp: 2024-03-12T07:05:11Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: gatekeeper-3.12
+            componentID: 6485a559e6ed1f9a
+            componentName: stdlib
+            componentVersion: go1.21.5
+            componentType: go-module
+            componentLocation: /usr/bin/manager
+            scanner: grype
+      - timestamp: 2024-03-12T07:06:07Z
+        type: fixed
+        data:
+          fixed-version: 3.12.0-r11
+
+  - id: CGA-qj23-2j5c-346p
+    aliases:
+      - CVE-2023-44487
+      - GHSA-m425-mq94-257g
+      - GHSA-qppj-fm5r-hxr3
+    events:
+      - timestamp: 2023-10-16T21:02:44Z
+        type: fixed
+        data:
+          fixed-version: 3.12.0-r6
+      - timestamp: 2023-11-06T22:59:34Z
+        type: fixed
+        data:
+          fixed-version: 3.12.0-r8
+
+  - id: CGA-qvpc-m8j7-qwg7
+    aliases:
+      - CVE-2023-3978
+      - GHSA-2wrh-6pvc-2jm9
+    events:
+      - timestamp: 2023-10-16T21:02:23Z
+        type: fixed
+        data:
+          fixed-version: 3.12.0-r6
+
+  - id: CGA-qx3h-7mxx-r8xv
+    aliases:
+      - CVE-2023-45288
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-12T08:28:09Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: gatekeeper-3.12
+            componentID: 40dd04d6db52e064
+            componentName: stdlib
+            componentVersion: go1.22.1
+            componentType: go-module
+            componentLocation: /usr/bin/manager
+            scanner: grype
+
   - id: CGA-r57q-67xj-c662
     aliases:
       - CVE-2024-24784
@@ -209,27 +216,25 @@ advisories:
         data:
           fixed-version: 3.12.0-r11
 
-  - id: CGA-fwxr-pj95-qhp7
+  - id: CGA-rh73-qrqq-h4h3
     aliases:
-      - CVE-2024-24785
-      - GHSA-j6m3-gc37-6r6q
+      - CVE-2023-39325
+      - GHSA-4374-p667-p6c8
     events:
-      - timestamp: 2024-03-12T07:05:16Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: gatekeeper-3.12
-            componentID: 6485a559e6ed1f9a
-            componentName: stdlib
-            componentVersion: go1.21.5
-            componentType: go-module
-            componentLocation: /usr/bin/manager
-            scanner: grype
-      - timestamp: 2024-03-12T07:06:11Z
+      - timestamp: 2023-10-16T21:02:05Z
         type: fixed
         data:
-          fixed-version: 3.12.0-r11
+          fixed-version: 3.12.0-r6
+
+  - id: CGA-rqx3-9jjw-vx9v
+    aliases:
+      - CVE-2023-45142
+      - GHSA-rcjv-mgp8-qvmr
+    events:
+      - timestamp: 2023-10-23T12:04:06Z
+        type: fixed
+        data:
+          fixed-version: 3.12.0-r7
 
   - id: CGA-x6jx-p3g9-w3j8
     aliases:

--- a/gatekeeper-3.13.advisories.yaml
+++ b/gatekeeper-3.13.advisories.yaml
@@ -4,16 +4,35 @@ package:
   name: gatekeeper-3.13
 
 advisories:
-  - id: CGA-qmmp-9cm3-4xhv
+  - id: CGA-8cw3-86j9-wp6g
     aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
+      - CVE-2023-45142
+      - GHSA-rcjv-mgp8-qvmr
     events:
-      - timestamp: 2023-08-30T19:53:46Z
-        type: false-positive-determination
+      - timestamp: 2023-10-23T12:04:06Z
+        type: fixed
         data:
-          type: vulnerable-code-not-in-execution-path
-          note: This CVE affects the Prometheus UI (Javascript) and not the Go code
+          fixed-version: 3.13.3-r1
+
+  - id: CGA-9r8w-vph3-6vcf
+    aliases:
+      - CVE-2024-24784
+      - GHSA-fgq5-q76c-gx78
+    events:
+      - timestamp: 2024-03-12T10:03:04Z
+        type: fixed
+        data:
+          fixed-version: 3.13.4-r3
+
+  - id: CGA-cr23-7245-4599
+    aliases:
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2024-02-15T07:42:53Z
+        type: fixed
+        data:
+          fixed-version: 3.13.4-r2
 
   - id: CGA-gw6r-3j9j-6g3j
     aliases:
@@ -26,15 +45,15 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Go vulndb has marked this code NOT_IMPORTABLE.
 
-  - id: CGA-8cw3-86j9-wp6g
+  - id: CGA-p43x-hxp2-cpfr
     aliases:
-      - CVE-2023-45142
-      - GHSA-rcjv-mgp8-qvmr
+      - CVE-2023-45290
+      - GHSA-rr6r-cfgf-gc6h
     events:
-      - timestamp: 2023-10-23T12:04:06Z
+      - timestamp: 2024-03-12T10:03:02Z
         type: fixed
         data:
-          fixed-version: 3.13.3-r1
+          fixed-version: 3.13.4-r3
 
   - id: CGA-q386-rvx5-jp3w
     aliases:
@@ -42,17 +61,6 @@ advisories:
       - GHSA-vvjp-q62m-2vph
     events:
       - timestamp: 2023-11-07T19:27:31Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
-  - id: CGA-x56p-rpc8-fhrr
-    aliases:
-      - CVE-2023-45284
-      - GHSA-rq3x-83w4-p28c
-    events:
-      - timestamp: 2023-11-07T19:27:33Z
         type: false-positive-determination
         data:
           type: vulnerable-code-not-included-in-package
@@ -68,55 +76,21 @@ advisories:
         data:
           fixed-version: 3.13.4-r3
 
-  - id: CGA-p43x-hxp2-cpfr
+  - id: CGA-qmmp-9cm3-4xhv
     aliases:
-      - CVE-2023-45290
-      - GHSA-rr6r-cfgf-gc6h
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
     events:
-      - timestamp: 2024-03-12T10:03:02Z
-        type: fixed
+      - timestamp: 2023-08-30T19:53:46Z
+        type: false-positive-determination
         data:
-          fixed-version: 3.13.4-r3
-
-  - id: CGA-cr23-7245-4599
-    aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
-    events:
-      - timestamp: 2024-02-15T07:42:53Z
-        type: fixed
+          type: vulnerable-code-not-in-execution-path
+          note: This CVE affects the Prometheus UI (Javascript) and not the Go code
+      - timestamp: 2025-03-04T17:58:28Z
+        type: false-positive-determination
         data:
-          fixed-version: 3.13.4-r2
-
-  - id: CGA-wwcx-5ff8-rj4x
-    aliases:
-      - CVE-2024-24783
-      - GHSA-3q2c-pvp5-3cqp
-    events:
-      - timestamp: 2024-03-12T10:03:03Z
-        type: fixed
-        data:
-          fixed-version: 3.13.4-r3
-
-  - id: CGA-9r8w-vph3-6vcf
-    aliases:
-      - CVE-2024-24784
-      - GHSA-fgq5-q76c-gx78
-    events:
-      - timestamp: 2024-03-12T10:03:04Z
-        type: fixed
-        data:
-          fixed-version: 3.13.4-r3
-
-  - id: CGA-wr4c-xjwx-q848
-    aliases:
-      - CVE-2024-24785
-      - GHSA-j6m3-gc37-6r6q
-    events:
-      - timestamp: 2024-03-12T10:03:00Z
-        type: fixed
-        data:
-          fixed-version: 3.13.4-r3
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-v6wq-wfrv-c3qf
     aliases:
@@ -139,3 +113,34 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.13.4-r4
+
+  - id: CGA-wr4c-xjwx-q848
+    aliases:
+      - CVE-2024-24785
+      - GHSA-j6m3-gc37-6r6q
+    events:
+      - timestamp: 2024-03-12T10:03:00Z
+        type: fixed
+        data:
+          fixed-version: 3.13.4-r3
+
+  - id: CGA-wwcx-5ff8-rj4x
+    aliases:
+      - CVE-2024-24783
+      - GHSA-3q2c-pvp5-3cqp
+    events:
+      - timestamp: 2024-03-12T10:03:03Z
+        type: fixed
+        data:
+          fixed-version: 3.13.4-r3
+
+  - id: CGA-x56p-rpc8-fhrr
+    aliases:
+      - CVE-2023-45284
+      - GHSA-rq3x-83w4-p28c
+    events:
+      - timestamp: 2023-11-07T19:27:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows

--- a/gatekeeper-3.14.advisories.yaml
+++ b/gatekeeper-3.14.advisories.yaml
@@ -91,6 +91,11 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
+      - timestamp: 2025-03-04T17:58:36Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-chhg-fpxj-j88v
     aliases:

--- a/gcsfuse.advisories.yaml
+++ b/gcsfuse.advisories.yaml
@@ -31,6 +31,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gcsfuse
             scanner: grype
+      - timestamp: 2025-03-04T17:58:44Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-3h2r-hq3h-6xmf
     aliases:

--- a/gitaly-17.9.advisories.yaml
+++ b/gitaly-17.9.advisories.yaml
@@ -21,3 +21,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gitaly
             scanner: grype
+      - timestamp: 2025-03-04T17:58:52Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.

--- a/grafana-11.5.advisories.yaml
+++ b/grafana-11.5.advisories.yaml
@@ -86,6 +86,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/grafana
             scanner: grype
+      - timestamp: 2025-03-04T17:58:59Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-vw8v-gg4v-m9rg
     aliases:

--- a/grafana.advisories.yaml
+++ b/grafana.advisories.yaml
@@ -4,28 +4,6 @@ package:
   name: grafana
 
 advisories:
-  - id: CGA-hw2w-w5j9-96vf
-    aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
-    events:
-      - timestamp: 2023-12-14T10:32:41Z
-        type: false-positive-determination
-        data:
-          type: component-vulnerability-mismatch
-          note: Go modules are not identifiying the version correctly. Example, v1.8.2-0.20211011171444-354d8d2ecfac is not v1.8.2, using the date and commit sha we can see that this is v2.31.0-rc.0~39 which contains the fix.
-
-  - id: CGA-jxr3-5j3m-vxx8
-    aliases:
-      - CVE-2023-45283
-      - GHSA-vvjp-q62m-2vph
-    events:
-      - timestamp: 2023-11-07T19:28:37Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
   - id: CGA-5f4j-2xph-wmq2
     aliases:
       - CVE-2023-45284
@@ -55,15 +33,15 @@ advisories:
             componentLocation: /usr/bin/grafana
             scanner: grype
 
-  - id: CGA-h437-rw82-45c8
+  - id: CGA-85wh-38wf-qwmf
     aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
+      - CVE-2024-1442
+      - GHSA-5mxf-42f5-j782
     events:
-      - timestamp: 2023-12-19T20:58:19Z
+      - timestamp: 2024-03-08T07:18:33Z
         type: fixed
         data:
-          fixed-version: 10.2.3-r1
+          fixed-version: 10.4.0-r0
 
   - id: CGA-89jf-47wm-w9rp
     aliases:
@@ -87,16 +65,6 @@ advisories:
         data:
           fixed-version: 10.3.3-r0
 
-  - id: CGA-85wh-38wf-qwmf
-    aliases:
-      - CVE-2024-1442
-      - GHSA-5mxf-42f5-j782
-    events:
-      - timestamp: 2024-03-08T07:18:33Z
-        type: fixed
-        data:
-          fixed-version: 10.4.0-r0
-
   - id: CGA-9hh3-5qwj-hh48
     aliases:
       - CVE-2024-24786
@@ -118,6 +86,86 @@ advisories:
         type: fixed
         data:
           fixed-version: 10.4.0-r3
+
+  - id: CGA-h437-rw82-45c8
+    aliases:
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2023-12-19T20:58:19Z
+        type: fixed
+        data:
+          fixed-version: 10.2.3-r1
+
+  - id: CGA-hw2w-w5j9-96vf
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-12-14T10:32:41Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Go modules are not identifiying the version correctly. Example, v1.8.2-0.20211011171444-354d8d2ecfac is not v1.8.2, using the date and commit sha we can see that this is v2.31.0-rc.0~39 which contains the fix.
+      - timestamp: 2025-03-04T17:59:07Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
+
+  - id: CGA-jxr3-5j3m-vxx8
+    aliases:
+      - CVE-2023-45283
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-11-07T19:28:37Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-p7pg-p7jj-xh8g
+    aliases:
+      - GHSA-9763-4f94-gfch
+    events:
+      - timestamp: 2024-01-11T07:19:14Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: grafana
+            componentID: 3e3db7e99fc61bc6
+            componentName: github.com/cloudflare/circl
+            componentVersion: v1.3.3
+            componentType: go-module
+            componentLocation: /usr/bin/grafana
+            scanner: grype
+      - timestamp: 2024-01-23T17:32:11Z
+        type: fixed
+        data:
+          fixed-version: 10.3.1-r0
+
+  - id: CGA-vr5c-cpcm-xcwc
+    aliases:
+      - CVE-2024-28180
+      - GHSA-c5q2-7r4c-mv6g
+    events:
+      - timestamp: 2024-03-08T07:18:33Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: grafana
+            componentID: c3916d13aa91e911
+            componentName: github.com/go-jose/go-jose/v3
+            componentVersion: v3.0.1
+            componentType: go-module
+            componentLocation: /usr/bin/grafana
+            scanner: grype
+      - timestamp: 2024-03-08T07:50:30Z
+        type: fixed
+        data:
+          fixed-version: 10.4.0-r1
 
   - id: CGA-xcf7-p2w4-pv5r
     aliases:
@@ -154,46 +202,3 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/grafana-server
             scanner: grype
-
-  - id: CGA-vr5c-cpcm-xcwc
-    aliases:
-      - CVE-2024-28180
-      - GHSA-c5q2-7r4c-mv6g
-    events:
-      - timestamp: 2024-03-08T07:18:33Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: grafana
-            componentID: c3916d13aa91e911
-            componentName: github.com/go-jose/go-jose/v3
-            componentVersion: v3.0.1
-            componentType: go-module
-            componentLocation: /usr/bin/grafana
-            scanner: grype
-      - timestamp: 2024-03-08T07:50:30Z
-        type: fixed
-        data:
-          fixed-version: 10.4.0-r1
-
-  - id: CGA-p7pg-p7jj-xh8g
-    aliases:
-      - GHSA-9763-4f94-gfch
-    events:
-      - timestamp: 2024-01-11T07:19:14Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: grafana
-            componentID: 3e3db7e99fc61bc6
-            componentName: github.com/cloudflare/circl
-            componentVersion: v1.3.3
-            componentType: go-module
-            componentLocation: /usr/bin/grafana
-            scanner: grype
-      - timestamp: 2024-01-23T17:32:11Z
-        type: fixed
-        data:
-          fixed-version: 10.3.1-r0

--- a/istio-1.24.advisories.yaml
+++ b/istio-1.24.advisories.yaml
@@ -75,6 +75,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/istioctl
             scanner: grype
+      - timestamp: 2025-03-04T17:59:15Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-pg9v-2xr3-55x6
     aliases:

--- a/istio-operator-1.19.advisories.yaml
+++ b/istio-operator-1.19.advisories.yaml
@@ -4,6 +4,37 @@ package:
   name: istio-operator-1.19
 
 advisories:
+  - id: CGA-23rr-97f7-mxmw
+    aliases:
+      - GHSA-jq35-85cj-fj4p
+    events:
+      - timestamp: 2023-10-31T20:03:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is in the container runtime itself, not clients of the container runtime.
+
+  - id: CGA-24w2-65f6-7j2q
+    aliases:
+      - CVE-2023-39325
+      - GHSA-4374-p667-p6c8
+    events:
+      - timestamp: 2023-10-12T22:19:15Z
+        type: fixed
+        data:
+          fixed-version: 1.19.3-r0
+
+  - id: CGA-385m-22vr-r2p8
+    aliases:
+      - CVE-2023-45284
+      - GHSA-rq3x-83w4-p28c
+    events:
+      - timestamp: 2023-11-07T19:29:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
   - id: CGA-4w9g-ffhm-3ppm
     aliases:
       - CVE-2019-25210
@@ -27,69 +58,6 @@ advisories:
           type: vulnerability-record-analysis-contested
           note: 'This is not a vulnerability. Learn more about the response from Helm: https://helm.sh/blog/response-cve-2019-25210'
 
-  - id: CGA-fqxp-3f84-p2m9
-    aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
-    events:
-      - timestamp: 2023-09-25T20:27:23Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-version-not-used
-          note: Prometheus version 0.45 is actually 2.45 which is newer than the fixed version 2.7.1
-
-  - id: CGA-24w2-65f6-7j2q
-    aliases:
-      - CVE-2023-39325
-      - GHSA-4374-p667-p6c8
-    events:
-      - timestamp: 2023-10-12T22:19:15Z
-        type: fixed
-        data:
-          fixed-version: 1.19.3-r0
-
-  - id: CGA-xgxx-84wg-g98c
-    aliases:
-      - CVE-2023-45283
-      - GHSA-vvjp-q62m-2vph
-    events:
-      - timestamp: 2023-11-07T19:29:42Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
-  - id: CGA-385m-22vr-r2p8
-    aliases:
-      - CVE-2023-45284
-      - GHSA-rq3x-83w4-p28c
-    events:
-      - timestamp: 2023-11-07T19:29:44Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
-  - id: CGA-j54h-h9g9-4f32
-    aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
-    events:
-      - timestamp: 2023-12-20T13:01:03Z
-        type: fixed
-        data:
-          fixed-version: 1.19.5-r2
-
-  - id: CGA-98fp-p2m3-rmx5
-    aliases:
-      - CVE-2023-49290
-      - GHSA-7f9x-gw85-8grf
-    events:
-      - timestamp: 2024-01-24T17:13:01Z
-        type: fixed
-        data:
-          fixed-version: 1.19.6-r1
-
   - id: CGA-57v2-mmmr-jq8g
     aliases:
       - CVE-2024-21664
@@ -112,27 +80,15 @@ advisories:
         data:
           fixed-version: 1.19.6-r2
 
-  - id: CGA-vj2x-r92w-wrxm
+  - id: CGA-98fp-p2m3-rmx5
     aliases:
-      - CVE-2024-25620
-      - GHSA-v53g-5gjp-272r
+      - CVE-2023-49290
+      - GHSA-7f9x-gw85-8grf
     events:
-      - timestamp: 2024-02-16T07:38:59Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-operator-1.19
-            componentID: d9aa68be3258c586
-            componentName: helm.sh/helm/v3
-            componentVersion: v3.12.2
-            componentType: go-module
-            componentLocation: /usr/bin/operator
-            scanner: grype
-      - timestamp: 2024-02-24T17:03:16Z
+      - timestamp: 2024-01-24T17:13:01Z
         type: fixed
         data:
-          fixed-version: 1.19.7-r1
+          fixed-version: 1.19.6-r1
 
   - id: CGA-cffv-prrf-jc52
     aliases:
@@ -155,6 +111,22 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.19.7-r1
+
+  - id: CGA-fqxp-3f84-p2m9
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-09-25T20:27:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Prometheus version 0.45 is actually 2.45 which is newer than the fixed version 2.7.1
+      - timestamp: 2025-03-04T17:59:23Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-fxch-3g4r-m82f
     aliases:
@@ -183,12 +155,45 @@ advisories:
             componentLocation: /usr/bin/operator
             scanner: grype
 
-  - id: CGA-23rr-97f7-mxmw
+  - id: CGA-j54h-h9g9-4f32
     aliases:
-      - GHSA-jq35-85cj-fj4p
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
     events:
-      - timestamp: 2023-10-31T20:03:50Z
+      - timestamp: 2023-12-20T13:01:03Z
+        type: fixed
+        data:
+          fixed-version: 1.19.5-r2
+
+  - id: CGA-vj2x-r92w-wrxm
+    aliases:
+      - CVE-2024-25620
+      - GHSA-v53g-5gjp-272r
+    events:
+      - timestamp: 2024-02-16T07:38:59Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-operator-1.19
+            componentID: d9aa68be3258c586
+            componentName: helm.sh/helm/v3
+            componentVersion: v3.12.2
+            componentType: go-module
+            componentLocation: /usr/bin/operator
+            scanner: grype
+      - timestamp: 2024-02-24T17:03:16Z
+        type: fixed
+        data:
+          fixed-version: 1.19.7-r1
+
+  - id: CGA-xgxx-84wg-g98c
+    aliases:
+      - CVE-2023-45283
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-11-07T19:29:42Z
         type: false-positive-determination
         data:
           type: vulnerable-code-not-included-in-package
-          note: This vulnerability is in the container runtime itself, not clients of the container runtime.
+          note: Only affects Windows

--- a/istio-operator-1.20.advisories.yaml
+++ b/istio-operator-1.20.advisories.yaml
@@ -4,28 +4,27 @@ package:
   name: istio-operator-1.20
 
 advisories:
-  - id: CGA-r776-6mc7-f8cc
+  - id: CGA-2mhf-548x-p4qh
     aliases:
-      - CVE-2019-25210
-      - GHSA-jw44-4f3j-q396
+      - CVE-2024-28180
+      - GHSA-c5q2-7r4c-mv6g
     events:
-      - timestamp: 2024-03-06T07:13:26Z
+      - timestamp: 2024-03-08T07:12:10Z
         type: detection
         data:
           type: scan/v1
           data:
             subpackageName: istio-operator-1.20
-            componentID: 3f9e5ce749ddac88
-            componentName: helm.sh/helm/v3
-            componentVersion: v3.14.2
+            componentID: 0bdfc2b42062fc77
+            componentName: github.com/go-jose/go-jose/v3
+            componentVersion: v3.0.1
             componentType: go-module
             componentLocation: /usr/bin/operator
             scanner: grype
-      - timestamp: 2024-03-15T00:01:21Z
-        type: false-positive-determination
+      - timestamp: 2024-03-11T00:36:33Z
+        type: fixed
         data:
-          type: vulnerability-record-analysis-contested
-          note: 'This is not a vulnerability. Learn more about the response from Helm: https://helm.sh/blog/response-cve-2019-25210'
+          fixed-version: 1.20.3-r4
 
   - id: CGA-3hw4-84cc-cxfx
     aliases:
@@ -37,78 +36,11 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
-
-  - id: CGA-7hqf-rjrv-wf33
-    aliases:
-      - CVE-2023-45288
-      - GHSA-4v7x-pqxf-cx7m
-    events:
-      - timestamp: 2024-04-09T10:50:44Z
-        type: detection
+      - timestamp: 2025-03-04T17:59:31Z
+        type: false-positive-determination
         data:
-          type: scan/v1
-          data:
-            subpackageName: istio-operator-1.20
-            componentID: 14cf3549a3369b6c
-            componentName: stdlib
-            componentVersion: go1.22.1
-            componentType: go-module
-            componentLocation: /usr/bin/operator
-            scanner: grype
-
-  - id: CGA-6v8q-9jxr-669v
-    aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
-    events:
-      - timestamp: 2023-12-20T13:01:28Z
-        type: fixed
-        data:
-          fixed-version: 1.20.1-r2
-
-  - id: CGA-hj9h-6h2x-49ph
-    aliases:
-      - CVE-2023-49290
-      - GHSA-7f9x-gw85-8grf
-    events:
-      - timestamp: 2024-01-24T07:11:51Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-operator-1.20
-            componentID: 66e705f1026a41b9
-            componentName: github.com/lestrrat-go/jwx
-            componentVersion: v1.2.26
-            componentType: go-module
-            componentLocation: /usr/bin/operator
-            scanner: grype
-      - timestamp: 2024-01-24T17:13:06Z
-        type: fixed
-        data:
-          fixed-version: 1.20.2-r1
-
-  - id: CGA-rjc7-4vhw-626h
-    aliases:
-      - CVE-2024-21664
-      - GHSA-pvcr-v8j8-j5q3
-    events:
-      - timestamp: 2024-01-24T07:11:52Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-operator-1.20
-            componentID: 66e705f1026a41b9
-            componentName: github.com/lestrrat-go/jwx
-            componentVersion: v1.2.26
-            componentType: go-module
-            componentLocation: /usr/bin/operator
-            scanner: grype
-      - timestamp: 2024-01-26T08:34:14Z
-        type: fixed
-        data:
-          fixed-version: 1.20.2-r2
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-62hc-f7cq-6cq5
     aliases:
@@ -127,50 +59,6 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/operator
             scanner: grype
-
-  - id: CGA-wh8p-rp2w-p5mj
-    aliases:
-      - CVE-2024-24786
-      - GHSA-8r3f-844c-mc37
-    events:
-      - timestamp: 2024-03-14T08:18:55Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-operator-1.20
-            componentID: 2390df842be342eb
-            componentName: google.golang.org/protobuf
-            componentVersion: v1.31.0
-            componentType: go-module
-            componentLocation: /usr/bin/operator
-            scanner: grype
-      - timestamp: 2024-03-14T18:49:07Z
-        type: fixed
-        data:
-          fixed-version: 1.20.4-r1
-
-  - id: CGA-cj83-4cc6-2j6c
-    aliases:
-      - CVE-2024-25620
-      - GHSA-v53g-5gjp-272r
-    events:
-      - timestamp: 2024-02-16T07:19:04Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-operator-1.20
-            componentID: 46b8774dd70cb68d
-            componentName: helm.sh/helm/v3
-            componentVersion: v3.12.3
-            componentType: go-module
-            componentLocation: /usr/bin/operator
-            scanner: grype
-      - timestamp: 2024-02-18T13:37:16Z
-        type: fixed
-        data:
-          fixed-version: 1.20.3-r1
 
   - id: CGA-6qr5-2pq4-4j8h
     aliases:
@@ -194,6 +82,123 @@ advisories:
         data:
           fixed-version: 1.20.3-r2
 
+  - id: CGA-6v8q-9jxr-669v
+    aliases:
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2023-12-20T13:01:28Z
+        type: fixed
+        data:
+          fixed-version: 1.20.1-r2
+
+  - id: CGA-7hqf-rjrv-wf33
+    aliases:
+      - CVE-2023-45288
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-09T10:50:44Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-operator-1.20
+            componentID: 14cf3549a3369b6c
+            componentName: stdlib
+            componentVersion: go1.22.1
+            componentType: go-module
+            componentLocation: /usr/bin/operator
+            scanner: grype
+
+  - id: CGA-cj83-4cc6-2j6c
+    aliases:
+      - CVE-2024-25620
+      - GHSA-v53g-5gjp-272r
+    events:
+      - timestamp: 2024-02-16T07:19:04Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-operator-1.20
+            componentID: 46b8774dd70cb68d
+            componentName: helm.sh/helm/v3
+            componentVersion: v3.12.3
+            componentType: go-module
+            componentLocation: /usr/bin/operator
+            scanner: grype
+      - timestamp: 2024-02-18T13:37:16Z
+        type: fixed
+        data:
+          fixed-version: 1.20.3-r1
+
+  - id: CGA-hj9h-6h2x-49ph
+    aliases:
+      - CVE-2023-49290
+      - GHSA-7f9x-gw85-8grf
+    events:
+      - timestamp: 2024-01-24T07:11:51Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-operator-1.20
+            componentID: 66e705f1026a41b9
+            componentName: github.com/lestrrat-go/jwx
+            componentVersion: v1.2.26
+            componentType: go-module
+            componentLocation: /usr/bin/operator
+            scanner: grype
+      - timestamp: 2024-01-24T17:13:06Z
+        type: fixed
+        data:
+          fixed-version: 1.20.2-r1
+
+  - id: CGA-r776-6mc7-f8cc
+    aliases:
+      - CVE-2019-25210
+      - GHSA-jw44-4f3j-q396
+    events:
+      - timestamp: 2024-03-06T07:13:26Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-operator-1.20
+            componentID: 3f9e5ce749ddac88
+            componentName: helm.sh/helm/v3
+            componentVersion: v3.14.2
+            componentType: go-module
+            componentLocation: /usr/bin/operator
+            scanner: grype
+      - timestamp: 2024-03-15T00:01:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: 'This is not a vulnerability. Learn more about the response from Helm: https://helm.sh/blog/response-cve-2019-25210'
+
+  - id: CGA-rjc7-4vhw-626h
+    aliases:
+      - CVE-2024-21664
+      - GHSA-pvcr-v8j8-j5q3
+    events:
+      - timestamp: 2024-01-24T07:11:52Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-operator-1.20
+            componentID: 66e705f1026a41b9
+            componentName: github.com/lestrrat-go/jwx
+            componentVersion: v1.2.26
+            componentType: go-module
+            componentLocation: /usr/bin/operator
+            scanner: grype
+      - timestamp: 2024-01-26T08:34:14Z
+        type: fixed
+        data:
+          fixed-version: 1.20.2-r2
+
   - id: CGA-rq48-3v9w-f6gr
     aliases:
       - CVE-2024-28122
@@ -216,24 +221,24 @@ advisories:
         data:
           fixed-version: 1.20.3-r4
 
-  - id: CGA-2mhf-548x-p4qh
+  - id: CGA-wh8p-rp2w-p5mj
     aliases:
-      - CVE-2024-28180
-      - GHSA-c5q2-7r4c-mv6g
+      - CVE-2024-24786
+      - GHSA-8r3f-844c-mc37
     events:
-      - timestamp: 2024-03-08T07:12:10Z
+      - timestamp: 2024-03-14T08:18:55Z
         type: detection
         data:
           type: scan/v1
           data:
             subpackageName: istio-operator-1.20
-            componentID: 0bdfc2b42062fc77
-            componentName: github.com/go-jose/go-jose/v3
-            componentVersion: v3.0.1
+            componentID: 2390df842be342eb
+            componentName: google.golang.org/protobuf
+            componentVersion: v1.31.0
             componentType: go-module
             componentLocation: /usr/bin/operator
             scanner: grype
-      - timestamp: 2024-03-11T00:36:33Z
+      - timestamp: 2024-03-14T18:49:07Z
         type: fixed
         data:
-          fixed-version: 1.20.3-r4
+          fixed-version: 1.20.4-r1

--- a/istio-pilot-agent-1.18.advisories.yaml
+++ b/istio-pilot-agent-1.18.advisories.yaml
@@ -4,12 +4,32 @@ package:
   name: istio-pilot-agent-1.18
 
 advisories:
-  - id: CGA-w3wh-5wj5-7fjq
+  - id: CGA-2574-7j5m-grj3
     aliases:
-      - CVE-2019-25210
-      - GHSA-jw44-4f3j-q396
+      - CVE-2023-39325
+      - GHSA-4374-p667-p6c8
     events:
-      - timestamp: 2024-03-06T07:15:06Z
+      - timestamp: 2023-10-12T22:18:43Z
+        type: fixed
+        data:
+          fixed-version: 1.18.5-r0
+
+  - id: CGA-28gx-2882-448c
+    aliases:
+      - CVE-2023-49290
+      - GHSA-7f9x-gw85-8grf
+    events:
+      - timestamp: 2024-01-24T17:13:02Z
+        type: fixed
+        data:
+          fixed-version: 1.18.7-r1
+
+  - id: CGA-66fh-g2wx-qcf9
+    aliases:
+      - CVE-2024-25620
+      - GHSA-v53g-5gjp-272r
+    events:
+      - timestamp: 2024-02-16T08:41:21Z
         type: detection
         data:
           type: scan/v1
@@ -21,54 +41,6 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pilot-agent
             scanner: grype
-      - timestamp: 2024-03-26T16:35:18Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: 'This is not a vulnerability. Learn more about the response from Helm: https://helm.sh/blog/response-cve-2019-25210'
-
-  - id: CGA-g29f-v4hf-c5h7
-    aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
-    events:
-      - timestamp: 2023-09-15T13:54:14Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-version-not-used
-          note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.
-
-  - id: CGA-ghh6-75v8-g2mq
-    aliases:
-      - CVE-2020-8552
-      - GHSA-82hx-w2r5-c2wq
-    events:
-      - timestamp: 2023-09-19T16:42:29Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Go vulndb has marked this code NOT_IMPORTABLE.
-
-  - id: CGA-2574-7j5m-grj3
-    aliases:
-      - CVE-2023-39325
-      - GHSA-4374-p667-p6c8
-    events:
-      - timestamp: 2023-10-12T22:18:43Z
-        type: fixed
-        data:
-          fixed-version: 1.18.5-r0
-
-  - id: CGA-m967-cgxh-jpqv
-    aliases:
-      - CVE-2023-45283
-      - GHSA-vvjp-q62m-2vph
-    events:
-      - timestamp: 2023-11-07T19:29:46Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
 
   - id: CGA-7hxx-w5g3-gchq
     aliases:
@@ -81,48 +53,30 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
 
-  - id: CGA-hvjf-vrh2-h33v
+  - id: CGA-7p93-6g33-fgm8
     aliases:
-      - CVE-2023-45288
-      - GHSA-4v7x-pqxf-cx7m
+      - CVE-2024-24786
+      - GHSA-8r3f-844c-mc37
     events:
-      - timestamp: 2024-04-16T07:32:15Z
+      - timestamp: 2024-04-16T07:32:09Z
         type: detection
         data:
           type: scan/v1
           data:
             subpackageName: istio-pilot-agent-1.18
-            componentID: 6db5273ce40722e3
-            componentName: stdlib
-            componentVersion: go1.21.6
+            componentID: 6910529a36488ca1
+            componentName: google.golang.org/protobuf
+            componentVersion: v1.31.0
             componentType: go-module
             componentLocation: /usr/bin/pilot-agent
             scanner: grype
 
-  - id: CGA-v98j-xq8g-wg96
+  - id: CGA-8jf7-7r8q-xfpg
     aliases:
-      - CVE-2023-45289
-      - GHSA-32ch-6x54-q4h9
+      - CVE-2024-24783
+      - GHSA-3q2c-pvp5-3cqp
     events:
-      - timestamp: 2024-03-12T08:10:59Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.18
-            componentID: 6db5273ce40722e3
-            componentName: stdlib
-            componentVersion: go1.21.6
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
-
-  - id: CGA-gvp4-fg43-jq4x
-    aliases:
-      - CVE-2023-45290
-      - GHSA-rr6r-cfgf-gc6h
-    events:
-      - timestamp: 2024-03-12T08:11:01Z
+      - timestamp: 2024-03-12T08:11:03Z
         type: detection
         data:
           type: scan/v1
@@ -145,15 +99,179 @@ advisories:
         data:
           fixed-version: 1.18.6-r2
 
-  - id: CGA-28gx-2882-448c
+  - id: CGA-chhw-87wj-c3w4
     aliases:
-      - CVE-2023-49290
-      - GHSA-7f9x-gw85-8grf
+      - CVE-2024-24785
+      - GHSA-j6m3-gc37-6r6q
     events:
-      - timestamp: 2024-01-24T17:13:02Z
-        type: fixed
+      - timestamp: 2024-03-12T08:11:07Z
+        type: detection
         data:
-          fixed-version: 1.18.7-r1
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.18
+            componentID: 6db5273ce40722e3
+            componentName: stdlib
+            componentVersion: go1.21.6
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype
+
+  - id: CGA-crq8-r48v-ffq5
+    aliases:
+      - CVE-2024-26147
+      - GHSA-r53h-jv2g-vpx6
+    events:
+      - timestamp: 2024-02-23T07:06:09Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.18
+            componentID: 55d655371cc66bd4
+            componentName: helm.sh/helm/v3
+            componentVersion: v3.11.2
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype
+
+  - id: CGA-f2c2-5733-3hj4
+    aliases:
+      - CVE-2024-24784
+      - GHSA-fgq5-q76c-gx78
+    events:
+      - timestamp: 2024-03-12T08:11:05Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.18
+            componentID: 6db5273ce40722e3
+            componentName: stdlib
+            componentVersion: go1.21.6
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype
+
+  - id: CGA-fr4v-qgq2-p3gp
+    aliases:
+      - CVE-2024-28122
+      - GHSA-hj3v-m684-v259
+    events:
+      - timestamp: 2024-03-09T07:43:52Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.18
+            componentID: 3bcff3defc5ecc94
+            componentName: github.com/lestrrat-go/jwx
+            componentVersion: v1.2.28
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype
+
+  - id: CGA-g29f-v4hf-c5h7
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-09-15T13:54:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.
+      - timestamp: 2025-03-04T17:59:39Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
+
+  - id: CGA-ghh6-75v8-g2mq
+    aliases:
+      - CVE-2020-8552
+      - GHSA-82hx-w2r5-c2wq
+    events:
+      - timestamp: 2023-09-19T16:42:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Go vulndb has marked this code NOT_IMPORTABLE.
+
+  - id: CGA-gvp4-fg43-jq4x
+    aliases:
+      - CVE-2023-45290
+      - GHSA-rr6r-cfgf-gc6h
+    events:
+      - timestamp: 2024-03-12T08:11:01Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.18
+            componentID: 6db5273ce40722e3
+            componentName: stdlib
+            componentVersion: go1.21.6
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype
+
+  - id: CGA-hvjf-vrh2-h33v
+    aliases:
+      - CVE-2023-45288
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-16T07:32:15Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.18
+            componentID: 6db5273ce40722e3
+            componentName: stdlib
+            componentVersion: go1.21.6
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype
+
+  - id: CGA-jhw9-5p3f-mchx
+    aliases:
+      - CVE-2024-24557
+      - GHSA-xw73-rw38-6vjc
+    events:
+      - timestamp: 2024-04-16T07:32:12Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.18
+            componentID: 49f14b769a227627
+            componentName: github.com/docker/docker
+            componentVersion: v24.0.7+incompatible
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype
+
+  - id: CGA-m967-cgxh-jpqv
+    aliases:
+      - CVE-2023-45283
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-11-07T19:29:46Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-rp39-7rpp-6pfq
+    aliases:
+      - GHSA-6xv5-86q9-7xr8
+    events:
+      - timestamp: 2023-09-13T15:32:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is only present on Windows.
 
   - id: CGA-rpgf-46xv-22fc
     aliases:
@@ -177,30 +295,12 @@ advisories:
         data:
           fixed-version: 1.18.7-r2
 
-  - id: CGA-jhw9-5p3f-mchx
+  - id: CGA-v98j-xq8g-wg96
     aliases:
-      - CVE-2024-24557
-      - GHSA-xw73-rw38-6vjc
+      - CVE-2023-45289
+      - GHSA-32ch-6x54-q4h9
     events:
-      - timestamp: 2024-04-16T07:32:12Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.18
-            componentID: 49f14b769a227627
-            componentName: github.com/docker/docker
-            componentVersion: v24.0.7+incompatible
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
-
-  - id: CGA-8jf7-7r8q-xfpg
-    aliases:
-      - CVE-2024-24783
-      - GHSA-3q2c-pvp5-3cqp
-    events:
-      - timestamp: 2024-03-12T08:11:03Z
+      - timestamp: 2024-03-12T08:10:59Z
         type: detection
         data:
           type: scan/v1
@@ -213,66 +313,12 @@ advisories:
             componentLocation: /usr/bin/pilot-agent
             scanner: grype
 
-  - id: CGA-f2c2-5733-3hj4
+  - id: CGA-w3wh-5wj5-7fjq
     aliases:
-      - CVE-2024-24784
-      - GHSA-fgq5-q76c-gx78
+      - CVE-2019-25210
+      - GHSA-jw44-4f3j-q396
     events:
-      - timestamp: 2024-03-12T08:11:05Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.18
-            componentID: 6db5273ce40722e3
-            componentName: stdlib
-            componentVersion: go1.21.6
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
-
-  - id: CGA-chhw-87wj-c3w4
-    aliases:
-      - CVE-2024-24785
-      - GHSA-j6m3-gc37-6r6q
-    events:
-      - timestamp: 2024-03-12T08:11:07Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.18
-            componentID: 6db5273ce40722e3
-            componentName: stdlib
-            componentVersion: go1.21.6
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
-
-  - id: CGA-7p93-6g33-fgm8
-    aliases:
-      - CVE-2024-24786
-      - GHSA-8r3f-844c-mc37
-    events:
-      - timestamp: 2024-04-16T07:32:09Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.18
-            componentID: 6910529a36488ca1
-            componentName: google.golang.org/protobuf
-            componentVersion: v1.31.0
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
-
-  - id: CGA-66fh-g2wx-qcf9
-    aliases:
-      - CVE-2024-25620
-      - GHSA-v53g-5gjp-272r
-    events:
-      - timestamp: 2024-02-16T08:41:21Z
+      - timestamp: 2024-03-06T07:15:06Z
         type: detection
         data:
           type: scan/v1
@@ -284,49 +330,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pilot-agent
             scanner: grype
-
-  - id: CGA-crq8-r48v-ffq5
-    aliases:
-      - CVE-2024-26147
-      - GHSA-r53h-jv2g-vpx6
-    events:
-      - timestamp: 2024-02-23T07:06:09Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.18
-            componentID: 55d655371cc66bd4
-            componentName: helm.sh/helm/v3
-            componentVersion: v3.11.2
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
-
-  - id: CGA-fr4v-qgq2-p3gp
-    aliases:
-      - CVE-2024-28122
-      - GHSA-hj3v-m684-v259
-    events:
-      - timestamp: 2024-03-09T07:43:52Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.18
-            componentID: 3bcff3defc5ecc94
-            componentName: github.com/lestrrat-go/jwx
-            componentVersion: v1.2.28
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
-
-  - id: CGA-rp39-7rpp-6pfq
-    aliases:
-      - GHSA-6xv5-86q9-7xr8
-    events:
-      - timestamp: 2023-09-13T15:32:21Z
+      - timestamp: 2024-03-26T16:35:18Z
         type: false-positive-determination
         data:
-          type: vulnerable-code-not-included-in-package
-          note: This vulnerability is only present on Windows.
+          type: vulnerability-record-analysis-contested
+          note: 'This is not a vulnerability. Learn more about the response from Helm: https://helm.sh/blog/response-cve-2019-25210'

--- a/istio-pilot-agent-1.19.advisories.yaml
+++ b/istio-pilot-agent-1.19.advisories.yaml
@@ -4,38 +4,6 @@ package:
   name: istio-pilot-agent-1.19
 
 advisories:
-  - id: CGA-98jm-8phc-prpw
-    aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
-    events:
-      - timestamp: 2023-10-01T16:44:14Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-version-not-used
-          note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.
-
-  - id: CGA-w8g6-j3qf-72vw
-    aliases:
-      - CVE-2023-39325
-      - GHSA-4374-p667-p6c8
-    events:
-      - timestamp: 2023-10-12T22:19:40Z
-        type: fixed
-        data:
-          fixed-version: 1.19.3-r0
-
-  - id: CGA-w469-w5wj-qmx9
-    aliases:
-      - CVE-2023-45283
-      - GHSA-vvjp-q62m-2vph
-    events:
-      - timestamp: 2023-11-07T19:29:49Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
   - id: CGA-5ch7-3ghx-h33q
     aliases:
       - CVE-2023-45284
@@ -47,15 +15,38 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
 
-  - id: CGA-qwfc-cqw5-v6qr
+  - id: CGA-847w-p38c-mmxh
     aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
+      - GHSA-c5q2-7r4c-mv6g
     events:
-      - timestamp: 2023-12-20T13:02:13Z
-        type: fixed
+      - timestamp: 2024-03-08T07:09:36Z
+        type: detection
         data:
-          fixed-version: 1.19.5-r2
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.19
+            componentID: c298b501a620f07b
+            componentName: github.com/go-jose/go-jose/v3
+            componentVersion: v3.0.1
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype
+
+  - id: CGA-98jm-8phc-prpw
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-10-01T16:44:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.
+      - timestamp: 2025-03-04T17:59:47Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-f8xg-cj47-c8gw
     aliases:
@@ -101,22 +92,36 @@ advisories:
         data:
           fixed-version: 1.19.6-r2
 
-  - id: CGA-847w-p38c-mmxh
+  - id: CGA-qwfc-cqw5-v6qr
     aliases:
-      - GHSA-c5q2-7r4c-mv6g
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
     events:
-      - timestamp: 2024-03-08T07:09:36Z
-        type: detection
+      - timestamp: 2023-12-20T13:02:13Z
+        type: fixed
         data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.19
-            componentID: c298b501a620f07b
-            componentName: github.com/go-jose/go-jose/v3
-            componentVersion: v3.0.1
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
+          fixed-version: 1.19.5-r2
+
+  - id: CGA-w469-w5wj-qmx9
+    aliases:
+      - CVE-2023-45283
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-11-07T19:29:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-w8g6-j3qf-72vw
+    aliases:
+      - CVE-2023-39325
+      - GHSA-4374-p667-p6c8
+    events:
+      - timestamp: 2023-10-12T22:19:40Z
+        type: fixed
+        data:
+          fixed-version: 1.19.3-r0
 
   - id: CGA-wmqr-f578-hpfw
     aliases:

--- a/istio-pilot-agent-1.20.advisories.yaml
+++ b/istio-pilot-agent-1.20.advisories.yaml
@@ -4,55 +4,6 @@ package:
   name: istio-pilot-agent-1.20
 
 advisories:
-  - id: CGA-99q8-f3qr-gjq7
-    aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
-    events:
-      - timestamp: 2023-12-17T17:35:59Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-version-not-used
-          note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
-
-  - id: CGA-w3w6-9mvq-h2qc
-    aliases:
-      - CVE-2023-45288
-      - GHSA-4v7x-pqxf-cx7m
-    events:
-      - timestamp: 2024-04-10T10:53:46Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.20
-            componentID: 4489cadd67fd8e1e
-            componentName: stdlib
-            componentVersion: go1.22.1
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
-
-  - id: CGA-qxcp-8jmf-cc9w
-    aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
-    events:
-      - timestamp: 2023-12-20T13:02:31Z
-        type: fixed
-        data:
-          fixed-version: 1.20.1-r2
-
-  - id: CGA-f79m-wwxv-m882
-    aliases:
-      - CVE-2023-49290
-      - GHSA-7f9x-gw85-8grf
-    events:
-      - timestamp: 2024-01-24T17:13:08Z
-        type: fixed
-        data:
-          fixed-version: 1.20.2-r2
-
   - id: CGA-3hmh-6hmr-cg6g
     aliases:
       - CVE-2024-21664
@@ -74,46 +25,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.20.2-r3
-
-  - id: CGA-wfq3-vpc9-838r
-    aliases:
-      - CVE-2024-24557
-      - GHSA-xw73-rw38-6vjc
-    events:
-      - timestamp: 2024-04-10T10:49:57Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.20
-            componentID: 490fa75eebdd4904
-            componentName: github.com/docker/docker
-            componentVersion: v24.0.7+incompatible
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
-
-  - id: CGA-p855-qj8h-pprc
-    aliases:
-      - CVE-2024-24786
-      - GHSA-8r3f-844c-mc37
-    events:
-      - timestamp: 2024-03-14T07:07:38Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-agent-1.20
-            componentID: 5b2c245bcb2957a3
-            componentName: google.golang.org/protobuf
-            componentVersion: v1.31.0
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-agent
-            scanner: grype
-      - timestamp: 2024-03-14T19:12:57Z
-        type: fixed
-        data:
-          fixed-version: 1.20.4-r0
 
   - id: CGA-6pm8-p738-rrw3
     aliases:
@@ -137,6 +48,82 @@ advisories:
         data:
           fixed-version: 1.20.3-r3
 
+  - id: CGA-99q8-f3qr-gjq7
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-12-17T17:35:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
+      - timestamp: 2025-03-04T17:59:55Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
+
+  - id: CGA-f79m-wwxv-m882
+    aliases:
+      - CVE-2023-49290
+      - GHSA-7f9x-gw85-8grf
+    events:
+      - timestamp: 2024-01-24T17:13:08Z
+        type: fixed
+        data:
+          fixed-version: 1.20.2-r2
+
+  - id: CGA-p855-qj8h-pprc
+    aliases:
+      - CVE-2024-24786
+      - GHSA-8r3f-844c-mc37
+    events:
+      - timestamp: 2024-03-14T07:07:38Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.20
+            componentID: 5b2c245bcb2957a3
+            componentName: google.golang.org/protobuf
+            componentVersion: v1.31.0
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype
+      - timestamp: 2024-03-14T19:12:57Z
+        type: fixed
+        data:
+          fixed-version: 1.20.4-r0
+
+  - id: CGA-qxcp-8jmf-cc9w
+    aliases:
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2023-12-20T13:02:31Z
+        type: fixed
+        data:
+          fixed-version: 1.20.1-r2
+
+  - id: CGA-w3w6-9mvq-h2qc
+    aliases:
+      - CVE-2023-45288
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-10T10:53:46Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.20
+            componentID: 4489cadd67fd8e1e
+            componentName: stdlib
+            componentVersion: go1.22.1
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype
+
   - id: CGA-w9c2-fqpv-4hvg
     aliases:
       - CVE-2024-28180
@@ -158,3 +145,21 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.20.3-r2
+
+  - id: CGA-wfq3-vpc9-838r
+    aliases:
+      - CVE-2024-24557
+      - GHSA-xw73-rw38-6vjc
+    events:
+      - timestamp: 2024-04-10T10:49:57Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-agent-1.20
+            componentID: 490fa75eebdd4904
+            componentName: github.com/docker/docker
+            componentVersion: v24.0.7+incompatible
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-agent
+            scanner: grype

--- a/istio-pilot-discovery-1.19.advisories.yaml
+++ b/istio-pilot-discovery-1.19.advisories.yaml
@@ -4,48 +4,37 @@ package:
   name: istio-pilot-discovery-1.19
 
 advisories:
-  - id: CGA-grhh-5rp4-vqq7
+  - id: CGA-3pp9-f8mv-3662
     aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
+      - CVE-2024-21664
+      - GHSA-pvcr-v8j8-j5q3
     events:
-      - timestamp: 2023-09-15T13:54:14Z
-        type: false-positive-determination
+      - timestamp: 2024-01-24T07:10:05Z
+        type: detection
         data:
-          type: vulnerable-code-version-not-used
-          note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.
-
-  - id: CGA-mqmv-hjhr-5875
-    aliases:
-      - CVE-2020-8552
-      - GHSA-82hx-w2r5-c2wq
-    events:
-      - timestamp: 2023-09-19T16:42:36Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Go vulndb has marked this code NOT_IMPORTABLE.
-
-  - id: CGA-7c8q-x42x-hpcj
-    aliases:
-      - CVE-2023-39325
-      - GHSA-4374-p667-p6c8
-    events:
-      - timestamp: 2023-10-12T22:20:14Z
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-discovery-1.19
+            componentID: 348b2a3ebdd0b92f
+            componentName: github.com/lestrrat-go/jwx
+            componentVersion: v1.2.26
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-discovery
+            scanner: grype
+      - timestamp: 2024-01-26T08:34:14Z
         type: fixed
         data:
-          fixed-version: 1.19.3-r0
+          fixed-version: 1.19.6-r2
 
-  - id: CGA-8j34-649h-4xxc
+  - id: CGA-4hjg-4m22-mv25
     aliases:
-      - CVE-2023-45283
-      - GHSA-vvjp-q62m-2vph
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
     events:
-      - timestamp: 2023-11-07T19:29:55Z
-        type: false-positive-determination
+      - timestamp: 2023-12-20T13:03:02Z
+        type: fixed
         data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
+          fixed-version: 1.19.5-r2
 
   - id: CGA-4rj6-2rj6-h97j
     aliases:
@@ -58,15 +47,44 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
 
-  - id: CGA-4hjg-4m22-mv25
+  - id: CGA-7c8q-x42x-hpcj
     aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
+      - CVE-2023-39325
+      - GHSA-4374-p667-p6c8
     events:
-      - timestamp: 2023-12-20T13:03:02Z
+      - timestamp: 2023-10-12T22:20:14Z
         type: fixed
         data:
-          fixed-version: 1.19.5-r2
+          fixed-version: 1.19.3-r0
+
+  - id: CGA-8frm-7x63-77gm
+    aliases:
+      - CVE-2024-28122
+      - GHSA-hj3v-m684-v259
+    events:
+      - timestamp: 2024-03-09T07:43:40Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-discovery-1.19
+            componentID: cae4aa46683f2c2e
+            componentName: github.com/lestrrat-go/jwx
+            componentVersion: v1.2.28
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-discovery
+            scanner: grype
+
+  - id: CGA-8j34-649h-4xxc
+    aliases:
+      - CVE-2023-45283
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-11-07T19:29:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
 
   - id: CGA-f347-47gw-h2mj
     aliases:
@@ -90,45 +108,50 @@ advisories:
         data:
           fixed-version: 1.19.6-r1
 
-  - id: CGA-3pp9-f8mv-3662
+  - id: CGA-g4v8-wmg4-vv66
     aliases:
-      - CVE-2024-21664
-      - GHSA-pvcr-v8j8-j5q3
+      - GHSA-jq35-85cj-fj4p
     events:
-      - timestamp: 2024-01-24T07:10:05Z
-        type: detection
+      - timestamp: 2023-10-31T20:03:52Z
+        type: false-positive-determination
         data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-discovery-1.19
-            componentID: 348b2a3ebdd0b92f
-            componentName: github.com/lestrrat-go/jwx
-            componentVersion: v1.2.26
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-discovery
-            scanner: grype
-      - timestamp: 2024-01-26T08:34:14Z
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is in the container runtime itself, not clients of the container runtime.
+
+  - id: CGA-grhh-5rp4-vqq7
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-09-15T13:54:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.
+      - timestamp: 2025-03-04T18:00:02Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
+
+  - id: CGA-m53g-c749-fg6f
+    aliases:
+      - GHSA-2c7c-3mj9-8fqh
+    events:
+      - timestamp: 2023-11-23T10:18:09Z
         type: fixed
         data:
-          fixed-version: 1.19.6-r2
+          fixed-version: 1.19.4-r1
 
-  - id: CGA-8frm-7x63-77gm
+  - id: CGA-m5x6-rcrq-8vvp
     aliases:
-      - CVE-2024-28122
-      - GHSA-hj3v-m684-v259
+      - GHSA-6xv5-86q9-7xr8
     events:
-      - timestamp: 2024-03-09T07:43:40Z
-        type: detection
+      - timestamp: 2023-09-09T15:18:15Z
+        type: false-positive-determination
         data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-discovery-1.19
-            componentID: cae4aa46683f2c2e
-            componentName: github.com/lestrrat-go/jwx
-            componentVersion: v1.2.28
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-discovery
-            scanner: grype
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is only present on Windows.
 
   - id: CGA-mgf2-hh2j-63w9
     aliases:
@@ -152,31 +175,13 @@ advisories:
         data:
           fixed-version: 1.19.7-r2
 
-  - id: CGA-m53g-c749-fg6f
+  - id: CGA-mqmv-hjhr-5875
     aliases:
-      - GHSA-2c7c-3mj9-8fqh
+      - CVE-2020-8552
+      - GHSA-82hx-w2r5-c2wq
     events:
-      - timestamp: 2023-11-23T10:18:09Z
-        type: fixed
-        data:
-          fixed-version: 1.19.4-r1
-
-  - id: CGA-m5x6-rcrq-8vvp
-    aliases:
-      - GHSA-6xv5-86q9-7xr8
-    events:
-      - timestamp: 2023-09-09T15:18:15Z
+      - timestamp: 2023-09-19T16:42:36Z
         type: false-positive-determination
         data:
           type: vulnerable-code-not-included-in-package
-          note: This vulnerability is only present on Windows.
-
-  - id: CGA-g4v8-wmg4-vv66
-    aliases:
-      - GHSA-jq35-85cj-fj4p
-    events:
-      - timestamp: 2023-10-31T20:03:52Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: This vulnerability is in the container runtime itself, not clients of the container runtime.
+          note: Go vulndb has marked this code NOT_IMPORTABLE.

--- a/istio-pilot-discovery-1.20.advisories.yaml
+++ b/istio-pilot-discovery-1.20.advisories.yaml
@@ -4,55 +4,6 @@ package:
   name: istio-pilot-discovery-1.20
 
 advisories:
-  - id: CGA-fh5w-8wfj-vcvr
-    aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
-    events:
-      - timestamp: 2023-12-17T17:36:05Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-version-not-used
-          note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
-
-  - id: CGA-h737-234h-86cr
-    aliases:
-      - CVE-2023-45288
-      - GHSA-4v7x-pqxf-cx7m
-    events:
-      - timestamp: 2024-04-09T11:29:42Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-discovery-1.20
-            componentID: 49cc7b3b9f03b4d4
-            componentName: stdlib
-            componentVersion: go1.22.1
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-discovery
-            scanner: grype
-
-  - id: CGA-78x5-43hv-2jgx
-    aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
-    events:
-      - timestamp: 2023-12-20T13:03:19Z
-        type: fixed
-        data:
-          fixed-version: 1.20.1-r2
-
-  - id: CGA-gv2p-4qmm-v36r
-    aliases:
-      - CVE-2023-49290
-      - GHSA-7f9x-gw85-8grf
-    events:
-      - timestamp: 2024-01-24T17:13:08Z
-        type: fixed
-        data:
-          fixed-version: 1.20.2-r2
-
   - id: CGA-5f62-fvxx-5fvh
     aliases:
       - CVE-2024-21664
@@ -74,46 +25,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.20.2-r3
-
-  - id: CGA-64hv-qqx4-c4f3
-    aliases:
-      - CVE-2024-24557
-      - GHSA-xw73-rw38-6vjc
-    events:
-      - timestamp: 2024-03-23T08:01:43Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-discovery-1.20
-            componentID: 121f21f662b2e868
-            componentName: github.com/docker/docker
-            componentVersion: v24.0.7+incompatible
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-discovery
-            scanner: grype
-
-  - id: CGA-wq3c-26pv-h85m
-    aliases:
-      - CVE-2024-24786
-      - GHSA-8r3f-844c-mc37
-    events:
-      - timestamp: 2024-03-14T17:57:46Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-pilot-discovery-1.20
-            componentID: 871d778ad1266207
-            componentName: google.golang.org/protobuf
-            componentVersion: v1.31.0
-            componentType: go-module
-            componentLocation: /usr/bin/pilot-discovery
-            scanner: grype
-      - timestamp: 2024-03-14T19:27:01Z
-        type: fixed
-        data:
-          fixed-version: 1.20.4-r1
 
   - id: CGA-5f79-cv7f-rh64
     aliases:
@@ -137,6 +48,34 @@ advisories:
         data:
           fixed-version: 1.20.3-r2
 
+  - id: CGA-64hv-qqx4-c4f3
+    aliases:
+      - CVE-2024-24557
+      - GHSA-xw73-rw38-6vjc
+    events:
+      - timestamp: 2024-03-23T08:01:43Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-discovery-1.20
+            componentID: 121f21f662b2e868
+            componentName: github.com/docker/docker
+            componentVersion: v24.0.7+incompatible
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-discovery
+            scanner: grype
+
+  - id: CGA-78x5-43hv-2jgx
+    aliases:
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2023-12-20T13:03:19Z
+        type: fixed
+        data:
+          fixed-version: 1.20.1-r2
+
   - id: CGA-c6wr-q2gj-mmg7
     aliases:
       - CVE-2024-28180
@@ -159,6 +98,50 @@ advisories:
         data:
           fixed-version: 1.20.3-r2
 
+  - id: CGA-fh5w-8wfj-vcvr
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-12-17T17:36:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
+      - timestamp: 2025-03-04T18:00:10Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
+
+  - id: CGA-gv2p-4qmm-v36r
+    aliases:
+      - CVE-2023-49290
+      - GHSA-7f9x-gw85-8grf
+    events:
+      - timestamp: 2024-01-24T17:13:08Z
+        type: fixed
+        data:
+          fixed-version: 1.20.2-r2
+
+  - id: CGA-h737-234h-86cr
+    aliases:
+      - CVE-2023-45288
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-09T11:29:42Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-discovery-1.20
+            componentID: 49cc7b3b9f03b4d4
+            componentName: stdlib
+            componentVersion: go1.22.1
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-discovery
+            scanner: grype
+
   - id: CGA-vmcx-qmfx-qf2h
     aliases:
       - GHSA-2c7c-3mj9-8fqh
@@ -167,3 +150,25 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.20.0-r2
+
+  - id: CGA-wq3c-26pv-h85m
+    aliases:
+      - CVE-2024-24786
+      - GHSA-8r3f-844c-mc37
+    events:
+      - timestamp: 2024-03-14T17:57:46Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: istio-pilot-discovery-1.20
+            componentID: 871d778ad1266207
+            componentName: google.golang.org/protobuf
+            componentVersion: v1.31.0
+            componentType: go-module
+            componentLocation: /usr/bin/pilot-discovery
+            scanner: grype
+      - timestamp: 2024-03-14T19:27:01Z
+        type: fixed
+        data:
+          fixed-version: 1.20.4-r1

--- a/k8sgpt.advisories.yaml
+++ b/k8sgpt.advisories.yaml
@@ -213,6 +213,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/k8sgpt
             scanner: grype
+      - timestamp: 2025-03-04T18:00:23Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-75rj-q565-5p3g
     aliases:

--- a/keda-2.16.advisories.yaml
+++ b/keda-2.16.advisories.yaml
@@ -100,6 +100,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/keda-adapter
             scanner: grype
+      - timestamp: 2025-03-04T18:00:35Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-rp96-w5r4-hmm8
     aliases:

--- a/loki-3.4.advisories.yaml
+++ b/loki-3.4.advisories.yaml
@@ -21,3 +21,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/logcli
             scanner: grype
+      - timestamp: 2025-03-04T18:00:42Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.

--- a/loki.advisories.yaml
+++ b/loki.advisories.yaml
@@ -4,55 +4,14 @@ package:
   name: loki
 
 advisories:
-  - id: CGA-8mfm-3rwc-952x
+  - id: CGA-38p4-6wmw-9v8j
     aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
+      - GHSA-jq35-85cj-fj4p
     events:
-      - timestamp: 2023-09-02T01:06:18Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-in-execution-path
-          note: This CVE affects the Prometheus UI (Javascript) and not the Go code
-
-  - id: CGA-vmv7-r228-chvf
-    aliases:
-      - CVE-2020-8559
-      - GHSA-33c5-9fx5-fvjm
-    events:
-      - timestamp: 2024-04-25T14:10:17Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: loki
-            componentID: 6431bf3399f259eb
-            componentName: k8s.io/apimachinery
-            componentVersion: v0.29.2
-            componentType: go-module
-            componentLocation: /usr/bin/loki
-            scanner: grype
-
-  - id: CGA-8xwx-h3q4-g46x
-    aliases:
-      - CVE-2023-40577
-      - GHSA-v86x-5fm3-5p7j
-    events:
-      - timestamp: 2023-09-02T01:06:18Z
+      - timestamp: 2023-12-22T10:47:09Z
         type: fixed
         data:
-          fixed-version: 2.8.4-r5
-
-  - id: CGA-c5wm-8j7m-6w79
-    aliases:
-      - CVE-2023-45283
-      - GHSA-vvjp-q62m-2vph
-    events:
-      - timestamp: 2023-11-07T19:32:51Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
+          fixed-version: 2.9.3-r1
 
   - id: CGA-4h39-vcmr-gjfv
     aliases:
@@ -64,86 +23,6 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
-
-  - id: CGA-q3qf-fhh8-464x
-    aliases:
-      - CVE-2023-45288
-      - GHSA-4v7x-pqxf-cx7m
-    events:
-      - timestamp: 2024-04-20T14:56:01Z
-        type: fixed
-        data:
-          fixed-version: 3.0.0-r2
-
-  - id: CGA-5m4r-qjfp-j8fv
-    aliases:
-      - CVE-2023-45289
-      - GHSA-32ch-6x54-q4h9
-    events:
-      - timestamp: 2024-03-12T08:05:23Z
-        type: fixed
-        data:
-          fixed-version: 2.9.5-r1
-
-  - id: CGA-gm4h-mphm-5q59
-    aliases:
-      - CVE-2023-45290
-      - GHSA-rr6r-cfgf-gc6h
-    events:
-      - timestamp: 2024-03-12T08:05:24Z
-        type: fixed
-        data:
-          fixed-version: 2.9.5-r1
-
-  - id: CGA-xv2r-75ch-26f4
-    aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
-    events:
-      - timestamp: 2023-12-22T10:47:16Z
-        type: fixed
-        data:
-          fixed-version: 2.9.3-r1
-
-  - id: CGA-hr6p-h36h-g26r
-    aliases:
-      - CVE-2024-24557
-      - GHSA-xw73-rw38-6vjc
-    events:
-      - timestamp: 2024-03-21T11:42:22Z
-        type: fixed
-        data:
-          fixed-version: 2.9.5-r3
-
-  - id: CGA-gh97-6fqx-r4rr
-    aliases:
-      - CVE-2024-24783
-      - GHSA-3q2c-pvp5-3cqp
-    events:
-      - timestamp: 2024-03-12T08:05:25Z
-        type: fixed
-        data:
-          fixed-version: 2.9.5-r1
-
-  - id: CGA-xm92-f5mw-vxq3
-    aliases:
-      - CVE-2024-24784
-      - GHSA-fgq5-q76c-gx78
-    events:
-      - timestamp: 2024-03-12T08:05:21Z
-        type: fixed
-        data:
-          fixed-version: 2.9.5-r1
-
-  - id: CGA-9crp-w39g-vr3j
-    aliases:
-      - CVE-2024-24785
-      - GHSA-j6m3-gc37-6r6q
-    events:
-      - timestamp: 2024-03-12T08:05:22Z
-        type: fixed
-        data:
-          fixed-version: 2.9.5-r1
 
   - id: CGA-4qp2-cm83-776p
     aliases:
@@ -167,6 +46,38 @@ advisories:
         data:
           fixed-version: 2.9.5-r2
 
+  - id: CGA-56rm-w32c-546x
+    aliases:
+      - CVE-2024-24788
+      - GHSA-2jwv-jmq4-4j3r
+    events:
+      - timestamp: 2024-05-14T07:24:25Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: loki
+            componentID: 6a57ca19145f2048
+            componentName: stdlib
+            componentVersion: go1.22.2
+            componentType: go-module
+            componentLocation: /usr/bin/loki
+            scanner: grype
+      - timestamp: 2024-05-22T09:13:18Z
+        type: fixed
+        data:
+          fixed-version: 3.0.0-r3
+
+  - id: CGA-5m4r-qjfp-j8fv
+    aliases:
+      - CVE-2023-45289
+      - GHSA-32ch-6x54-q4h9
+    events:
+      - timestamp: 2024-03-12T08:05:23Z
+        type: fixed
+        data:
+          fixed-version: 2.9.5-r1
+
   - id: CGA-846h-2r7r-7xg8
     aliases:
       - CVE-2024-24787
@@ -189,27 +100,72 @@ advisories:
         data:
           fixed-version: 3.0.0-r3
 
-  - id: CGA-56rm-w32c-546x
+  - id: CGA-8mfm-3rwc-952x
     aliases:
-      - CVE-2024-24788
-      - GHSA-2jwv-jmq4-4j3r
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
     events:
-      - timestamp: 2024-05-14T07:24:25Z
-        type: detection
+      - timestamp: 2023-09-02T01:06:18Z
+        type: false-positive-determination
         data:
-          type: scan/v1
-          data:
-            subpackageName: loki
-            componentID: 6a57ca19145f2048
-            componentName: stdlib
-            componentVersion: go1.22.2
-            componentType: go-module
-            componentLocation: /usr/bin/loki
-            scanner: grype
-      - timestamp: 2024-05-22T09:13:18Z
+          type: vulnerable-code-not-in-execution-path
+          note: This CVE affects the Prometheus UI (Javascript) and not the Go code
+      - timestamp: 2025-03-04T18:00:50Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
+
+  - id: CGA-8xwx-h3q4-g46x
+    aliases:
+      - CVE-2023-40577
+      - GHSA-v86x-5fm3-5p7j
+    events:
+      - timestamp: 2023-09-02T01:06:18Z
         type: fixed
         data:
-          fixed-version: 3.0.0-r3
+          fixed-version: 2.8.4-r5
+
+  - id: CGA-9crp-w39g-vr3j
+    aliases:
+      - CVE-2024-24785
+      - GHSA-j6m3-gc37-6r6q
+    events:
+      - timestamp: 2024-03-12T08:05:22Z
+        type: fixed
+        data:
+          fixed-version: 2.9.5-r1
+
+  - id: CGA-c5wm-8j7m-6w79
+    aliases:
+      - CVE-2023-45283
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-11-07T19:32:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-gh97-6fqx-r4rr
+    aliases:
+      - CVE-2024-24783
+      - GHSA-3q2c-pvp5-3cqp
+    events:
+      - timestamp: 2024-03-12T08:05:25Z
+        type: fixed
+        data:
+          fixed-version: 2.9.5-r1
+
+  - id: CGA-gm4h-mphm-5q59
+    aliases:
+      - CVE-2023-45290
+      - GHSA-rr6r-cfgf-gc6h
+    events:
+      - timestamp: 2024-03-12T08:05:24Z
+        type: fixed
+        data:
+          fixed-version: 2.9.5-r1
 
   - id: CGA-hjgc-8pv6-g89x
     aliases:
@@ -233,11 +189,60 @@ advisories:
         data:
           fixed-version: 3.0.0-r1
 
-  - id: CGA-38p4-6wmw-9v8j
+  - id: CGA-hr6p-h36h-g26r
     aliases:
-      - GHSA-jq35-85cj-fj4p
+      - CVE-2024-24557
+      - GHSA-xw73-rw38-6vjc
     events:
-      - timestamp: 2023-12-22T10:47:09Z
+      - timestamp: 2024-03-21T11:42:22Z
+        type: fixed
+        data:
+          fixed-version: 2.9.5-r3
+
+  - id: CGA-q3qf-fhh8-464x
+    aliases:
+      - CVE-2023-45288
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-20T14:56:01Z
+        type: fixed
+        data:
+          fixed-version: 3.0.0-r2
+
+  - id: CGA-vmv7-r228-chvf
+    aliases:
+      - CVE-2020-8559
+      - GHSA-33c5-9fx5-fvjm
+    events:
+      - timestamp: 2024-04-25T14:10:17Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: loki
+            componentID: 6431bf3399f259eb
+            componentName: k8s.io/apimachinery
+            componentVersion: v0.29.2
+            componentType: go-module
+            componentLocation: /usr/bin/loki
+            scanner: grype
+
+  - id: CGA-xm92-f5mw-vxq3
+    aliases:
+      - CVE-2024-24784
+      - GHSA-fgq5-q76c-gx78
+    events:
+      - timestamp: 2024-03-12T08:05:21Z
+        type: fixed
+        data:
+          fixed-version: 2.9.5-r1
+
+  - id: CGA-xv2r-75ch-26f4
+    aliases:
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2023-12-22T10:47:16Z
         type: fixed
         data:
           fixed-version: 2.9.3-r1

--- a/mc.advisories.yaml
+++ b/mc.advisories.yaml
@@ -310,6 +310,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mc
             scanner: grype
+      - timestamp: 2025-03-04T18:00:58Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-v854-2rch-24rc
     aliases:

--- a/metrics-server.advisories.yaml
+++ b/metrics-server.advisories.yaml
@@ -291,6 +291,11 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: This CVE affects the Prometheus UI (Javascript) and not the Go code. See prometheus/prometheus#12403 and prometheus/prometheus#5163
+      - timestamp: 2025-03-04T18:01:06Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-h8h2-464m-2qr4
     aliases:

--- a/minio.advisories.yaml
+++ b/minio.advisories.yaml
@@ -314,6 +314,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/minio
             scanner: grype
+      - timestamp: 2025-03-04T18:01:13Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-q6h3-c3c6-jjjr
     aliases:

--- a/node-problem-detector-0.8.advisories.yaml
+++ b/node-problem-detector-0.8.advisories.yaml
@@ -49,6 +49,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/node-problem-detector
             scanner: grype
+      - timestamp: 2025-03-04T18:01:21Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-4vqg-ppfw-9wxm
     aliases:

--- a/opentelemetry-collector-contrib.advisories.yaml
+++ b/opentelemetry-collector-contrib.advisories.yaml
@@ -252,6 +252,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol-contrib
             scanner: grype
+      - timestamp: 2025-03-04T18:01:29Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-q5w3-f5vm-g9m3
     aliases:

--- a/opentelemetry-collector.advisories.yaml
+++ b/opentelemetry-collector.advisories.yaml
@@ -124,6 +124,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-03-04T18:01:37Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-9qrc-2mhh-q5mh
     aliases:

--- a/opentelemetry-operator.advisories.yaml
+++ b/opentelemetry-operator.advisories.yaml
@@ -65,3 +65,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/main
             scanner: grype
+      - timestamp: 2025-03-04T18:01:46Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.

--- a/prometheus-3.2.advisories.yaml
+++ b/prometheus-3.2.advisories.yaml
@@ -21,3 +21,8 @@ advisories:
             componentType: go-module
             componentLocation: /opt/bitnami/prometheus/bin/prometheus
             scanner: grype
+      - timestamp: 2025-03-04T18:01:53Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.

--- a/prometheus-operator.advisories.yaml
+++ b/prometheus-operator.advisories.yaml
@@ -265,6 +265,11 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: This CVE only impacts prometheus 2.7 but our prometheus-operator is using v0.46.0 Go library which is in fact prothemeus 2.46
+      - timestamp: 2025-03-04T18:02:01Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-p2c9-fmw8-fhrq
     aliases:

--- a/prometheus-pushgateway.advisories.yaml
+++ b/prometheus-pushgateway.advisories.yaml
@@ -168,6 +168,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/pushgateway
             scanner: grype
+      - timestamp: 2025-03-04T18:02:09Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-f4h3-cvq8-f763
     aliases:

--- a/splunk-otel-collector.advisories.yaml
+++ b/splunk-otel-collector.advisories.yaml
@@ -75,6 +75,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-03-04T18:02:17Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-g9w6-g4x6-6jc9
     aliases:

--- a/telegraf-1.26.advisories.yaml
+++ b/telegraf-1.26.advisories.yaml
@@ -4,192 +4,6 @@ package:
   name: telegraf-1.26
 
 advisories:
-  - id: CGA-687w-3gmq-jfxx
-    aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
-    events:
-      - timestamp: 2023-08-25T22:09:21Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.
-
-  - id: CGA-v4xv-g87p-w8w2
-    aliases:
-      - CVE-2023-34231
-      - GHSA-fwv2-65wh-2w8c
-    events:
-      - timestamp: 2023-08-25T23:13:42Z
-        type: detection
-        data:
-          type: manual
-      - timestamp: 2023-09-08T22:36:02Z
-        type: false-positive-determination
-        data:
-          type: vulnerability-record-analysis-contested
-          note: The vulnerability doesn't appear to be legitimate. The fix (https://github.com/snowflakedb/gosnowflake/pull/757) cannot fix any vulnerability, since it only introduces unused code. If a vulnerability exists as part of the SSO process, it would need to be addressed server side, and not in the Snowflake Golang client. Ultimately, the SSO server is responsible for determining if a redirect URL is allowed, not the client. The Go vulndb has also indicated this CVE is not a vulnerability (https://github.com/golang/vulndb/issues/1846).
-
-  - id: CGA-vj9x-j2gr-4w2q
-    aliases:
-      - CVE-2023-39325
-      - GHSA-4374-p667-p6c8
-    events:
-      - timestamp: 2023-10-14T00:45:47Z
-        type: fixed
-        data:
-          fixed-version: 1.26.3-r4
-
-  - id: CGA-pjcf-cqmf-jvgm
-    aliases:
-      - CVE-2023-3978
-      - GHSA-2wrh-6pvc-2jm9
-    events:
-      - timestamp: 2023-10-14T00:46:04Z
-        type: fixed
-        data:
-          fixed-version: 1.26.3-r4
-
-  - id: CGA-vrwc-ghcx-vgf2
-    aliases:
-      - CVE-2023-44487
-      - GHSA-qppj-fm5r-hxr3
-    events:
-      - timestamp: 2023-11-05T14:53:30Z
-        type: fixed
-        data:
-          fixed-version: 1.26.3-r6
-
-  - id: CGA-7pcw-mwh7-j692
-    aliases:
-      - CVE-2023-45283
-      - GHSA-vvjp-q62m-2vph
-    events:
-      - timestamp: 2023-11-07T19:38:53Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
-  - id: CGA-g436-v5hv-3xvm
-    aliases:
-      - CVE-2023-45284
-      - GHSA-rq3x-83w4-p28c
-    events:
-      - timestamp: 2023-11-07T19:38:55Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
-  - id: CGA-jcfg-hmcr-85xq
-    aliases:
-      - CVE-2023-45289
-      - GHSA-32ch-6x54-q4h9
-    events:
-      - timestamp: 2024-03-12T08:03:19Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: telegraf-1.26
-            componentID: d27fbefe16b09517
-            componentName: stdlib
-            componentVersion: go1.22.0
-            componentType: go-module
-            componentLocation: /usr/bin/telegraf
-            scanner: grype
-      - timestamp: 2024-03-12T09:19:12Z
-        type: fixed
-        data:
-          fixed-version: 1.26.3-r12
-
-  - id: CGA-7gx7-qjxc-qpqw
-    aliases:
-      - CVE-2023-45290
-      - GHSA-rr6r-cfgf-gc6h
-    events:
-      - timestamp: 2024-03-12T08:03:22Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: telegraf-1.26
-            componentID: d27fbefe16b09517
-            componentName: stdlib
-            componentVersion: go1.22.0
-            componentType: go-module
-            componentLocation: /usr/bin/telegraf
-            scanner: grype
-      - timestamp: 2024-03-12T09:19:14Z
-        type: fixed
-        data:
-          fixed-version: 1.26.3-r12
-
-  - id: CGA-vr4h-v25q-p87j
-    aliases:
-      - CVE-2023-46129
-      - GHSA-mr45-rx8q-wcm9
-    events:
-      - timestamp: 2023-11-05T14:55:01Z
-        type: fixed
-        data:
-          fixed-version: 1.26.3-r6
-
-  - id: CGA-pxcv-3h6p-cvx3
-    aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
-    events:
-      - timestamp: 2023-12-21T15:41:49Z
-        type: fixed
-        data:
-          fixed-version: 1.26.3-r9
-
-  - id: CGA-c4ph-9jh8-27mp
-    aliases:
-      - CVE-2023-50658
-      - GHSA-6294-6rgp-fr7r
-    events:
-      - timestamp: 2024-03-03T07:34:23Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: telegraf-1.26
-            componentID: 6a09b7be340462cc
-            componentName: github.com/dvsekhvalnov/jose2go
-            componentVersion: v1.5.1-0.20231206184617-48ba0b76bc88
-            componentType: go-module
-            componentLocation: /usr/bin/telegraf
-            scanner: grype
-      - timestamp: 2024-03-04T08:53:11Z
-        type: fixed
-        data:
-          fixed-version: 1.26.3-r11
-
-  - id: CGA-6pwp-3ff7-889g
-    aliases:
-      - CVE-2024-21626
-      - GHSA-xr7r-f8xq-vfvv
-    events:
-      - timestamp: 2024-02-05T07:10:37Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: telegraf-1.26
-            componentID: 35b42b25badb286a
-            componentName: github.com/opencontainers/runc
-            componentVersion: v1.1.5
-            componentType: go-module
-            componentLocation: /usr/bin/telegraf
-            scanner: grype
-      - timestamp: 2024-02-10T07:30:59Z
-        type: fixed
-        data:
-          fixed-version: 1.26.3-r10
-
   - id: CGA-3chj-825f-95rr
     aliases:
       - CVE-2024-24783
@@ -234,6 +48,53 @@ advisories:
         data:
           fixed-version: 1.26.3-r12
 
+  - id: CGA-5m26-hq38-hw8f
+    aliases:
+      - GHSA-7ww5-4wqc-m92c
+    events:
+      - timestamp: 2023-12-21T15:42:12Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r9
+
+  - id: CGA-687w-3gmq-jfxx
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-08-25T22:09:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.
+      - timestamp: 2025-03-04T18:02:25Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
+
+  - id: CGA-6pwp-3ff7-889g
+    aliases:
+      - CVE-2024-21626
+      - GHSA-xr7r-f8xq-vfvv
+    events:
+      - timestamp: 2024-02-05T07:10:37Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: telegraf-1.26
+            componentID: 35b42b25badb286a
+            componentName: github.com/opencontainers/runc
+            componentVersion: v1.1.5
+            componentType: go-module
+            componentLocation: /usr/bin/telegraf
+            scanner: grype
+      - timestamp: 2024-02-10T07:30:59Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r10
+
   - id: CGA-6px3-r3mh-q5hj
     aliases:
       - CVE-2024-24785
@@ -256,6 +117,158 @@ advisories:
         data:
           fixed-version: 1.26.3-r12
 
+  - id: CGA-6v2m-f9wj-224j
+    aliases:
+      - GHSA-mhpq-9638-x6pw
+    events:
+      - timestamp: 2023-12-21T15:42:34Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r9
+
+  - id: CGA-7gx7-qjxc-qpqw
+    aliases:
+      - CVE-2023-45290
+      - GHSA-rr6r-cfgf-gc6h
+    events:
+      - timestamp: 2024-03-12T08:03:22Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: telegraf-1.26
+            componentID: d27fbefe16b09517
+            componentName: stdlib
+            componentVersion: go1.22.0
+            componentType: go-module
+            componentLocation: /usr/bin/telegraf
+            scanner: grype
+      - timestamp: 2024-03-12T09:19:14Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r12
+
+  - id: CGA-7p3p-9pwp-5p9m
+    aliases:
+      - GHSA-2w8w-qhg4-f78j
+    events:
+      - timestamp: 2023-08-25T22:21:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability only affects Jaeger UI, not the library code imported by telegraf.
+
+  - id: CGA-7pcw-mwh7-j692
+    aliases:
+      - CVE-2023-45283
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-11-07T19:38:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-c4ph-9jh8-27mp
+    aliases:
+      - CVE-2023-50658
+      - GHSA-6294-6rgp-fr7r
+    events:
+      - timestamp: 2024-03-03T07:34:23Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: telegraf-1.26
+            componentID: 6a09b7be340462cc
+            componentName: github.com/dvsekhvalnov/jose2go
+            componentVersion: v1.5.1-0.20231206184617-48ba0b76bc88
+            componentType: go-module
+            componentLocation: /usr/bin/telegraf
+            scanner: grype
+      - timestamp: 2024-03-04T08:53:11Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r11
+
+  - id: CGA-g436-v5hv-3xvm
+    aliases:
+      - CVE-2023-45284
+      - GHSA-rq3x-83w4-p28c
+    events:
+      - timestamp: 2023-11-07T19:38:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-jcfg-hmcr-85xq
+    aliases:
+      - CVE-2023-45289
+      - GHSA-32ch-6x54-q4h9
+    events:
+      - timestamp: 2024-03-12T08:03:19Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: telegraf-1.26
+            componentID: d27fbefe16b09517
+            componentName: stdlib
+            componentVersion: go1.22.0
+            componentType: go-module
+            componentLocation: /usr/bin/telegraf
+            scanner: grype
+      - timestamp: 2024-03-12T09:19:12Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r12
+
+  - id: CGA-pjcf-cqmf-jvgm
+    aliases:
+      - CVE-2023-3978
+      - GHSA-2wrh-6pvc-2jm9
+    events:
+      - timestamp: 2023-10-14T00:46:04Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r4
+
+  - id: CGA-pxcv-3h6p-cvx3
+    aliases:
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2023-12-21T15:41:49Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r9
+
+  - id: CGA-r9p8-vgx2-gv6w
+    aliases:
+      - GHSA-jq35-85cj-fj4p
+    events:
+      - timestamp: 2023-10-31T20:04:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is in the container runtime itself, not clients of the container runtime.
+
+  - id: CGA-v4xv-g87p-w8w2
+    aliases:
+      - CVE-2023-34231
+      - GHSA-fwv2-65wh-2w8c
+    events:
+      - timestamp: 2023-08-25T23:13:42Z
+        type: detection
+        data:
+          type: manual
+      - timestamp: 2023-09-08T22:36:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The vulnerability doesn't appear to be legitimate. The fix (https://github.com/snowflakedb/gosnowflake/pull/757) cannot fix any vulnerability, since it only introduces unused code. If a vulnerability exists as part of the SSO process, it would need to be addressed server side, and not in the Snowflake Golang client. Ultimately, the SSO server is responsible for determining if a redirect URL is allowed, not the client. The Go vulndb has also indicated this CVE is not a vulnerability (https://github.com/golang/vulndb/issues/1846).
+
   - id: CGA-v5qh-2cx5-8xv6
     aliases:
       - CVE-2024-27289
@@ -274,40 +287,32 @@ advisories:
             componentLocation: /usr/bin/telegraf
             scanner: grype
 
-  - id: CGA-7p3p-9pwp-5p9m
+  - id: CGA-vj9x-j2gr-4w2q
     aliases:
-      - GHSA-2w8w-qhg4-f78j
+      - CVE-2023-39325
+      - GHSA-4374-p667-p6c8
     events:
-      - timestamp: 2023-08-25T22:21:50Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: This vulnerability only affects Jaeger UI, not the library code imported by telegraf.
-
-  - id: CGA-5m26-hq38-hw8f
-    aliases:
-      - GHSA-7ww5-4wqc-m92c
-    events:
-      - timestamp: 2023-12-21T15:42:12Z
+      - timestamp: 2023-10-14T00:45:47Z
         type: fixed
         data:
-          fixed-version: 1.26.3-r9
+          fixed-version: 1.26.3-r4
 
-  - id: CGA-r9p8-vgx2-gv6w
+  - id: CGA-vr4h-v25q-p87j
     aliases:
-      - GHSA-jq35-85cj-fj4p
+      - CVE-2023-46129
+      - GHSA-mr45-rx8q-wcm9
     events:
-      - timestamp: 2023-10-31T20:04:02Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: This vulnerability is in the container runtime itself, not clients of the container runtime.
-
-  - id: CGA-6v2m-f9wj-224j
-    aliases:
-      - GHSA-mhpq-9638-x6pw
-    events:
-      - timestamp: 2023-12-21T15:42:34Z
+      - timestamp: 2023-11-05T14:55:01Z
         type: fixed
         data:
-          fixed-version: 1.26.3-r9
+          fixed-version: 1.26.3-r6
+
+  - id: CGA-vrwc-ghcx-vgf2
+    aliases:
+      - CVE-2023-44487
+      - GHSA-qppj-fm5r-hxr3
+    events:
+      - timestamp: 2023-11-05T14:53:30Z
+        type: fixed
+        data:
+          fixed-version: 1.26.3-r6

--- a/telegraf-1.27.advisories.yaml
+++ b/telegraf-1.27.advisories.yaml
@@ -4,92 +4,46 @@ package:
   name: telegraf-1.27
 
 advisories:
-  - id: CGA-xg67-xwcm-pq72
+  - id: CGA-33qr-pq47-pvvv
     aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
+      - GHSA-7jwh-3vrq-q3m8
     events:
-      - timestamp: 2023-08-25T22:09:52Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.
-
-  - id: CGA-gmq6-783h-6r2h
-    aliases:
-      - CVE-2023-39325
-      - GHSA-4374-p667-p6c8
-    events:
-      - timestamp: 2023-10-14T14:57:30Z
-        type: fixed
-        data:
-          fixed-version: 1.27.4-r4
-
-  - id: CGA-qg4w-crjp-pm66
-    aliases:
-      - CVE-2023-44487
-      - GHSA-m425-mq94-257g
-      - GHSA-qppj-fm5r-hxr3
-    events:
-      - timestamp: 2023-10-14T14:57:42Z
-        type: fixed
-        data:
-          fixed-version: 1.27.4-r4
-      - timestamp: 2023-11-06T23:26:35Z
-        type: fixed
-        data:
-          fixed-version: 1.27.4-r6
-
-  - id: CGA-wqvr-wpfq-2jgq
-    aliases:
-      - CVE-2023-45283
-      - GHSA-vvjp-q62m-2vph
-    events:
-      - timestamp: 2023-11-07T19:38:57Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
-  - id: CGA-w2vq-8gch-p9m9
-    aliases:
-      - CVE-2023-45284
-      - GHSA-rq3x-83w4-p28c
-    events:
-      - timestamp: 2023-11-07T19:38:59Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
-  - id: CGA-p5m3-2623-p72j
-    aliases:
-      - CVE-2023-45288
-      - GHSA-4v7x-pqxf-cx7m
-    events:
-      - timestamp: 2024-04-10T10:38:30Z
+      - timestamp: 2024-04-10T10:32:32Z
         type: detection
         data:
           type: scan/v1
           data:
             subpackageName: telegraf-1.27
-            componentID: 79b2de744b8768a9
-            componentName: stdlib
-            componentVersion: go1.22.1
+            componentID: 46e1b455915fe73d
+            componentName: github.com/jackc/pgproto3/v2
+            componentVersion: v2.3.2
             componentType: go-module
             componentLocation: /usr/bin/telegraf
             scanner: grype
-      - timestamp: 2024-04-15T11:24:07Z
-        type: fix-not-planned
-        data:
-          note: Telegraf 1.27 is no longer supported upstream.
 
-  - id: CGA-5qh6-5gfh-j93p
+  - id: CGA-49x2-mjgm-f2j6
     aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
+      - CVE-2024-27289
+      - GHSA-m7wr-2xf7-cm9p
     events:
-      - timestamp: 2023-12-21T15:57:34Z
+      - timestamp: 2024-03-13T10:13:39Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: telegraf-1.27
+            componentID: d38bb9ff8ef0b888
+            componentName: github.com/jackc/pgx/v4
+            componentVersion: v4.18.1
+            componentType: go-module
+            componentLocation: /usr/bin/telegraf
+            scanner: grype
+
+  - id: CGA-4jhx-mx3j-qr7f
+    aliases:
+      - GHSA-mhpq-9638-x6pw
+    events:
+      - timestamp: 2023-12-21T15:58:08Z
         type: fixed
         data:
           fixed-version: 1.27.4-r9
@@ -116,99 +70,15 @@ advisories:
         data:
           fixed-version: 1.27.4-r11
 
-  - id: CGA-pxxm-rf97-h5g3
+  - id: CGA-5qh6-5gfh-j93p
     aliases:
-      - CVE-2024-21626
-      - GHSA-xr7r-f8xq-vfvv
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
     events:
-      - timestamp: 2024-02-10T07:20:16Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: telegraf-1.27
-            componentID: 35b42b25badb286a
-            componentName: github.com/opencontainers/runc
-            componentVersion: v1.1.5
-            componentType: go-module
-            componentLocation: /usr/bin/telegraf
-            scanner: grype
-      - timestamp: 2024-02-10T07:25:14Z
+      - timestamp: 2023-12-21T15:57:34Z
         type: fixed
         data:
-          fixed-version: 1.27.4-r10
-
-  - id: CGA-g5m9-wv89-v43q
-    aliases:
-      - CVE-2024-24557
-      - GHSA-xw73-rw38-6vjc
-    events:
-      - timestamp: 2024-04-10T10:37:00Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: telegraf-1.27
-            componentID: 8cc8ea0bebf5b4b9
-            componentName: github.com/docker/docker
-            componentVersion: v24.0.7+incompatible
-            componentType: go-module
-            componentLocation: /usr/bin/telegraf
-            scanner: grype
-
-  - id: CGA-mmmm-j592-9952
-    aliases:
-      - CVE-2024-24786
-      - GHSA-8r3f-844c-mc37
-    events:
-      - timestamp: 2024-04-10T10:34:15Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: telegraf-1.27
-            componentID: 1072173f6a441cb6
-            componentName: google.golang.org/protobuf
-            componentVersion: v1.31.0
-            componentType: go-module
-            componentLocation: /usr/bin/telegraf
-            scanner: grype
-
-  - id: CGA-49x2-mjgm-f2j6
-    aliases:
-      - CVE-2024-27289
-      - GHSA-m7wr-2xf7-cm9p
-    events:
-      - timestamp: 2024-03-13T10:13:39Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: telegraf-1.27
-            componentID: d38bb9ff8ef0b888
-            componentName: github.com/jackc/pgx/v4
-            componentVersion: v4.18.1
-            componentType: go-module
-            componentLocation: /usr/bin/telegraf
-            scanner: grype
-
-  - id: CGA-f7w9-92mx-84gv
-    aliases:
-      - CVE-2024-27304
-      - GHSA-mrww-27vc-gghv
-    events:
-      - timestamp: 2024-04-10T10:35:35Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: telegraf-1.27
-            componentID: 46e1b455915fe73d
-            componentName: github.com/jackc/pgproto3/v2
-            componentVersion: v2.3.2
-            componentType: go-module
-            componentLocation: /usr/bin/telegraf
-            scanner: grype
+          fixed-version: 1.27.4-r9
 
   - id: CGA-8m28-xmv8-j65x
     aliases:
@@ -232,23 +102,6 @@ advisories:
         data:
           fixed-version: 1.27.4-r13
 
-  - id: CGA-33qr-pq47-pvvv
-    aliases:
-      - GHSA-7jwh-3vrq-q3m8
-    events:
-      - timestamp: 2024-04-10T10:32:32Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: telegraf-1.27
-            componentID: 46e1b455915fe73d
-            componentName: github.com/jackc/pgproto3/v2
-            componentVersion: v2.3.2
-            componentType: go-module
-            componentLocation: /usr/bin/telegraf
-            scanner: grype
-
   - id: CGA-8vw4-75vj-9xhv
     aliases:
       - GHSA-7ww5-4wqc-m92c
@@ -268,11 +121,163 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: This vulnerability is in the container runtime itself, not clients of the container runtime.
 
-  - id: CGA-4jhx-mx3j-qr7f
+  - id: CGA-f7w9-92mx-84gv
     aliases:
-      - GHSA-mhpq-9638-x6pw
+      - CVE-2024-27304
+      - GHSA-mrww-27vc-gghv
     events:
-      - timestamp: 2023-12-21T15:58:08Z
+      - timestamp: 2024-04-10T10:35:35Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: telegraf-1.27
+            componentID: 46e1b455915fe73d
+            componentName: github.com/jackc/pgproto3/v2
+            componentVersion: v2.3.2
+            componentType: go-module
+            componentLocation: /usr/bin/telegraf
+            scanner: grype
+
+  - id: CGA-g5m9-wv89-v43q
+    aliases:
+      - CVE-2024-24557
+      - GHSA-xw73-rw38-6vjc
+    events:
+      - timestamp: 2024-04-10T10:37:00Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: telegraf-1.27
+            componentID: 8cc8ea0bebf5b4b9
+            componentName: github.com/docker/docker
+            componentVersion: v24.0.7+incompatible
+            componentType: go-module
+            componentLocation: /usr/bin/telegraf
+            scanner: grype
+
+  - id: CGA-gmq6-783h-6r2h
+    aliases:
+      - CVE-2023-39325
+      - GHSA-4374-p667-p6c8
+    events:
+      - timestamp: 2023-10-14T14:57:30Z
         type: fixed
         data:
-          fixed-version: 1.27.4-r9
+          fixed-version: 1.27.4-r4
+
+  - id: CGA-mmmm-j592-9952
+    aliases:
+      - CVE-2024-24786
+      - GHSA-8r3f-844c-mc37
+    events:
+      - timestamp: 2024-04-10T10:34:15Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: telegraf-1.27
+            componentID: 1072173f6a441cb6
+            componentName: google.golang.org/protobuf
+            componentVersion: v1.31.0
+            componentType: go-module
+            componentLocation: /usr/bin/telegraf
+            scanner: grype
+
+  - id: CGA-p5m3-2623-p72j
+    aliases:
+      - CVE-2023-45288
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-10T10:38:30Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: telegraf-1.27
+            componentID: 79b2de744b8768a9
+            componentName: stdlib
+            componentVersion: go1.22.1
+            componentType: go-module
+            componentLocation: /usr/bin/telegraf
+            scanner: grype
+      - timestamp: 2024-04-15T11:24:07Z
+        type: fix-not-planned
+        data:
+          note: Telegraf 1.27 is no longer supported upstream.
+
+  - id: CGA-pxxm-rf97-h5g3
+    aliases:
+      - CVE-2024-21626
+      - GHSA-xr7r-f8xq-vfvv
+    events:
+      - timestamp: 2024-02-10T07:20:16Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: telegraf-1.27
+            componentID: 35b42b25badb286a
+            componentName: github.com/opencontainers/runc
+            componentVersion: v1.1.5
+            componentType: go-module
+            componentLocation: /usr/bin/telegraf
+            scanner: grype
+      - timestamp: 2024-02-10T07:25:14Z
+        type: fixed
+        data:
+          fixed-version: 1.27.4-r10
+
+  - id: CGA-qg4w-crjp-pm66
+    aliases:
+      - CVE-2023-44487
+      - GHSA-m425-mq94-257g
+      - GHSA-qppj-fm5r-hxr3
+    events:
+      - timestamp: 2023-10-14T14:57:42Z
+        type: fixed
+        data:
+          fixed-version: 1.27.4-r4
+      - timestamp: 2023-11-06T23:26:35Z
+        type: fixed
+        data:
+          fixed-version: 1.27.4-r6
+
+  - id: CGA-w2vq-8gch-p9m9
+    aliases:
+      - CVE-2023-45284
+      - GHSA-rq3x-83w4-p28c
+    events:
+      - timestamp: 2023-11-07T19:38:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-wqvr-wpfq-2jgq
+    aliases:
+      - CVE-2023-45283
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-11-07T19:38:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-xg67-xwcm-pq72
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-08-25T22:09:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability is an XSS flaw in the Prometheus server and is not affecting this package which uses the library code.
+      - timestamp: 2025-03-04T18:02:33Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.

--- a/telegraf-1.29.advisories.yaml
+++ b/telegraf-1.29.advisories.yaml
@@ -4,27 +4,6 @@ package:
   name: telegraf-1.29
 
 advisories:
-  - id: CGA-xx9p-8cr5-gj5v
-    aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
-    events:
-      - timestamp: 2023-12-17T17:36:20Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-version-not-used
-          note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
-
-  - id: CGA-ww4v-5qh8-jvpx
-    aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
-    events:
-      - timestamp: 2023-12-21T17:15:28Z
-        type: fixed
-        data:
-          fixed-version: 1.29.1-r1
-
   - id: CGA-9qcx-7wg3-7mxg
     aliases:
       - CVE-2024-27289
@@ -42,6 +21,24 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/telegraf
             scanner: grype
+
+  - id: CGA-fq98-568c-76gh
+    aliases:
+      - GHSA-mhpq-9638-x6pw
+    events:
+      - timestamp: 2023-12-21T17:16:18Z
+        type: fixed
+        data:
+          fixed-version: 1.29.1-r1
+
+  - id: CGA-h67j-h787-j66q
+    aliases:
+      - GHSA-7ww5-4wqc-m92c
+    events:
+      - timestamp: 2023-12-21T17:16:05Z
+        type: fixed
+        data:
+          fixed-version: 1.29.1-r1
 
   - id: CGA-hm7v-mrf7-g6w4
     aliases:
@@ -65,20 +62,28 @@ advisories:
         data:
           fixed-version: 1.29.5-r2
 
-  - id: CGA-h67j-h787-j66q
+  - id: CGA-ww4v-5qh8-jvpx
     aliases:
-      - GHSA-7ww5-4wqc-m92c
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
     events:
-      - timestamp: 2023-12-21T17:16:05Z
+      - timestamp: 2023-12-21T17:15:28Z
         type: fixed
         data:
           fixed-version: 1.29.1-r1
 
-  - id: CGA-fq98-568c-76gh
+  - id: CGA-xx9p-8cr5-gj5v
     aliases:
-      - GHSA-mhpq-9638-x6pw
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
     events:
-      - timestamp: 2023-12-21T17:16:18Z
-        type: fixed
+      - timestamp: 2023-12-17T17:36:20Z
+        type: false-positive-determination
         data:
-          fixed-version: 1.29.1-r1
+          type: vulnerable-code-version-not-used
+          note: This vulnerability has been fixed in version v2.7.1 which corresponds to the Go library version v0.7.1 and this package includes a later version.
+      - timestamp: 2025-03-04T18:02:41Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.

--- a/telegraf-1.33.advisories.yaml
+++ b/telegraf-1.33.advisories.yaml
@@ -95,3 +95,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/telegraf
             scanner: grype
+      - timestamp: 2025-03-04T18:02:49Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.

--- a/tempo.advisories.yaml
+++ b/tempo.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/tempo-cli
             scanner: grype
+      - timestamp: 2025-03-04T18:02:57Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-49rr-6pr6-qc4m
     aliases:

--- a/thanos-0.31.advisories.yaml
+++ b/thanos-0.31.advisories.yaml
@@ -4,26 +4,23 @@ package:
   name: thanos-0.31
 
 advisories:
-  - id: CGA-m945-rhv2-82cw
+  - id: CGA-2f87-h79p-gqxh
     aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
+      - CVE-2024-24785
+      - GHSA-j6m3-gc37-6r6q
     events:
-      - timestamp: 2023-08-30T21:45:02Z
-        type: false-positive-determination
+      - timestamp: 2024-03-12T08:04:03Z
+        type: detection
         data:
-          type: component-vulnerability-mismatch
-          note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
-
-  - id: CGA-69j3-429w-q49f
-    aliases:
-      - CVE-2023-39325
-      - GHSA-4374-p667-p6c8
-    events:
-      - timestamp: 2023-10-13T23:18:43Z
-        type: fixed
-        data:
-          fixed-version: 0.31.0-r5
+          type: scan/v1
+          data:
+            subpackageName: thanos-0.31
+            componentID: 7fe824ba690e397b
+            componentName: stdlib
+            componentVersion: go1.21.6
+            componentType: go-module
+            componentLocation: /usr/bin/thanos
+            scanner: grype
 
   - id: CGA-3ff2-v5jg-6g72
     aliases:
@@ -34,60 +31,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.31.0-r5
-
-  - id: CGA-fm97-7fqm-gp74
-    aliases:
-      - CVE-2023-40577
-      - GHSA-v86x-5fm3-5p7j
-    events:
-      - timestamp: 2023-08-30T20:54:21Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-in-execution-path
-          note: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.
-
-  - id: CGA-jm66-m52h-37p8
-    aliases:
-      - CVE-2023-44487
-      - GHSA-m425-mq94-257g
-      - GHSA-qppj-fm5r-hxr3
-    events:
-      - timestamp: 2023-11-03T09:43:05Z
-        type: fixed
-        data:
-          fixed-version: 0.31.0-r7
-
-  - id: CGA-7cpw-vrvp-9cjq
-    aliases:
-      - CVE-2023-45142
-      - GHSA-rcjv-mgp8-qvmr
-    events:
-      - timestamp: 2023-10-19T02:06:21Z
-        type: fixed
-        data:
-          fixed-version: 0.31.0-r6
-
-  - id: CGA-cvf6-5fw7-jv5x
-    aliases:
-      - CVE-2023-45283
-      - GHSA-vvjp-q62m-2vph
-    events:
-      - timestamp: 2023-11-07T19:39:24Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
-  - id: CGA-j97q-fwrj-28f8
-    aliases:
-      - CVE-2023-45284
-      - GHSA-rq3x-83w4-p28c
-    events:
-      - timestamp: 2023-11-07T19:39:26Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
 
   - id: CGA-3hx8-grx6-pj92
     aliases:
@@ -107,12 +50,32 @@ advisories:
             componentLocation: /usr/bin/thanos
             scanner: grype
 
-  - id: CGA-hxp2-684w-rj7f
+  - id: CGA-69j3-429w-q49f
     aliases:
-      - CVE-2023-45290
-      - GHSA-rr6r-cfgf-gc6h
+      - CVE-2023-39325
+      - GHSA-4374-p667-p6c8
     events:
-      - timestamp: 2024-03-12T08:03:58Z
+      - timestamp: 2023-10-13T23:18:43Z
+        type: fixed
+        data:
+          fixed-version: 0.31.0-r5
+
+  - id: CGA-7cpw-vrvp-9cjq
+    aliases:
+      - CVE-2023-45142
+      - GHSA-rcjv-mgp8-qvmr
+    events:
+      - timestamp: 2023-10-19T02:06:21Z
+        type: fixed
+        data:
+          fixed-version: 0.31.0-r6
+
+  - id: CGA-8226-9p2r-2g82
+    aliases:
+      - CVE-2024-24783
+      - GHSA-3q2c-pvp5-3cqp
+    events:
+      - timestamp: 2024-03-12T08:04:00Z
         type: detection
         data:
           type: scan/v1
@@ -125,22 +88,34 @@ advisories:
             componentLocation: /usr/bin/thanos
             scanner: grype
 
-  - id: CGA-vpmm-xhgv-4v6r
+  - id: CGA-cvf6-5fw7-jv5x
     aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
+      - CVE-2023-45283
+      - GHSA-vvjp-q62m-2vph
     events:
-      - timestamp: 2023-12-20T05:29:04Z
-        type: fixed
+      - timestamp: 2023-11-07T19:39:24Z
+        type: false-positive-determination
         data:
-          fixed-version: 0.31.0-r10
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
 
-  - id: CGA-8226-9p2r-2g82
+  - id: CGA-fm97-7fqm-gp74
     aliases:
-      - CVE-2024-24783
-      - GHSA-3q2c-pvp5-3cqp
+      - CVE-2023-40577
+      - GHSA-v86x-5fm3-5p7j
     events:
-      - timestamp: 2024-03-12T08:04:00Z
+      - timestamp: 2023-08-30T20:54:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.
+
+  - id: CGA-hxp2-684w-rj7f
+    aliases:
+      - CVE-2023-45290
+      - GHSA-rr6r-cfgf-gc6h
+    events:
+      - timestamp: 2024-03-12T08:03:58Z
         type: detection
         data:
           type: scan/v1
@@ -171,20 +146,50 @@ advisories:
             componentLocation: /usr/bin/thanos
             scanner: grype
 
-  - id: CGA-2f87-h79p-gqxh
+  - id: CGA-j97q-fwrj-28f8
     aliases:
-      - CVE-2024-24785
-      - GHSA-j6m3-gc37-6r6q
+      - CVE-2023-45284
+      - GHSA-rq3x-83w4-p28c
     events:
-      - timestamp: 2024-03-12T08:04:03Z
-        type: detection
+      - timestamp: 2023-11-07T19:39:26Z
+        type: false-positive-determination
         data:
-          type: scan/v1
-          data:
-            subpackageName: thanos-0.31
-            componentID: 7fe824ba690e397b
-            componentName: stdlib
-            componentVersion: go1.21.6
-            componentType: go-module
-            componentLocation: /usr/bin/thanos
-            scanner: grype
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-jm66-m52h-37p8
+    aliases:
+      - CVE-2023-44487
+      - GHSA-m425-mq94-257g
+      - GHSA-qppj-fm5r-hxr3
+    events:
+      - timestamp: 2023-11-03T09:43:05Z
+        type: fixed
+        data:
+          fixed-version: 0.31.0-r7
+
+  - id: CGA-m945-rhv2-82cw
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-08-30T21:45:02Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
+      - timestamp: 2025-03-04T18:03:05Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
+
+  - id: CGA-vpmm-xhgv-4v6r
+    aliases:
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2023-12-20T05:29:04Z
+        type: fixed
+        data:
+          fixed-version: 0.31.0-r10

--- a/thanos-0.32.advisories.yaml
+++ b/thanos-0.32.advisories.yaml
@@ -4,80 +4,6 @@ package:
   name: thanos-0.32
 
 advisories:
-  - id: CGA-rg76-hmgp-99g7
-    aliases:
-      - CVE-2019-3826
-      - GHSA-3m87-5598-2v4f
-    events:
-      - timestamp: 2023-08-30T21:45:02Z
-        type: false-positive-determination
-        data:
-          type: component-vulnerability-mismatch
-          note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
-
-  - id: CGA-hhch-75fm-6cvh
-    aliases:
-      - CVE-2023-39325
-      - GHSA-4374-p667-p6c8
-    events:
-      - timestamp: 2023-10-13T23:19:03Z
-        type: fixed
-        data:
-          fixed-version: 0.32.4-r3
-
-  - id: CGA-f6c8-hx7q-gg7x
-    aliases:
-      - CVE-2023-3978
-      - GHSA-2wrh-6pvc-2jm9
-    events:
-      - timestamp: 2023-10-13T23:20:07Z
-        type: fixed
-        data:
-          fixed-version: 0.32.4-r3
-
-  - id: CGA-qrgj-wj7v-r5x2
-    aliases:
-      - CVE-2023-40577
-      - GHSA-v86x-5fm3-5p7j
-    events:
-      - timestamp: 2023-08-30T20:54:21Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-in-execution-path
-          note: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.
-
-  - id: CGA-w8w4-2885-pj8c
-    aliases:
-      - CVE-2023-44487
-      - GHSA-m425-mq94-257g
-      - GHSA-qppj-fm5r-hxr3
-    events:
-      - timestamp: 2023-11-03T09:43:22Z
-        type: fixed
-        data:
-          fixed-version: 0.32.5-r1
-
-  - id: CGA-wrmm-4cq4-67rw
-    aliases:
-      - CVE-2023-45142
-      - GHSA-rcjv-mgp8-qvmr
-    events:
-      - timestamp: 2023-10-19T02:06:34Z
-        type: fixed
-        data:
-          fixed-version: 0.32.4-r4
-
-  - id: CGA-8w39-7mm6-85h5
-    aliases:
-      - CVE-2023-45283
-      - GHSA-vvjp-q62m-2vph
-    events:
-      - timestamp: 2023-11-07T19:39:28Z
-        type: false-positive-determination
-        data:
-          type: vulnerable-code-not-included-in-package
-          note: Only affects Windows
-
   - id: CGA-2wq4-xc9q-2x74
     aliases:
       - CVE-2023-45284
@@ -89,69 +15,23 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
 
-  - id: CGA-whjj-cv98-f3cw
+  - id: CGA-378r-5h3p-m35w
     aliases:
-      - CVE-2023-45288
-      - GHSA-4v7x-pqxf-cx7m
+      - CVE-2024-24786
+      - GHSA-8r3f-844c-mc37
     events:
-      - timestamp: 2024-04-06T13:35:16Z
+      - timestamp: 2024-04-04T08:02:20Z
         type: detection
         data:
           type: scan/v1
           data:
             subpackageName: thanos-0.32
-            componentID: f60faaf269f531fb
-            componentName: stdlib
-            componentVersion: go1.21.5
+            componentID: 956642cadc7a4500
+            componentName: google.golang.org/protobuf
+            componentVersion: v1.31.0
             componentType: go-module
             componentLocation: /usr/bin/thanos
             scanner: grype
-
-  - id: CGA-hwhg-9h86-xggq
-    aliases:
-      - CVE-2023-45289
-      - GHSA-32ch-6x54-q4h9
-    events:
-      - timestamp: 2024-03-12T08:03:57Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: thanos-0.32
-            componentID: f60faaf269f531fb
-            componentName: stdlib
-            componentVersion: go1.21.5
-            componentType: go-module
-            componentLocation: /usr/bin/thanos
-            scanner: grype
-
-  - id: CGA-8hw7-v295-6g6m
-    aliases:
-      - CVE-2023-45290
-      - GHSA-rr6r-cfgf-gc6h
-    events:
-      - timestamp: 2024-03-12T08:03:59Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: thanos-0.32
-            componentID: f60faaf269f531fb
-            componentName: stdlib
-            componentVersion: go1.21.5
-            componentType: go-module
-            componentLocation: /usr/bin/thanos
-            scanner: grype
-
-  - id: CGA-f475-rj53-3rx7
-    aliases:
-      - CVE-2023-48795
-      - GHSA-45x7-px36-x8w8
-    events:
-      - timestamp: 2023-12-20T05:29:30Z
-        type: fixed
-        data:
-          fixed-version: 0.32.5-r4
 
   - id: CGA-4cfg-69gh-x2mc
     aliases:
@@ -159,24 +39,6 @@ advisories:
       - GHSA-3q2c-pvp5-3cqp
     events:
       - timestamp: 2024-03-12T08:04:01Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: thanos-0.32
-            componentID: f60faaf269f531fb
-            componentName: stdlib
-            componentVersion: go1.21.5
-            componentType: go-module
-            componentLocation: /usr/bin/thanos
-            scanner: grype
-
-  - id: CGA-mgfj-chpm-m4pw
-    aliases:
-      - CVE-2024-24784
-      - GHSA-fgq5-q76c-gx78
-    events:
-      - timestamp: 2024-03-12T08:04:02Z
         type: detection
         data:
           type: scan/v1
@@ -207,20 +69,163 @@ advisories:
             componentLocation: /usr/bin/thanos
             scanner: grype
 
-  - id: CGA-378r-5h3p-m35w
+  - id: CGA-8hw7-v295-6g6m
     aliases:
-      - CVE-2024-24786
-      - GHSA-8r3f-844c-mc37
+      - CVE-2023-45290
+      - GHSA-rr6r-cfgf-gc6h
     events:
-      - timestamp: 2024-04-04T08:02:20Z
+      - timestamp: 2024-03-12T08:03:59Z
         type: detection
         data:
           type: scan/v1
           data:
             subpackageName: thanos-0.32
-            componentID: 956642cadc7a4500
-            componentName: google.golang.org/protobuf
-            componentVersion: v1.31.0
+            componentID: f60faaf269f531fb
+            componentName: stdlib
+            componentVersion: go1.21.5
             componentType: go-module
             componentLocation: /usr/bin/thanos
             scanner: grype
+
+  - id: CGA-8w39-7mm6-85h5
+    aliases:
+      - CVE-2023-45283
+      - GHSA-vvjp-q62m-2vph
+    events:
+      - timestamp: 2023-11-07T19:39:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only affects Windows
+
+  - id: CGA-f475-rj53-3rx7
+    aliases:
+      - CVE-2023-48795
+      - GHSA-45x7-px36-x8w8
+    events:
+      - timestamp: 2023-12-20T05:29:30Z
+        type: fixed
+        data:
+          fixed-version: 0.32.5-r4
+
+  - id: CGA-f6c8-hx7q-gg7x
+    aliases:
+      - CVE-2023-3978
+      - GHSA-2wrh-6pvc-2jm9
+    events:
+      - timestamp: 2023-10-13T23:20:07Z
+        type: fixed
+        data:
+          fixed-version: 0.32.4-r3
+
+  - id: CGA-hhch-75fm-6cvh
+    aliases:
+      - CVE-2023-39325
+      - GHSA-4374-p667-p6c8
+    events:
+      - timestamp: 2023-10-13T23:19:03Z
+        type: fixed
+        data:
+          fixed-version: 0.32.4-r3
+
+  - id: CGA-hwhg-9h86-xggq
+    aliases:
+      - CVE-2023-45289
+      - GHSA-32ch-6x54-q4h9
+    events:
+      - timestamp: 2024-03-12T08:03:57Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: thanos-0.32
+            componentID: f60faaf269f531fb
+            componentName: stdlib
+            componentVersion: go1.21.5
+            componentType: go-module
+            componentLocation: /usr/bin/thanos
+            scanner: grype
+
+  - id: CGA-mgfj-chpm-m4pw
+    aliases:
+      - CVE-2024-24784
+      - GHSA-fgq5-q76c-gx78
+    events:
+      - timestamp: 2024-03-12T08:04:02Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: thanos-0.32
+            componentID: f60faaf269f531fb
+            componentName: stdlib
+            componentVersion: go1.21.5
+            componentType: go-module
+            componentLocation: /usr/bin/thanos
+            scanner: grype
+
+  - id: CGA-qrgj-wj7v-r5x2
+    aliases:
+      - CVE-2023-40577
+      - GHSA-v86x-5fm3-5p7j
+    events:
+      - timestamp: 2023-08-30T20:54:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: This vulnerability is an XSS flaw affecting alertmanager as a server, not when imported as a library.
+
+  - id: CGA-rg76-hmgp-99g7
+    aliases:
+      - CVE-2019-3826
+      - GHSA-3m87-5598-2v4f
+    events:
+      - timestamp: 2023-08-30T21:45:02Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This only impacts the prometheus UI JS code and not the Go module. See https://github.com/prometheus/prometheus/issues/12403
+      - timestamp: 2025-03-04T18:03:13Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
+
+  - id: CGA-w8w4-2885-pj8c
+    aliases:
+      - CVE-2023-44487
+      - GHSA-m425-mq94-257g
+      - GHSA-qppj-fm5r-hxr3
+    events:
+      - timestamp: 2023-11-03T09:43:22Z
+        type: fixed
+        data:
+          fixed-version: 0.32.5-r1
+
+  - id: CGA-whjj-cv98-f3cw
+    aliases:
+      - CVE-2023-45288
+      - GHSA-4v7x-pqxf-cx7m
+    events:
+      - timestamp: 2024-04-06T13:35:16Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: thanos-0.32
+            componentID: f60faaf269f531fb
+            componentName: stdlib
+            componentVersion: go1.21.5
+            componentType: go-module
+            componentLocation: /usr/bin/thanos
+            scanner: grype
+
+  - id: CGA-wrmm-4cq4-67rw
+    aliases:
+      - CVE-2023-45142
+      - GHSA-rcjv-mgp8-qvmr
+    events:
+      - timestamp: 2023-10-19T02:06:34Z
+        type: fixed
+        data:
+          fixed-version: 0.32.4-r4

--- a/thanos.advisories.yaml
+++ b/thanos.advisories.yaml
@@ -191,6 +191,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/thanos
             scanner: grype
+      - timestamp: 2025-03-04T18:03:21Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-gq22-qmjg-x6rf
     aliases:

--- a/trillian.advisories.yaml
+++ b/trillian.advisories.yaml
@@ -293,6 +293,11 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: The installed version of the prometheus library is ahead of the vulnerability fix version, but prometheus violates Go's rules for v2 module versioning.
+      - timestamp: 2025-03-04T18:03:29Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: Prometheus ships a Go (Golang) library with a versioning scheme that follows the 0.x format. However, the Prometheus application itself uses a versioning scheme based on 1.x, 2.x, etc. The vulnerability identified in CVE-2019-3826 is specifically associated with the Prometheus application, not the Golang library.
 
   - id: CGA-p9g6-8rqg-gphv
     aliases:


### PR DESCRIPTION
CVE-2019-3826 is a false positive due to Prometheus having a library (go package) and the Prometheus application. They are named the same but the versioning schema is different for each. The go package is not affected. 