### PR TITLE
Multiple package CVE-2024-36620 advisories

### DIFF
--- a/amazon-cloudwatch-agent-operator.advisories.yaml
+++ b/amazon-cloudwatch-agent-operator.advisories.yaml
@@ -84,6 +84,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/manager
             scanner: grype
+      - timestamp: 2025-03-06T01:19:25Z
+        type: pending-upstream-fix
+        data:
+          note: 'amazon-cloudwatch-agent-operator 2.1.0 uses Docker 25.0.6, as seen here: https://github.com/aws/amazon-cloudwatch-agent-operator/blob/v2.1.0/go.mod#L75 The fixed version to remediate this CVE is 26.1.0; however, breaking changes between these major versions require upstream maintainers to implement compatibility.'
 
   - id: CGA-v2mf-56pw-3fx4
     aliases:

--- a/gitlab-runner-17.8.advisories.yaml
+++ b/gitlab-runner-17.8.advisories.yaml
@@ -104,3 +104,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gitlab-runner-helper
             scanner: grype
+      - timestamp: 2025-03-06T00:58:34Z
+        type: pending-upstream-fix
+        data:
+          note: 'gitlab-runner 17.8.3 uses Docker 25.0.6, as seen here: https://gitlab.com/gitlab-org/gitlab-runner/-/blob/c4cbe9dd7840ba5fdbd4cb08252983544826a485/go.mod#L31 The fixed version to remediate this CVE is 26.1.0; however, breaking changes between these major versions require upstream maintainers to implement compatibility.'

--- a/gitlab-runner-17.9.advisories.yaml
+++ b/gitlab-runner-17.9.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gitlab-runner-helper
             scanner: grype
+      - timestamp: 2025-03-06T01:21:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'gitlab-runner 17.9.0 uses Docker 25.0.6, as seen here: https://gitlab.com/gitlab-org/gitlab-runner/-/blob/v17.9.0/go.mod?ref_type=tags#L31 The fixed version to remediate this CVE is 26.1.0; however, breaking changes between these major versions require upstream maintainers to implement compatibility.'
 
   - id: CGA-96qp-63gq-cqfx
     aliases:

--- a/k3s.advisories.yaml
+++ b/k3s.advisories.yaml
@@ -651,6 +651,10 @@ advisories:
             componentType: go-module
             componentLocation: /bin/k3s
             scanner: grype
+      - timestamp: 2025-03-06T01:10:07Z
+        type: pending-upstream-fix
+        data:
+          note: 'k3s 1.32.2.1 uses Docker 25.0.6, as seen here: https://github.com/k3s-io/k3s/blame/v1.32.2%2Bk3s1/go.mod#L16 The fixed version to remediate this CVE is 26.1.0; however, breaking changes between these major versions require upstream maintainers to implement compatibility.'
 
   - id: CGA-xvc2-4hwx-xxv9
     aliases:

--- a/promxy.advisories.yaml
+++ b/promxy.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/promxy
             scanner: grype
+      - timestamp: 2025-03-06T01:27:26Z
+        type: pending-upstream-fix
+        data:
+          note: 'promxy 0.0.92 uses Docker 25.0.6, as seen here: https://github.com/jacksontj/promxy/blob/61b08be9f603c54155808ec1642e632e0b5c6a37/go.mod#L56 The fixed version to remediate this CVE is 26.1.0; however, breaking changes between these major versions require upstream maintainers to implement compatibility.'
 
   - id: CGA-8pf2-3qf8-qxv9
     aliases:


### PR DESCRIPTION
The below packages use Docker 25.0.6, The fixed version to remediate this CVE is 26.1.0; however, breaking changes between these major versions require upstream maintainers to implement compatibility.