### PR TITLE
feat(advisory): In preparation for CVE-2025-22869 remediation I scanned packages to match golang.org/x/crypto/ssh symbol path and in addition used govulncheck and marked false positive those that did not match

### DIFF
--- a/actions-runner-controller.advisories.yaml
+++ b/actions-runner-controller.advisories.yaml
@@ -343,6 +343,16 @@ advisories:
         data:
           fixed-version: 0.8.1-r1
 
+  - id: CGA-x7f6-254q-8m9g
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:54:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'actions-runner-controller version 0.10.1-r3: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-x93h-c5h9-f86w
     aliases:
       - CVE-2024-24789

--- a/amass.advisories.yaml
+++ b/amass.advisories.yaml
@@ -242,6 +242,16 @@ advisories:
         data:
           fixed-version: 4.2.0-r14
 
+  - id: CGA-f99v-2892-m4qq
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:44:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'amass version 4.2.0-r19: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-gfg9-3r2c-93h9
     aliases:
       - CVE-2024-24783

--- a/amazon-cloudwatch-agent-operator.advisories.yaml
+++ b/amazon-cloudwatch-agent-operator.advisories.yaml
@@ -40,6 +40,16 @@ advisories:
             componentLocation: /usr/bin/manager
             scanner: grype
 
+  - id: CGA-fq5p-gcqj-gx95
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:45:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'amazon-cloudwatch-agent-operator version 2.1.0-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-hx53-29r5-p52v
     aliases:
       - CVE-2024-45338

--- a/amazon-cloudwatch-agent.advisories.yaml
+++ b/amazon-cloudwatch-agent.advisories.yaml
@@ -44,6 +44,16 @@ advisories:
         data:
           fixed-version: 1.300052.0-r1
 
+  - id: CGA-j994-fwhw-5r44
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:48:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'amazon-cloudwatch-agent version 1.300053.0-r5: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-qhhp-9rmp-vcgm
     aliases:
       - CVE-2024-45338

--- a/argo-rollouts.advisories.yaml
+++ b/argo-rollouts.advisories.yaml
@@ -68,6 +68,16 @@ advisories:
         data:
           fixed-version: 1.7.2-r4
 
+  - id: CGA-g84r-6853-86c5
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:47:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'argo-rollouts version 1.8.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-m9rp-87wr-xj88
     aliases:
       - CVE-2024-45337

--- a/authservice.advisories.yaml
+++ b/authservice.advisories.yaml
@@ -78,6 +78,16 @@ advisories:
         data:
           fixed-version: 1.0.4-r1
 
+  - id: CGA-q429-3jf6-cf2w
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:46:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'authservice version 1.0.4-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-qmwf-fvx7-hmgc
     aliases:
       - CVE-2024-34155

--- a/azcopy.advisories.yaml
+++ b/azcopy.advisories.yaml
@@ -157,3 +157,13 @@ advisories:
         type: fixed
         data:
           fixed-version: 10.26.0-r1
+
+  - id: CGA-x3hc-526x-f9pp
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:48:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'azcopy version 10.28.0-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'

--- a/azuredisk-csi-1.31.advisories.yaml
+++ b/azuredisk-csi-1.31.advisories.yaml
@@ -100,6 +100,16 @@ advisories:
         data:
           fixed-version: 1.31.3-r0
 
+  - id: CGA-pfg6-r93w-wgf7
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:45:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'azuredisk-csi-1.31 version 1.31.4-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-w5qq-94m2-qmh9
     aliases:
       - CVE-2024-45337

--- a/bank-vaults.advisories.yaml
+++ b/bank-vaults.advisories.yaml
@@ -218,6 +218,16 @@ advisories:
         data:
           fixed-version: 1.20.4-r22
 
+  - id: CGA-9jhq-cx92-vpm5
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:45:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'bank-vaults version 1.20.4-r25: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-9vxr-p5mv-wm83
     aliases:
       - CVE-2025-22866

--- a/boring-registry.advisories.yaml
+++ b/boring-registry.advisories.yaml
@@ -213,6 +213,16 @@ advisories:
         data:
           fixed-version: 0.15.4-r1
 
+  - id: CGA-9p77-cqg2-5763
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:46:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'boring-registry version 0.16.3-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-cgqq-vv62-2grg
     aliases:
       - CVE-2024-24787

--- a/buf.advisories.yaml
+++ b/buf.advisories.yaml
@@ -48,6 +48,16 @@ advisories:
         data:
           fixed-version: 1.47.2-r3
 
+  - id: CGA-6c58-9qrc-jhjq
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:46:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'buf version 1.50.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-6vh6-q6gv-m796
     aliases:
       - CVE-2024-45337

--- a/buildah.advisories.yaml
+++ b/buildah.advisories.yaml
@@ -258,6 +258,16 @@ advisories:
         data:
           fixed-version: 1.37.3-r1
 
+  - id: CGA-p984-6c78-h6pc
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:44:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'buildah version 1.39.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-qpcg-j47v-7mxp
     aliases:
       - CVE-2024-45338

--- a/cadvisor.advisories.yaml
+++ b/cadvisor.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: cadvisor
 
 advisories:
+  - id: CGA-29w5-jg5r-8qhq
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:48:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'cadvisor version 0.51.0-r4: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-37cv-6356-j6g7
     aliases:
       - CVE-2025-22866

--- a/cert-exporter.advisories.yaml
+++ b/cert-exporter.advisories.yaml
@@ -36,6 +36,16 @@ advisories:
         data:
           fixed-version: 2.12.0-r2
 
+  - id: CGA-3hfv-24gf-4mvw
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:50:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'cert-exporter version 2.14.0-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-48gv-xf63-v6jh
     aliases:
       - CVE-2020-8559

--- a/cert-manager-cmctl.advisories.yaml
+++ b/cert-manager-cmctl.advisories.yaml
@@ -58,6 +58,16 @@ advisories:
         data:
           fixed-version: 2.1.0-r1
 
+  - id: CGA-597p-hr76-2v46
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:56:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'cert-manager-cmctl version 2.1.1-r5: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-5jrj-8hcw-p545
     aliases:
       - GHSA-xr7q-jx4m-x55m

--- a/cert-manager-istio-csr.advisories.yaml
+++ b/cert-manager-istio-csr.advisories.yaml
@@ -25,6 +25,16 @@ advisories:
         data:
           fixed-version: 0.12.0-r1
 
+  - id: CGA-5cp5-4xcr-q9hh
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:51:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'cert-manager-istio-csr version 0.14.0-r3: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-6c94-vvvg-cv4v
     aliases:
       - CVE-2022-31045

--- a/cert-manager-webhook-pdns.advisories.yaml
+++ b/cert-manager-webhook-pdns.advisories.yaml
@@ -100,6 +100,16 @@ advisories:
         data:
           fixed-version: 2.5.1-r8
 
+  - id: CGA-c69m-72h2-fw3w
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:47:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'cert-manager-webhook-pdns version 2.5.2-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-crx2-mhj6-m6r4
     aliases:
       - CVE-2024-24788

--- a/cfssl.advisories.yaml
+++ b/cfssl.advisories.yaml
@@ -140,6 +140,16 @@ advisories:
         data:
           fixed-version: 1.6.5-r5
 
+  - id: CGA-9q5p-4gpw-r7pq
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:45:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'cfssl version 1.6.5-r15: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-c92w-w4vw-3m8f
     aliases:
       - CVE-2024-24784

--- a/chartmuseum.advisories.yaml
+++ b/chartmuseum.advisories.yaml
@@ -227,6 +227,16 @@ advisories:
         data:
           fixed-version: 0.16.0-r6
 
+  - id: CGA-c8pm-h2pw-pc7v
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:47:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'chartmuseum version 0.16.2-r11: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-cqxr-gcj4-75jp
     aliases:
       - CVE-2023-45283

