### PR TITLE
spark-3.5/GHSA-r978-9m6m-6gm6 advisory update

### DIFF
--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -1212,3 +1212,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/zookeeper-3.7.2.jar
             scanner: grype
+      - timestamp: 2025-03-04T19:08:58Z
+        type: pending-upstream-fix
+        data:
+          note: Due to complexity of implementation required to upgrade the version of Zookeeper to a fix version, the upstream maintainers are planning on releasing it as a part of a major release. So we require upstream maintainers to implement this fix. https://issues.apache.org/jira/browse/SPARK-47402


### PR DESCRIPTION
## 1. **GHSA-r978-9m6m-6gm6**
- **pending-upstream-fix:**
- Due to complexity of implementation required to upgrade the version of Zookeeper to a fix version, the upstream maintainers are planning on releasing it as a part of a major release. So we require upstream maintainers to implement this fix.
https://issues.apache.org/jira/browse/SPARK-47402