### PR TITLE
octo-sts: add policy for the new service

### DIFF
--- a/.github/chainguard/lifecycle-cve-eol-fix-not-planned.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-eol-fix-not-planned.sts.yaml
@@ -1,8 +1,8 @@
 issuer: https://accounts.google.com
 
 # staging-images: cve-eol-sa@staging-images-183e.iam.gserviceaccount.com (105584575053184700385)
-# prod-images: cve-eol-sa@prod-images-c6e5.iam.gserviceaccount.com ()
-subject_pattern: "(105584575053184700385)"
+# prod-images: cve-eol-sa@prod-images-c6e5.iam.gserviceaccount.com (117413894424617998846)
+subject_pattern: "(105584575053184700385|117413894424617998846)"
 
 permissions:
   pull_requests: write

--- a/.github/chainguard/lifecycle-cve-eol-fix-not-planned.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-eol-fix-not-planned.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://accounts.google.com
+
+# staging-images: cve-eol-sa@staging-images-183e.iam.gserviceaccount.com (105584575053184700385)
+# prod-images: cve-eol-sa@prod-images-c6e5.iam.gserviceaccount.com ()
+subject_pattern: "(105584575053184700385)"
+
+permissions:
+  pull_requests: write
+  contents: write
+  workflows: write


### PR DESCRIPTION
This service creates fix-not-planned advisory events for primary packages(python, ruby, nodejs) under EOL Grace Period support.