--- a/cloud-sql-proxy.advisories.yaml
+++ b/cloud-sql-proxy.advisories.yaml
@@ -267,6 +267,16 @@ advisories:
         data:
           fixed-version: 2.9.0-r1
 
+  - id: CGA-vxgc-wrr6-w7qr
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:50:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'cloud-sql-proxy version 2.15.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-wf3m-w7qx-mv9x
     aliases:
       - CVE-2024-34156

--- a/cloudnative-pg.advisories.yaml
+++ b/cloudnative-pg.advisories.yaml
@@ -123,6 +123,16 @@ advisories:
         data:
           fixed-version: 1.23.2-r5
 
+  - id: CGA-9hj7-x3r5-7mw7
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:49:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'cloudnative-pg version 1.25.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-fm8x-3mfw-ph7f
     aliases:
       - CVE-2025-22866

--- a/cloudprober.advisories.yaml
+++ b/cloudprober.advisories.yaml
@@ -48,6 +48,16 @@ advisories:
         data:
           fixed-version: 0.13.9-r1
 
+  - id: CGA-h6vq-j2m7-5x9f
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:48:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'cloudprober version 0.13.9-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-wv7w-9jhf-g93w
     aliases:
       - CVE-2024-45337

--- a/cluster-api-controller.advisories.yaml
+++ b/cluster-api-controller.advisories.yaml
@@ -49,6 +49,16 @@ advisories:
             This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
             We are not affected by this vulnerability as we do not build or support ppc64le.
 
+  - id: CGA-6wmj-82g2-7fh7
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:49:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'cluster-api-controller version 1.9.5-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-777f-8hmv-9m5f
     aliases:
       - CVE-2023-45288

--- a/clusterctl.advisories.yaml
+++ b/clusterctl.advisories.yaml
@@ -180,6 +180,16 @@ advisories:
         data:
           fixed-version: 1.7.1-r1
 
+  - id: CGA-mqpq-mx66-r9jw
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:50:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'clusterctl version 1.9.5-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-qgmw-fw2p-66v4
     aliases:
       - CVE-2024-24791

--- a/conftest.advisories.yaml
+++ b/conftest.advisories.yaml
@@ -308,6 +308,16 @@ advisories:
         data:
           fixed-version: 0.56.0-r2
 
+  - id: CGA-pjmw-rcr4-wrx6
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:49:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'conftest version 0.58.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-pjr6-r554-jpgc
     aliases:
       - CVE-2023-45284

--- a/coredns.advisories.yaml
+++ b/coredns.advisories.yaml
@@ -172,6 +172,16 @@ advisories:
         data:
           fixed-version: 1.11.1-r9
 
+  - id: CGA-7q22-jr4h-75p5
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:51:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'coredns version 1.12.0-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-8xxc-59x5-4784
     aliases:
       - CVE-2024-34155

--- a/croc.advisories.yaml
+++ b/croc.advisories.yaml
@@ -245,6 +245,16 @@ advisories:
         data:
           fixed-version: 10.0.7-r1
 
+  - id: CGA-m55w-hm2g-rxhh
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:51:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'croc version 10.2.1-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-m68x-h3ph-v7fg
     aliases:
       - CVE-2024-45341

--- a/crossplane-provider-sql.advisories.yaml
+++ b/crossplane-provider-sql.advisories.yaml
@@ -80,6 +80,16 @@ advisories:
         data:
           fixed-version: 0.9.0-r2
 
+  - id: CGA-q29q-pg5c-7wjr
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:53:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'crossplane-provider-sql version 0.11.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-x83v-7gjv-cv77
     aliases:
       - CVE-2024-45341

--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -252,6 +252,16 @@ advisories:
         data:
           fixed-version: 7.56.0-r0
 
+  - id: CGA-8x6r-mfj3-jvrr
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:54:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'datadog-agent version 7.63.2-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-94j3-xw25-m3v3
     aliases:
       - CVE-2024-24785

--- a/dbmate.advisories.yaml
+++ b/dbmate.advisories.yaml
@@ -79,6 +79,16 @@ advisories:
         data:
           fixed-version: 2.18.0-r1
 
+  - id: CGA-hxr2-w53q-h6rw
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:54:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'dbmate version 2.26.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-jw9c-qf82-cx4v
     aliases:
       - CVE-2024-45337

--- a/descheduler.advisories.yaml
+++ b/descheduler.advisories.yaml
@@ -90,6 +90,16 @@ advisories:
         data:
           fixed-version: 0.31.0-r0
 
+  - id: CGA-jp9m-3w34-g65x
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:52:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'descheduler version 0.32.2-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-m84m-m98j-q5rx
     aliases:
       - CVE-2024-45336

--- a/dgraph.advisories.yaml
+++ b/dgraph.advisories.yaml
@@ -594,6 +594,16 @@ advisories:
         data:
           fixed-version: 23.1.0-r5
 
+  - id: CGA-vfmg-533p-3j49
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:52:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'dgraph version 24.0.5-r7: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-w75r-3388-975j
     aliases:
       - CVE-2023-45289

--- a/distribution.advisories.yaml
+++ b/distribution.advisories.yaml
@@ -177,3 +177,13 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.0.0-r2
+
+  - id: CGA-wrq7-j9m2-p4hv
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:53:07Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'distribution version 3.0.0-r7: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'

--- a/docker-cli-buildx.advisories.yaml
+++ b/docker-cli-buildx.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: docker-cli-buildx
 
 advisories:
+  - id: CGA-5h26-26jm-9r84
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:53:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'docker-cli-buildx version 0.21.2-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-pm5p-rjx9-74xw
     aliases:
       - CVE-2024-45337

--- a/docker-credential-acr-env.advisories.yaml
+++ b/docker-credential-acr-env.advisories.yaml
@@ -167,6 +167,16 @@ advisories:
         data:
           fixed-version: 0.7.0-r17
 
+  - id: CGA-f82m-53wp-gx3v
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:52:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'docker-credential-acr-env version 0.7.0-r18: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-fg5q-rmm9-3m94
     aliases:
       - CVE-2024-34156

--- a/dockerize.advisories.yaml
+++ b/dockerize.advisories.yaml
@@ -88,6 +88,16 @@ advisories:
         data:
           fixed-version: 0.7.0-r8
 
+  - id: CGA-8rc5-5qq6-q32p
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:53:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'dockerize version 0.9.2-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-8rhv-gr29-p3w6
     aliases:
       - CVE-2024-34155

--- a/dynamic-localpv-provisioner.advisories.yaml
+++ b/dynamic-localpv-provisioner.advisories.yaml
@@ -293,6 +293,16 @@ advisories:
         data:
           fixed-version: 3.5.0-r4
 
+  - id: CGA-jm97-p8m4-6q8v
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:57:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'dynamic-localpv-provisioner version 4.2.0-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-mj57-h4mg-wrcj
     aliases:
       - CVE-2022-27664

--- a/envoy-gateway.advisories.yaml
+++ b/envoy-gateway.advisories.yaml
@@ -48,6 +48,16 @@ advisories:
         data:
           fixed-version: 1.2.4-r1
 
+  - id: CGA-m226-jmmq-x2j9
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:58:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'envoy-gateway version 1.3.0-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-p24w-9pqm-cmmw
     aliases:
       - CVE-2025-22866

--- a/etcd-3.5.advisories.yaml
+++ b/etcd-3.5.advisories.yaml
@@ -314,6 +314,16 @@ advisories:
         data:
           fixed-version: 3.5.12-r1
 
+  - id: CGA-wr84-m7q4-85w5
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:02:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'etcd-3.5 version 3.5.18-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-x23q-mfqm-wwjp
     aliases:
       - CVE-2024-24785

--- a/external-secrets-operator.advisories.yaml
+++ b/external-secrets-operator.advisories.yaml
@@ -228,6 +228,16 @@ advisories:
         data:
           fixed-version: 0.9.17-r1
 
