### PR TITLE
ruby-3.3: add pending-upstream-fix to open advisories

### DIFF
--- a/ruby-3.3.advisories.yaml
+++ b/ruby-3.3.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.3.0/specifications/default/uri-0.13.1.gemspec
             scanner: grype
+      - timestamp: 2025-03-04T18:38:23Z
+        type: pending-upstream-fix
+        data:
+          note: Ruby upstream have not backported the uri gem changes to the 3.3 maintenance branch.
 
   - id: CGA-68q6-52vr-628x
     aliases:
@@ -39,6 +43,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.3.0/specifications/default/cgi-0.4.1.gemspec
             scanner: grype
+      - timestamp: 2025-03-04T18:41:08Z
+        type: pending-upstream-fix
+        data:
+          note: Ruby upstream have not backported the cgi gem changes to the 3.3 maintenance branch.
 
   - id: CGA-cwr5-c6j9-f552
     aliases:
@@ -189,6 +197,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.3.0/specifications/default/cgi-0.4.1.gemspec
             scanner: grype
+      - timestamp: 2025-03-04T18:40:32Z
+        type: pending-upstream-fix
+        data:
+          note: Ruby upstream have not backported the cgi gem changes to the 3.3 maintenance branch.
 
   - id: CGA-w995-jp2x-p8gc
     aliases:


### PR DESCRIPTION
Unlike the other maintenance branches, Ruby upstream have not backported the fixed gem versions to the `ruby_3_3` branch, so there isn't a patch for us to pull.