### PR TITLE
prism/GHSA-h5c3-5r3r-rr8q/GHSA-rmvr-2pp2-xj38/GHSA-xx4v-prfh-6cgc advisory updates

### DIFF
--- a/prism.advisories.yaml
+++ b/prism.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: prism
 
 advisories:
+  - id: CGA-2wx9-rvv6-j8wx
+    aliases:
+      - CVE-2025-25290
+      - GHSA-rmvr-2pp2-xj38
+    events:
+      - timestamp: 2025-03-06T06:37:00Z
+        type: pending-upstream-fix
+        data:
+          note: 'octokit/request @ 6.2.8 is a direct dependency of prism, the fix versions of this dependency are several major versions higher (8.4.1or v9.2.1) and will require upstream maintainers to implement. '
+
   - id: CGA-59f4-cwwh-mh74
     aliases:
       - CVE-2025-1302
@@ -21,6 +31,16 @@ advisories:
             componentType: npm
             componentLocation: /usr/src/prism/node_modules/jsonpath-plus/package.json
             scanner: grype
+
+  - id: CGA-5cxq-p825-8rhg
+    aliases:
+      - CVE-2025-25289
+      - GHSA-xx4v-prfh-6cgc
+    events:
+      - timestamp: 2025-03-06T06:37:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'octokit/request-error@3.0.3 direct dependency of prism, the fix versions of this dependency are several major versions higher (v5.1.1 or v6.1.7) and will require upstream maintainers to implement. '
 
   - id: CGA-6g95-fwpp-33mh
     aliases:
@@ -43,3 +63,13 @@ advisories:
         type: fixed
         data:
           fixed-version: 5.11.2-r1
+
+  - id: CGA-mg8j-rfrx-fqh7
+    aliases:
+      - CVE-2025-25288
+      - GHSA-h5c3-5r3r-rr8q
+    events:
+      - timestamp: 2025-03-06T06:36:32Z
+        type: pending-upstream-fix
+        data:
+          note: 'octokit/plugin-paginate-rest @ 6.1.2 is a direct dependency of prism, the fix versions of this dependency are several major versions higher (v9.2.2 or v11.4.1) and will require upstream maintainers to implement. '


### PR DESCRIPTION
GHSA-h5c3-5r3r-rr8q
octokit/plugin-paginate-rest @ 6.1.2 is a direct dependency of prism, the fix versions of this dependency are several major versions higher (v9.2.2 or v11.4.1) and will require upstream maintainers to implement. 

GHSA-rmvr-2pp2-xj38
octokit/request @ 6.2.8 is a direct dependency of prism, the fix versions of this dependency are several major versions higher (8.4.1or v9.2.1) and will require upstream maintainers to implement. 

GHSA-xx4v-prfh-6cgc
octokit/request-error@3.0.3 direct dependency of prism, the fix versions of this dependency are several major versions higher (v5.1.1 or v6.1.7) and will require upstream maintainers to implement. 