+  - id: CGA-pj46-rcvf-mw52
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:00:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'external-secrets-operator version 0.14.3-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-qgj3-vh84-p9jq
     aliases:
       - GHSA-xr7q-jx4m-x55m

--- a/extism.advisories.yaml
+++ b/extism.advisories.yaml
@@ -46,6 +46,16 @@ advisories:
         data:
           fixed-version: 1.5.0-r1
 
+  - id: CGA-37rv-gmq2-32c7
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:55:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'extism version 1.6.2-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-3fpx-x749-22m3
     aliases:
       - CVE-2024-34155

--- a/falcosidekick.advisories.yaml
+++ b/falcosidekick.advisories.yaml
@@ -14,6 +14,16 @@ advisories:
         data:
           fixed-version: 2.29.0-r1
 
+  - id: CGA-2gvh-wv77-7v82
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:57:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'falcosidekick version 2.31.1-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-2qhf-472v-2gg4
     aliases:
       - CVE-2025-22866

--- a/ferretdb.advisories.yaml
+++ b/ferretdb.advisories.yaml
@@ -102,6 +102,16 @@ advisories:
             This vulnerability relates to p256NegCond within the crypto/internal/fips140/nistec package, specifically affecting the ppc64le architecture.
             We are not affected by this vulnerability as we do not build or support ppc64le.
 
+  - id: CGA-7hv8-ppvh-fg5j
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:56:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'ferretdb version 1.24.0-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-c9mp-7g38-q4j4
     aliases:
       - CVE-2024-45338

--- a/flannel.advisories.yaml
+++ b/flannel.advisories.yaml
@@ -65,6 +65,16 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
 
+  - id: CGA-8rm8-wpxg-9qrh
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:56:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'flannel version 0.26.4-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-c5pq-jmcp-jpfc
     aliases:
       - CVE-2024-24786

--- a/fluent-bit-plugin-loki.advisories.yaml
+++ b/fluent-bit-plugin-loki.advisories.yaml
@@ -130,6 +130,16 @@ advisories:
         data:
           fixed-version: 3.1.1-r1
 
+  - id: CGA-g4j9-c467-gr37
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:55:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'fluent-bit-plugin-loki version 3.4.2-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-j5r8-rwhx-x952
     aliases:
       - CVE-2024-45341

--- a/flux-helm-controller.advisories.yaml
+++ b/flux-helm-controller.advisories.yaml
@@ -354,6 +354,16 @@ advisories:
         data:
           fixed-version: 1.1.0-r4
 
+  - id: CGA-j324-qv79-f589
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:57:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'flux-helm-controller version 1.2.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-pj27-pmg8-82wv
     aliases:
       - CVE-2024-41110

--- a/flux-image-reflector-controller.advisories.yaml
+++ b/flux-image-reflector-controller.advisories.yaml
@@ -100,6 +100,16 @@ advisories:
         data:
           fixed-version: 0.31.2-r2
 
+  - id: CGA-62rq-w554-ggpj
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:01:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'flux-image-reflector-controller version 0.34.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-63h7-fx9m-6w96
     aliases:
       - CVE-2024-24790

--- a/flux-kustomize-controller.advisories.yaml
+++ b/flux-kustomize-controller.advisories.yaml
@@ -491,6 +491,16 @@ advisories:
         data:
           fixed-version: 1.1.1-r1
 
+  - id: CGA-xjf8-827j-rpg5
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:58:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'flux-kustomize-controller version 1.5.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-xmr2-jmhf-5mj5
     aliases:
       - CVE-2024-34158

--- a/flyte.advisories.yaml
+++ b/flyte.advisories.yaml
@@ -70,6 +70,16 @@ advisories:
         data:
           fixed-version: 1.13.1-r1
 
+  - id: CGA-64rr-6gv8-jm7x
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:00:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'flyte version 1.15.0-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-77hx-x9cc-8vc9
     aliases:
       - CVE-2025-27144

--- a/fq.advisories.yaml
+++ b/fq.advisories.yaml
@@ -56,6 +56,16 @@ advisories:
         data:
           fixed-version: 0.10.0-r2
 
+  - id: CGA-3fgg-9wv4-qj5x
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:55:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'fq version 0.14.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-6hv8-w9vx-276m
     aliases:
       - CVE-2023-45283

--- a/gcp-compute-persistent-disk-csi-driver-1.15.advisories.yaml
+++ b/gcp-compute-persistent-disk-csi-driver-1.15.advisories.yaml
@@ -58,6 +58,16 @@ advisories:
         data:
           fixed-version: 1.15.4-r2
 
+  - id: CGA-j847-7v42-wggc
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:00:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'gcp-compute-persistent-disk-csi-driver-1.15 version 1.15.4-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-qg94-hcf4-g52x
     aliases:
       - CVE-2024-45336

--- a/gcsfuse.advisories.yaml
+++ b/gcsfuse.advisories.yaml
@@ -54,6 +54,16 @@ advisories:
         data:
           fixed-version: 1.4.2-r15
 
+  - id: CGA-3hh3-537j-4j53
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:59:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'gcsfuse version 1.4.2-r15: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-3xhh-239m-cfm9
     aliases:
       - CVE-2024-24789

--- a/git-lfs.advisories.yaml
+++ b/git-lfs.advisories.yaml
@@ -229,6 +229,16 @@ advisories:
         data:
           fixed-version: 3.5.1-r8
 
+  - id: CGA-mg3m-4h4h-f7mh
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:59:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'git-lfs version 3.6.1-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-mmcp-vxj2-wqxw
     aliases:
       - CVE-2023-45284

--- a/gitleaks.advisories.yaml
+++ b/gitleaks.advisories.yaml
@@ -108,6 +108,16 @@ advisories:
         data:
           fixed-version: 8.22.0-r1
 
+  - id: CGA-c4hm-fxm6-wj79
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:58:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'gitleaks version 8.24.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-m639-pvh6-69x9
     aliases:
       - CVE-2021-38561

--- a/glab.advisories.yaml
+++ b/glab.advisories.yaml
@@ -68,6 +68,16 @@ advisories:
         data:
           fixed-version: 1.52.0-r1
 
+  - id: CGA-86jf-64p7-gcqc
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T17:59:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'glab version 1.53.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-88xv-6f4v-pvh7
     aliases:
       - CVE-2020-8559

--- a/gobuster.advisories.yaml
+++ b/gobuster.advisories.yaml
@@ -111,6 +111,16 @@ advisories:
         data:
           fixed-version: 3.6.0-r5
 
+  - id: CGA-8xvj-87j7-j59f
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:00:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'gobuster version 3.6.0-r18: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-9635-37wp-864v
     aliases:
       - CVE-2024-24791

--- a/grafana-agent-operator.advisories.yaml
+++ b/grafana-agent-operator.advisories.yaml
@@ -227,6 +227,16 @@ advisories:
         data:
           fixed-version: 0.42.0-r1
 
+  - id: CGA-wf8h-j3v8-3xpx
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:05:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'grafana-agent-operator version 0.44.2-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-xw5h-mq5m-fjpc
     aliases:
       - CVE-2023-45288

--- a/grafana-mimir.advisories.yaml
+++ b/grafana-mimir.advisories.yaml
@@ -58,6 +58,16 @@ advisories:
         data:
           fixed-version: 2.12.0-r1
 
+  - id: CGA-72cx-rrcm-pjx7
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:02:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'grafana-mimir version 2.15.0-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-752q-23cr-gcqw
     aliases:
       - CVE-2024-24791

--- a/grpc-health-probe.advisories.yaml
+++ b/grpc-health-probe.advisories.yaml
@@ -57,6 +57,16 @@ advisories:
         data:
           fixed-version: 0.4.26-r3
 
+  - id: CGA-5r2h-289v-8wc7
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:01:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'grpc-health-probe version 0.4.37-r3: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-99xp-4fc7-m3mv
     aliases:
       - CVE-2024-45336

--- a/harbor-2.12.advisories.yaml
+++ b/harbor-2.12.advisories.yaml
@@ -155,3 +155,13 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.12.0-r2
+
+  - id: CGA-vghr-r5p3-9hxq
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:02:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'harbor-2.12 version 2.12.2-r4: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'

--- a/harbor-registry.advisories.yaml
+++ b/harbor-registry.advisories.yaml
@@ -142,6 +142,16 @@ advisories:
             componentLocation: /usr/bin/harbor-registry
             scanner: grype
 
+  - id: CGA-9g6p-fg5j-wp4v
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:04:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'harbor-registry version 3.0.0_alpha1-r17: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-c245-p843-qhxc
     aliases:
       - CVE-2024-34158

--- a/helm-docs.advisories.yaml
+++ b/helm-docs.advisories.yaml
@@ -100,6 +100,16 @@ advisories:
         data:
           fixed-version: 1.14.2-r5
 
+  - id: CGA-m7v5-7m59-rfp4
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:02:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'helm-docs version 1.14.2-r5: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-mf9j-98jm-76v2
     aliases:
       - CVE-2024-34156

--- a/helm-operator.advisories.yaml
+++ b/helm-operator.advisories.yaml
@@ -321,6 +321,16 @@ advisories:
         data:
           fixed-version: 1.34.1-r1
 
+  - id: CGA-vg53-qm5h-x4cp
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:04:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'helm-operator version 1.39.1-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-vvhg-wrh3-2x3p
     aliases:
       - CVE-2024-25620

--- a/helm-push.advisories.yaml
+++ b/helm-push.advisories.yaml
@@ -258,6 +258,16 @@ advisories:
         data:
           fixed-version: 0.10.4-r2
 
+  - id: CGA-gj4p-7qgm-f54r
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:04:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'helm-push version 0.10.4-r19: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-hcpx-vh8j-2gmr
     aliases:
       - CVE-2024-24791

--- a/hugo-extended.advisories.yaml
+++ b/hugo-extended.advisories.yaml
@@ -184,6 +184,16 @@ advisories:
         data:
           fixed-version: 0.139.3-r1
 
+  - id: CGA-r258-fmfp-hj2q
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:03:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'hugo-extended version 0.145.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-wqr7-66c4-fq65
     aliases:
       - CVE-2024-24792

--- a/hugo.advisories.yaml
+++ b/hugo.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: hugo
 
 advisories:
+  - id: CGA-33jf-j4cm-hhvw
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:03:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'hugo version 0.145.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-3797-x2q6-6f92
     aliases:
       - CVE-2024-24792

--- a/influxd.advisories.yaml
+++ b/influxd.advisories.yaml
@@ -306,6 +306,16 @@ advisories:
             componentLocation: /usr/bin/influxd
             scanner: grype
 
+  - id: CGA-v58j-hc95-5phg
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:05:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'influxd version 2.7.11-r4: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-vpqx-h5jf-vgrp
     aliases:
       - CVE-2024-34155

--- a/k3s.advisories.yaml
+++ b/k3s.advisories.yaml
@@ -550,6 +550,16 @@ advisories:
         data:
           fixed-version: 1.30.3.1-r0
 
+  - id: CGA-qfgm-7cv8-fr2c
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:06:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'k3s version 1.32.2.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-qfhr-78m7-prm9
     aliases:
       - GHSA-jq35-85cj-fj4p

--- a/k6.advisories.yaml
+++ b/k6.advisories.yaml
@@ -36,6 +36,16 @@ advisories:
         data:
           fixed-version: 0.56.0-r1
 
+  - id: CGA-3rc5-693w-7vjv
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:04:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'k6 version 0.57.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-4vcc-779f-qc9m
     aliases:
       - CVE-2024-45341

--- a/k8ssandra-client.advisories.yaml
+++ b/k8ssandra-client.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: k8ssandra-client
 
 advisories:
+  - id: CGA-3p92-j3hj-89q9
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:09:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'k8ssandra-client version 0.6.0-r4: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-8f7f-8fm8-rqw8
     aliases:
       - CVE-2024-45337

--- a/kafka_exporter.advisories.yaml
+++ b/kafka_exporter.advisories.yaml
@@ -196,6 +196,16 @@ advisories:
         data:
           fixed-version: 1.8.0-r5
 
+  - id: CGA-vrf3-xqrx-fjq7
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:03:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kafka_exporter version 1.9.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-vw6j-vx6p-5525
     aliases:
       - CVE-2024-24790

--- a/kapp-controller.advisories.yaml
+++ b/kapp-controller.advisories.yaml
@@ -36,6 +36,16 @@ advisories:
         data:
           fixed-version: 0.55.0-r2
 
+  - id: CGA-8gfv-vw67-42cf
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:06:29Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kapp-controller version 0.55.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-f5hj-h6f6-v6m6
     aliases:
       - CVE-2024-45338

--- a/keda-2.16.advisories.yaml
+++ b/keda-2.16.advisories.yaml
@@ -101,6 +101,16 @@ advisories:
             componentLocation: /usr/bin/keda-adapter
             scanner: grype
 
+  - id: CGA-r685-5jg2-7g4f
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:18:11Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'keda-2.16 version 2.16.1-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-rp96-w5r4-hmm8
     aliases:
       - CVE-2024-45336

--- a/kserve-modelmesh-serving.advisories.yaml
+++ b/kserve-modelmesh-serving.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: kserve-modelmesh-serving
 
 advisories:
+  - id: CGA-4gv6-8gx4-phhf
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:08:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kserve-modelmesh-serving version 0.12.0-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-8xhw-pw8q-xw76
     aliases:
       - CVE-2024-45337

--- a/kube-bench.advisories.yaml
+++ b/kube-bench.advisories.yaml
@@ -254,6 +254,16 @@ advisories:
         data:
           fixed-version: 0.7.2-r1
 
+  - id: CGA-pq5q-w62f-h5wq
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:06:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kube-bench version 0.10.2-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-qq26-69q9-286j
     aliases:
       - CVE-2023-45284

--- a/kube-metrics-adapter.advisories.yaml
+++ b/kube-metrics-adapter.advisories.yaml
@@ -156,6 +156,16 @@ advisories:
         data:
           fixed-version: 0.2.3-r3
 
+  - id: CGA-vqx3-2g74-6g94
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:07:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kube-metrics-adapter version 0.2.3-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-wgmv-mp63-fvrv
     aliases:
       - CVE-2024-34156

--- a/kube-rbac-proxy.advisories.yaml
+++ b/kube-rbac-proxy.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: kube-rbac-proxy
 
 advisories:
+  - id: CGA-23wf-5qmp-xj6p
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:07:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kube-rbac-proxy version 0.19.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-32r2-f57x-g693
     aliases:
       - CVE-2025-22866

--- a/kube-state-metrics.advisories.yaml
+++ b/kube-state-metrics.advisories.yaml
@@ -108,6 +108,16 @@ advisories:
         data:
           fixed-version: 2.11.0-r0
 
+  - id: CGA-9vqx-mmq6-mp9v
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:09:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kube-state-metrics version 2.15.0-r3: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-f9r2-9437-mv79
     aliases:
       - CVE-2024-24791

--- a/kube-vip.advisories.yaml
+++ b/kube-vip.advisories.yaml
@@ -110,6 +110,16 @@ advisories:
         data:
           fixed-version: 0.8.3-r0
 
+  - id: CGA-h7wm-9452-5g97
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:08:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kube-vip version 0.8.9-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-hv6m-hhj8-f35w
     aliases:
       - CVE-2024-45341

--- a/kubernetes-dashboard-api.advisories.yaml
+++ b/kubernetes-dashboard-api.advisories.yaml
@@ -48,6 +48,16 @@ advisories:
         data:
           fixed-version: 1.10.2-r1
 
+  - id: CGA-c9p8-gwmf-wrpj
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:09:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kubernetes-dashboard-api version 1.11.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-jhhw-w8gg-53px
     aliases:
       - CVE-2024-45337

--- a/kubernetes-dashboard-auth.advisories.yaml
+++ b/kubernetes-dashboard-auth.advisories.yaml
@@ -36,6 +36,16 @@ advisories:
         data:
           fixed-version: 1.2.3-r1
 
+  - id: CGA-8jvh-299x-p65v
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:07:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kubernetes-dashboard-auth version 1.2.3-r3: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-c8m2-x48p-632v
     aliases:
       - CVE-2024-45337

--- a/kubernetes-dashboard-web.advisories.yaml
+++ b/kubernetes-dashboard-web.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: kubernetes-dashboard-web
 
 advisories:
+  - id: CGA-6x6c-8xwh-w2pj
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:11:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kubernetes-dashboard-web version 1.6.2-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-8vp7-82p5-wm4c
     aliases:
       - CVE-2025-22866

--- a/kubernetes-dashboard.advisories.yaml
+++ b/kubernetes-dashboard.advisories.yaml
@@ -14,6 +14,16 @@ advisories:
         data:
           fixed-version: 2.7.0-r19
 
+  - id: CGA-3jvc-6j7v-h6v7
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:09:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kubernetes-dashboard version 7.11.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-3v67-6xw3-mhh3
     aliases:
       - CVE-2024-24784

--- a/kubernetes-dns-node-cache.advisories.yaml
+++ b/kubernetes-dns-node-cache.advisories.yaml
@@ -124,6 +124,16 @@ advisories:
         data:
           fixed-version: 1.23.1-r4
 
+  - id: CGA-92fw-rv96-3297
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:07:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kubernetes-dns-node-cache version 1.25.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-9435-7j5v-5j5x
     aliases:
       - CVE-2024-24789

--- a/kubernetes-event-exporter.advisories.yaml
+++ b/kubernetes-event-exporter.advisories.yaml
@@ -152,6 +152,16 @@ advisories:
         data:
           fixed-version: 1.7-r11
 
+  - id: CGA-fxp8-p49c-4954
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:17:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kubernetes-event-exporter version 1.7-r16: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-g857-c4f2-c6qj
     aliases:
       - CVE-2024-34155

--- a/kwok.advisories.yaml
+++ b/kwok.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: kwok
 
 advisories:
+  - id: CGA-24fj-px5g-395v
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:14:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kwok version 0.6.1-r4: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-28rg-6wmg-rgfx
     aliases:
       - CVE-2024-24789

--- a/kyverno-policy-reporter-ui.advisories.yaml
+++ b/kyverno-policy-reporter-ui.advisories.yaml
@@ -186,6 +186,16 @@ advisories:
         data:
           fixed-version: 2.0.1-r1
 
+  - id: CGA-wp6f-83p3-329m
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:10:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kyverno-policy-reporter-ui version 2.1.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-x7g3-f5gj-4gf7
     aliases:
       - CVE-2024-24786

--- a/kyverno-policy-reporter.advisories.yaml
+++ b/kyverno-policy-reporter.advisories.yaml
@@ -297,3 +297,13 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.19.0-r1
+
+  - id: CGA-xmqw-cf47-9q32
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:10:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'kyverno-policy-reporter version 3.0.4-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'

--- a/local-static-provisioner.advisories.yaml
+++ b/local-static-provisioner.advisories.yaml
@@ -268,6 +268,16 @@ advisories:
         data:
           fixed-version: 2.7.0-r1
 
+  - id: CGA-p776-p38r-595m
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:11:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'local-static-provisioner version 2.7.0-r13: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-r266-hcfg-f5cj
     aliases:
       - CVE-2024-24791

--- a/mailpit.advisories.yaml
+++ b/mailpit.advisories.yaml
@@ -14,6 +14,16 @@ advisories:
         data:
           fixed-version: 1.22.1-r0
 
+  - id: CGA-54qr-j43c-hc9p
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:10:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'mailpit version 1.23.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-6xfg-p2h4-5g47
     aliases:
       - CVE-2024-45338

--- a/malcontent.advisories.yaml
+++ b/malcontent.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: malcontent
 
 advisories:
+  - id: CGA-87xp-8m9p-55wp
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:12:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'malcontent version 1.8.7-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-rfjj-xh44-jw47
     aliases:
       - CVE-2025-22866

--- a/memcached-exporter.advisories.yaml
+++ b/memcached-exporter.advisories.yaml
@@ -24,6 +24,16 @@ advisories:
         data:
           fixed-version: 0.14.2-r2
 
+  - id: CGA-3mfc-67mq-hc4x
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:11:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'memcached-exporter version 0.15.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-3pjq-fc88-c3pv
     aliases:
       - CVE-2024-24783

--- a/metrics-server.advisories.yaml
+++ b/metrics-server.advisories.yaml
@@ -155,6 +155,16 @@ advisories:
         data:
           fixed-version: 0.7.2-r2
 
+  - id: CGA-83c9-4j78-22p6
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:13:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'metrics-server version 0.7.2-r7: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-86gc-q59v-qf62
     aliases:
       - CVE-2024-24788

--- a/minio-operator.advisories.yaml
+++ b/minio-operator.advisories.yaml
@@ -48,6 +48,16 @@ advisories:
         data:
           fixed-version: 6.0.3-r1
 
+  - id: CGA-6vj9-69x3-pcxm
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:13:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'minio-operator version 7.0.0-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-7j5r-g7jg-r52g
     aliases:
       - CVE-2024-34158

--- a/mkcert.advisories.yaml
+++ b/mkcert.advisories.yaml
@@ -164,6 +164,16 @@ advisories:
         data:
           fixed-version: 1.4.4-r5
 
+  - id: CGA-jwqh-8jfp-3fwj
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:11:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'mkcert version 1.4.4-r9: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-pmq4-xqgc-r2jv
     aliases:
       - CVE-2024-34156

--- a/nats-server.advisories.yaml
+++ b/nats-server.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: nats-server
 
 advisories:
+  - id: CGA-2hv5-9qw3-xmmj
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:12:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'nats-server version 2.10.26-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-3fcc-pq38-h3gr
     aliases:
       - GHSA-2c64-vj8g-vwrq

--- a/nats.advisories.yaml
+++ b/nats.advisories.yaml
@@ -14,6 +14,16 @@ advisories:
         data:
           fixed-version: 0.1.1-r4
 
+  - id: CGA-3wfv-gff5-5qf2
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:14:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'nats version 0.1.6-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-456r-62vj-m4h7
     aliases:
       - CVE-2024-34155

--- a/neuvector-sigstore-interface.advisories.yaml
+++ b/neuvector-sigstore-interface.advisories.yaml
@@ -246,6 +246,16 @@ advisories:
         data:
           fixed-version: 0_git20240801-r4
 
+  - id: CGA-v33v-2372-p966
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:16:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'neuvector-sigstore-interface version 0_git20240801-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-v924-gcj3-ccj2
     aliases:
       - CVE-2024-6104

--- a/newrelic-nri-statsd.advisories.yaml
+++ b/newrelic-nri-statsd.advisories.yaml
@@ -140,6 +140,16 @@ advisories:
         data:
           fixed-version: 2.10.0-r2
 
+  - id: CGA-f2q6-3jxm-5wx6
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:12:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'newrelic-nri-statsd version 2.10.0-r3: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-fg52-xwm5-x95p
     aliases:
       - CVE-2024-45341

--- a/nfs-subdir-external-provisioner.advisories.yaml
+++ b/nfs-subdir-external-provisioner.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: nfs-subdir-external-provisioner
 
 advisories:
+  - id: CGA-28m7-w6q9-fpmf
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:17:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'nfs-subdir-external-provisioner version 4.0.18-r16: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-2jh5-h589-r97p
     aliases:
       - CVE-2024-45338

--- a/nginx-prometheus-exporter.advisories.yaml
+++ b/nginx-prometheus-exporter.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: nginx-prometheus-exporter
 
 advisories:
+  - id: CGA-6755-c4hx-pmrh
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:13:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'nginx-prometheus-exporter version 1.4.1-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-7rwq-hhh8-jx92
     aliases:
       - CVE-2025-22866

--- a/node-problem-detector-0.8.advisories.yaml
+++ b/node-problem-detector-0.8.advisories.yaml
@@ -70,6 +70,16 @@ advisories:
         data:
           fixed-version: 0.8.17-r0
 
+  - id: CGA-6g6c-xfq8-76w9
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:15:20Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'node-problem-detector-0.8 version 0.8.20-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-7m4g-cwm3-8cx2
     aliases:
       - CVE-2024-24786

--- a/nri-kafka.advisories.yaml
+++ b/nri-kafka.advisories.yaml
@@ -238,6 +238,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.10.2-r1
+      - timestamp: 2025-03-04T18:14:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'nri-kafka version 3.10.2-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
 
   - id: CGA-j7r8-x672-8r36
     aliases:

--- a/nri-mssql.advisories.yaml
+++ b/nri-mssql.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: nri-mssql
 
 advisories:
+  - id: CGA-2j98-gc72-r7pg
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:14:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'nri-mssql version 2.17.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-3pm9-4v42-fpc3
     aliases:
       - CVE-2023-45288

--- a/nsc.advisories.yaml
+++ b/nsc.advisories.yaml
@@ -218,6 +218,16 @@ advisories:
         data:
           fixed-version: 2.8.9-r0
 
+  - id: CGA-m6v7-4x6v-wvch
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:15:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'nsc version 2.10.2-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-pfjm-42x4-fg2j
     aliases:
       - CVE-2024-34158

--- a/oauth2-proxy.advisories.yaml
+++ b/oauth2-proxy.advisories.yaml
@@ -274,6 +274,16 @@ advisories:
         data:
           fixed-version: 7.5.1-r4
 
+  - id: CGA-q23p-r6w6-69qr
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:15:58Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'oauth2-proxy version 7.8.1-r3: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-q6x5-29q8-x5q3
     aliases:
       - CVE-2025-27144

--- a/octo-sts.advisories.yaml
+++ b/octo-sts.advisories.yaml
@@ -224,6 +224,16 @@ advisories:
         data:
           fixed-version: 0.4.2-r1
 
+  - id: CGA-vr74-7p59-7chr
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:16:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'octo-sts version 0.4.2-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-xr68-v2mj-jq6f
     aliases:
       - CVE-2024-45341

--- a/openbao-k8s.advisories.yaml
+++ b/openbao-k8s.advisories.yaml
@@ -24,6 +24,16 @@ advisories:
         data:
           fixed-version: 1.4.0-r3
 
+  - id: CGA-rcpj-4xcp-m43c
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:16:56Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'openbao-k8s version 1.4.0-r4: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-vr23-4pp7-4rhp
     aliases:
       - CVE-2024-45338

--- a/oras.advisories.yaml
+++ b/oras.advisories.yaml
@@ -266,6 +266,16 @@ advisories:
         data:
           fixed-version: 1.2.2-r1
 
+  - id: CGA-qc9c-w269-39wq
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:17:10Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'oras version 1.2.2-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-w6j7-f6vv-q39f
     aliases:
       - CVE-2024-24788

--- a/portieris.advisories.yaml
+++ b/portieris.advisories.yaml
@@ -91,3 +91,13 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.13.23-r3
+
+  - id: CGA-vwm2-wg2m-26jm
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:18:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'portieris version 0.13.24-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'

--- a/postgres-operator.advisories.yaml
+++ b/postgres-operator.advisories.yaml
@@ -96,6 +96,16 @@ advisories:
         data:
           fixed-version: 1.13.0-r3
 
+  - id: CGA-9v54-xxh4-x82p
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:18:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'postgres-operator version 1.14.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-ff25-9pgr-v35m
     aliases:
       - CVE-2023-45288

--- a/prometheus-adapter.advisories.yaml
+++ b/prometheus-adapter.advisories.yaml
@@ -123,6 +123,16 @@ advisories:
         data:
           fixed-version: 0.11.1-r4
 
+  - id: CGA-c47m-hfh6-vww5
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:22:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'prometheus-adapter version 0.12.0-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-c5f5-69q8-3j7c
     aliases:
       - CVE-2023-39325

--- a/prometheus-alertmanager.advisories.yaml
+++ b/prometheus-alertmanager.advisories.yaml
@@ -331,6 +331,16 @@ advisories:
         data:
           fixed-version: 0.27.0-r10
 
+  - id: CGA-pv28-j5vq-fm5w
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:20:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'prometheus-alertmanager version 0.28.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-qwhp-882g-xv83
     aliases:
       - CVE-2023-45290

--- a/prometheus-pushgateway.advisories.yaml
+++ b/prometheus-pushgateway.advisories.yaml
@@ -328,6 +328,16 @@ advisories:
         data:
           fixed-version: 1.7.0-r2
 
+  - id: CGA-wqvv-3h79-95mh
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:18:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'prometheus-pushgateway version 1.11.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-x9fq-r9xx-4qrc
     aliases:
       - CVE-2024-24790

--- a/rabbitmq-messaging-topology-operator.advisories.yaml
+++ b/rabbitmq-messaging-topology-operator.advisories.yaml
@@ -110,6 +110,16 @@ advisories:
         data:
           fixed-version: 1.16.0-r0
 
+  - id: CGA-c2rh-6x4h-pvj5
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:19:16Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'rabbitmq-messaging-topology-operator version 1.16.0-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-cq3f-vm3x-8rw3
     aliases:
       - CVE-2023-45283

--- a/rook.advisories.yaml
+++ b/rook.advisories.yaml
@@ -90,6 +90,16 @@ advisories:
         data:
           fixed-version: 1.13.6-r1
 
+  - id: CGA-897p-hgwr-9p57
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:22:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'rook version 1.16.4-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-fq9c-94m5-468x
     aliases:
       - CVE-2024-34158

--- a/sbomqs.advisories.yaml
+++ b/sbomqs.advisories.yaml
@@ -58,6 +58,16 @@ advisories:
         data:
           fixed-version: 0.1.9-r1
 
+  - id: CGA-7xxh-24mx-mvxj
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:19:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'sbomqs version 1.0.2-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-86v3-6c8r-2hrh
     aliases:
       - CVE-2023-45288

--- a/seaweedfs.advisories.yaml
+++ b/seaweedfs.advisories.yaml
@@ -48,6 +48,16 @@ advisories:
         data:
           fixed-version: 3.73-r0
 
+  - id: CGA-g9wx-mhxc-3v9g
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:22:55Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'seaweedfs version 3.85-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-p27p-955w-6r3g
     aliases:
       - CVE-2024-34158

--- a/secrets-store-csi-driver-provider-azure.advisories.yaml
+++ b/secrets-store-csi-driver-provider-azure.advisories.yaml
@@ -318,6 +318,16 @@ advisories:
         data:
           fixed-version: 1.5.3-r2
 
+  - id: CGA-w5f5-pp7w-vq9m
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:19:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'secrets-store-csi-driver-provider-azure version 1.6.2-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-wqjq-64jv-6hh9
     aliases:
       - CVE-2024-24783

--- a/secrets-store-csi-driver-provider-gcp.advisories.yaml
+++ b/secrets-store-csi-driver-provider-gcp.advisories.yaml
@@ -100,6 +100,16 @@ advisories:
         data:
           fixed-version: 1.5.0-r2
 
+  - id: CGA-996f-67h9-q7rw
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:21:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'secrets-store-csi-driver-provider-gcp version 1.7.0-r3: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-9cjq-mp74-4633
     aliases:
       - CVE-2024-45341

--- a/secrets-store-csi-driver.advisories.yaml
+++ b/secrets-store-csi-driver.advisories.yaml
@@ -294,3 +294,13 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
+
+  - id: CGA-w8hw-4323-44q4
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:20:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'secrets-store-csi-driver version 1.4.8-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'

--- a/sftpgo-plugin-auth.advisories.yaml
+++ b/sftpgo-plugin-auth.advisories.yaml
@@ -69,6 +69,16 @@ advisories:
         data:
           note: 'Awaiting release of fix by upstream dependency yamux: https://github.com/hashicorp/yamux/pull/143'
 
+  - id: CGA-75pr-2mff-g98h
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:20:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'sftpgo-plugin-auth version 1.0.11-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-7f5m-4f4w-2vqv
     aliases:
       - CVE-2024-45336

--- a/sftpgo-plugin-eventsearch.advisories.yaml
+++ b/sftpgo-plugin-eventsearch.advisories.yaml
@@ -67,6 +67,16 @@ advisories:
         data:
           fixed-version: 1.0.19-r3
 
+  - id: CGA-pfj5-4m36-p3jh
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:21:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'sftpgo-plugin-eventsearch version 1.0.20-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-r786-mcqw-6fmw
     aliases:
       - CVE-2024-45337

--- a/sftpgo-plugin-eventstore.advisories.yaml
+++ b/sftpgo-plugin-eventstore.advisories.yaml
@@ -69,6 +69,16 @@ advisories:
         data:
           fixed-version: 1.0.19-r4
 
+  - id: CGA-fpcm-h9gg-4pmg
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:21:47Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'sftpgo-plugin-eventstore version 1.0.20-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-p576-j5p6-569g
     aliases:
       - CVE-2024-45337

--- a/sftpgo-plugin-kms.advisories.yaml
+++ b/sftpgo-plugin-kms.advisories.yaml
@@ -79,6 +79,16 @@ advisories:
         data:
           fixed-version: 1.0.14-r3
 
+  - id: CGA-gf3j-f7c2-c239
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:22:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'sftpgo-plugin-kms version 1.0.15-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-pq8c-p9rg-4gr3
     aliases:
       - CVE-2024-45336

--- a/sftpgo-plugin-pubsub.advisories.yaml
+++ b/sftpgo-plugin-pubsub.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: sftpgo-plugin-pubsub
 
 advisories:
+  - id: CGA-634r-rxc6-xfx4
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:23:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'sftpgo-plugin-pubsub version 1.0.14-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-c2q6-wqpc-j8pg
     aliases:
       - CVE-2024-45341

--- a/skopeo.advisories.yaml
+++ b/skopeo.advisories.yaml
@@ -249,6 +249,21 @@ advisories:
         data:
           fixed-version: 1.14.1-r1
 
+  - id: CGA-j52x-8m9r-cjgx
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:23:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'skopeo version 1.18.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+      - timestamp: 2025-03-04T18:31:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'skopeo version 1.18.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-m8x6-3979-pj9v
     aliases:
       - CVE-2024-34158

--- a/sops.advisories.yaml
+++ b/sops.advisories.yaml
@@ -303,6 +303,21 @@ advisories:
         data:
           fixed-version: 3.9.2-r2
 
+  - id: CGA-jpjv-x72p-3gxh
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:32:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'sops version 3.9.4-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+      - timestamp: 2025-03-04T19:29:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'sops version 3.9.4-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-p5cr-3f5q-x52x
     aliases:
       - CVE-2023-48795

--- a/spicedb.advisories.yaml
+++ b/spicedb.advisories.yaml
@@ -187,6 +187,21 @@ advisories:
         data:
           fixed-version: 1.40.0-r1
 
+  - id: CGA-crgg-wqcq-9v35
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:32:02Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'spicedb version 1.41.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+      - timestamp: 2025-03-04T19:29:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'spicedb version 1.41.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-f822-vg76-v76h
     aliases:
       - GHSA-7jwh-3vrq-q3m8

--- a/spiffe-helper.advisories.yaml
+++ b/spiffe-helper.advisories.yaml
@@ -46,6 +46,21 @@ advisories:
         data:
           fixed-version: 0.9.0-r3
 
+  - id: CGA-gv78-m6r3-cmg7
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:23:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'spiffe-helper version 0.9.1-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+      - timestamp: 2025-03-04T18:31:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'spiffe-helper version 0.9.1-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-j8vc-j8rx-pvp9
     aliases:
       - CVE-2024-45337

--- a/spqr.advisories.yaml
+++ b/spqr.advisories.yaml
@@ -188,6 +188,16 @@ advisories:
         data:
           fixed-version: 2.1.0-r1
 
+  - id: CGA-w2fg-3qm2-j9wh
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:31:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'spqr version 2.4.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-w84r-xqxc-pcx6
     aliases:
       - CVE-2024-24790

--- a/sql_exporter.advisories.yaml
+++ b/sql_exporter.advisories.yaml
@@ -58,6 +58,16 @@ advisories:
         data:
           fixed-version: 0.17.0-r2
 
+  - id: CGA-mx79-7f3w-87v2
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:33:28Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'sql_exporter version 0.17.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-q892-385q-9p8q
     aliases:
       - CVE-2024-45337

--- a/src-fingerprint.advisories.yaml
+++ b/src-fingerprint.advisories.yaml
@@ -239,6 +239,21 @@ advisories:
         data:
           fixed-version: 0.19.0-r10
 
+  - id: CGA-gq5v-qv76-7jhw
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:23:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'src-fingerprint version 0.19.0-r23: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+      - timestamp: 2025-03-04T18:31:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'src-fingerprint version 0.19.0-r23: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-h5v7-3fjv-j24x
     aliases:
       - CVE-2025-22866

--- a/src.advisories.yaml
+++ b/src.advisories.yaml
@@ -108,6 +108,21 @@ advisories:
         data:
           fixed-version: 5.3.0-r2
 
+  - id: CGA-63hm-x2cq-292c
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:31:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'src version 6.1.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+      - timestamp: 2025-03-04T19:29:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'src version 6.1.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-6cfr-hjvp-rrw7
     aliases:
       - CVE-2024-24791

--- a/swagger.advisories.yaml
+++ b/swagger.advisories.yaml
@@ -130,6 +130,21 @@ advisories:
         data:
           fixed-version: 0.31.0-r2
 
+  - id: CGA-rc8w-wmcc-82mm
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:32:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'swagger version 0.31.0-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+      - timestamp: 2025-03-04T19:29:33Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'swagger version 0.31.0-r6: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-w359-g9jm-pvf3
     aliases:
       - CVE-2024-34156

--- a/tailscale.advisories.yaml
+++ b/tailscale.advisories.yaml
@@ -162,6 +162,21 @@ advisories:
         data:
           fixed-version: 1.60.1-r1
 
+  - id: CGA-pp4c-6wrr-ffp9
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:32:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'tailscale version 1.80.2-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+      - timestamp: 2025-03-04T19:30:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'tailscale version 1.80.2-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-qff3-cvv8-7mgj
     aliases:
       - CVE-2024-34158

--- a/teleport.advisories.yaml
+++ b/teleport.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: teleport
 
 advisories:
+  - id: CGA-2pwf-p6xm-672f
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:36:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'teleport version 17.3.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-35qq-v4x7-g8hr
     aliases:
       - CVE-2024-35255

--- a/tempo.advisories.yaml
+++ b/tempo.advisories.yaml
@@ -96,6 +96,21 @@ advisories:
         data:
           fixed-version: 2.4.1-r3
 
+  - id: CGA-9fpw-37m5-4743
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T18:32:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'tempo version 2.7.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+      - timestamp: 2025-03-04T19:29:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'tempo version 2.7.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-9h9r-pfxh-82vp
     aliases:
       - GHSA-87m9-rv8p-rgmg

--- a/temporal-server.advisories.yaml
+++ b/temporal-server.advisories.yaml
@@ -301,6 +301,16 @@ advisories:
         data:
           fixed-version: 1.22.6-r1
 
+  - id: CGA-xfxg-jc5v-grp6
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:30:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'temporal-server version 1.27.1-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-xfxm-r665-9p7r
     aliases:
       - CVE-2024-24783

--- a/temporal-ui-server.advisories.yaml
+++ b/temporal-ui-server.advisories.yaml
@@ -171,6 +171,16 @@ advisories:
         data:
           fixed-version: 2.24.0-r1
 
+  - id: CGA-mq99-9q3w-jrhj
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:31:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'temporal-ui-server version 2.36.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-pc4w-4863-9p9g
     aliases:
       - CVE-2024-45341

--- a/temporal.advisories.yaml
+++ b/temporal.advisories.yaml
@@ -48,6 +48,16 @@ advisories:
         data:
           fixed-version: 1.0.0-r1
 
+  - id: CGA-28xv-vx7q-pwgv
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:31:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'temporal version 1.3.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-295w-xp56-hv98
     aliases:
       - CVE-2024-34158

--- a/terraform-docs.advisories.yaml
+++ b/terraform-docs.advisories.yaml
@@ -101,6 +101,16 @@ advisories:
         data:
           fixed-version: 0.19.0-r2
 
+  - id: CGA-7339-7gqr-38h8
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:30:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'terraform-docs version 0.19.0-r4: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-82g5-h23x-33p6
     aliases:
       - CVE-2024-45337

--- a/terraform-provider-google.advisories.yaml
+++ b/terraform-provider-google.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: terraform-provider-google
 
 advisories:
+  - id: CGA-2f8w-rqjf-4525
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:32:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'terraform-provider-google version 6.24.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-3j7v-jxcq-4f62
     aliases:
       - CVE-2024-45338

--- a/terraform.advisories.yaml
+++ b/terraform.advisories.yaml
@@ -251,6 +251,16 @@ advisories:
         data:
           fixed-version: 1.5.7-r6
 
+  - id: CGA-fqpm-6522-2923
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:32:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'terraform version 0.19.0-r4: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-fvp6-ppp5-92v3
     aliases:
       - CVE-2023-48795

--- a/thanos.advisories.yaml
+++ b/thanos.advisories.yaml
@@ -174,6 +174,16 @@ advisories:
         data:
           fixed-version: 0.37.2-r1
 
+  - id: CGA-963v-h8j3-pvg2
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:35:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'thanos version 0.37.2-r4: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-fxmj-5xgj-gvjh
     aliases:
       - CVE-2019-3826

--- a/trust-manager.advisories.yaml
+++ b/trust-manager.advisories.yaml
@@ -46,6 +46,16 @@ advisories:
         data:
           fixed-version: 0.15.0-r1
 
+  - id: CGA-54qr-c8pq-94wq
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:35:45Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'trust-manager version 0.16.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-5gjx-8hcr-v9r6
     aliases:
       - CVE-2024-24790

--- a/undock.advisories.yaml
+++ b/undock.advisories.yaml
@@ -36,6 +36,16 @@ advisories:
         data:
           fixed-version: 0.9.0-r1
 
+  - id: CGA-7558-54j2-v7xq
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:32:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'undock version 0.9.0-r3: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-9447-8rx3-2v2g
     aliases:
       - CVE-2024-45337

--- a/vault-k8s.advisories.yaml
+++ b/vault-k8s.advisories.yaml
@@ -24,6 +24,16 @@ advisories:
         data:
           fixed-version: 1.4.1-r2
 
+  - id: CGA-3w8v-jv9x-4qrf
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:33:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'vault-k8s version 1.6.2-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-4g3v-pf2c-wf84
     aliases:
       - CVE-2024-34156

--- a/vcluster.advisories.yaml
+++ b/vcluster.advisories.yaml
@@ -217,3 +217,13 @@ advisories:
         type: fixed
         data:
           fixed-version: 0.19.6-r1
+
+  - id: CGA-xghr-6x7v-jh42
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:36:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'vcluster version 0.23.0-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'

--- a/velero-plugin-for-microsoft-azure.advisories.yaml
+++ b/velero-plugin-for-microsoft-azure.advisories.yaml
@@ -73,6 +73,16 @@ advisories:
         data:
           fixed-version: 1.11.1-r1
 
+  - id: CGA-hr58-7356-ph7j
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:35:14Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'velero-plugin-for-microsoft-azure version 1.11.1-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-jrqw-w6f3-w3v5
     aliases:
       - CVE-2024-45336

--- a/velero.advisories.yaml
+++ b/velero.advisories.yaml
@@ -26,6 +26,16 @@ advisories:
         data:
           fixed-version: 1.15.0-r2
 
+  - id: CGA-457f-4h56-jvwc
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:34:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'velero version 1.15.2-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-4v35-ffr9-x6vm
     aliases:
       - CVE-2024-45336

--- a/vendir.advisories.yaml
+++ b/vendir.advisories.yaml
@@ -26,6 +26,16 @@ advisories:
         data:
           fixed-version: 0.43.0-r2
 
+  - id: CGA-88pr-cjmr-rw5q
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:32:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'vendir version 0.43.0-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-gvhh-wh5x-whg5
     aliases:
       - CVE-2024-45341

--- a/weaviate.advisories.yaml
+++ b/weaviate.advisories.yaml
@@ -270,6 +270,16 @@ advisories:
         data:
           fixed-version: 1.28.4-r1
 
+  - id: CGA-vg99-hxvx-fc65
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:34:40Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'weaviate version 1.29.0-r1: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-vx3g-m66f-4mm3
     aliases:
       - CVE-2023-48795

--- a/wgcf.advisories.yaml
+++ b/wgcf.advisories.yaml
@@ -36,6 +36,16 @@ advisories:
         data:
           fixed-version: 2.2.22-r2
 
+  - id: CGA-6fx4-66rv-2j2q
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:34:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'wgcf version 2.2.25-r0: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-6qxg-xwv8-m858
     aliases:
       - CVE-2024-24790

--- a/wireguard-go.advisories.yaml
+++ b/wireguard-go.advisories.yaml
@@ -194,6 +194,16 @@ advisories:
         data:
           fixed-version: 0.0.20230223-r19
 
+  - id: CGA-g4rq-r3q7-5f38
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:33:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'wireguard-go version 0.0.20230223-r20: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-hrv4-73j5-p2vm
     aliases:
       - CVE-2024-24788

--- a/x509-certificate-exporter.advisories.yaml
+++ b/x509-certificate-exporter.advisories.yaml
@@ -24,6 +24,16 @@ advisories:
         data:
           fixed-version: 3.18.1-r1
 
+  - id: CGA-8rx4-rjqr-r27h
+    aliases:
+      - CVE-2025-22869
+    events:
+      - timestamp: 2025-03-04T19:34:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'x509-certificate-exporter version 3.18.1-r2: using govulncheck and identifying the symbols present in the package binary we determined that either the symbol path did not match the golang.org/x/crypto path OR govulncheck determined the binary was not vulnerable to this CVE. Marking as False Positive Determination'
+
   - id: CGA-98g3-7xqq-w3f7
     aliases:
       - CVE-2024-45341


### PR DESCRIPTION
For binaries in packages with symbols where the symbol paths do not match golang.org/x/crypto/ssh and where govulncheck reports no vulnerabilities I have created false positive determinations as we are confident that these packages are not vulnerable to CVE-2025-22869 [1][2]

[1] https://pkg.go.dev/vuln/GO-2025-3487
[2] https://www.cve.org/CVERecord?id=CVE-2025-22869

Signed-off-by: philroche <phil.roche@chainguard.dev>
