### PR TITLE
fix(argo-cd-2.10.advisories.yaml): Revert "Adding detection events for argo-cd-2.10 (#13637)"

### DIFF
--- a/argo-cd-2.10.advisories.yaml
+++ b/argo-cd-2.10.advisories.yaml
@@ -4,16 +4,6 @@ package:
   name: argo-cd-2.10
 
 advisories:
-  - id: CGA-266g-996x-r5hq
-    aliases:
-      - CVE-2024-21652
-      - GHSA-x32m-mvfj-52xv
-    events:
-      - timestamp: 2024-03-19T10:19:27Z
-        type: fixed
-        data:
-          fixed-version: 2.10.4-r0
-
   - id: CGA-2j44-w39x-mfj4
     aliases:
       - CVE-2023-45288
@@ -36,91 +26,15 @@ advisories:
         data:
           fixed-version: 2.10.7-r1
 
-  - id: CGA-33gc-vj8r-9xwx
+  - id: CGA-266g-996x-r5hq
     aliases:
-      - CVE-2024-28180
-      - GHSA-c5q2-7r4c-mv6g
+      - CVE-2024-21652
+      - GHSA-x32m-mvfj-52xv
     events:
-      - timestamp: 2024-03-08T07:04:01Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 01bb87cfc9651e9f
-            componentName: github.com/go-jose/go-jose/v3
-            componentVersion: v3.0.1
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-      - timestamp: 2024-03-08T22:43:36Z
+      - timestamp: 2024-03-19T10:19:27Z
         type: fixed
         data:
-          fixed-version: 2.10.2-r2
-
-  - id: CGA-3j7f-7v4g-h2v9
-    aliases:
-      - CVE-2024-31989
-      - GHSA-9766-5277-j5hr
-    events:
-      - timestamp: 2024-05-22T07:06:53Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 8f20ce86d68597f2
-            componentName: github.com/argoproj/argo-cd/v2
-            componentVersion: v2.10.9
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-4gjm-8gxx-cm3j
-    aliases:
-      - CVE-2024-41666
-      - GHSA-v8wx-v5jq-qhhw
-    events:
-      - timestamp: 2025-03-04T17:18:33Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 0f0708c265d45181
-            componentName: github.com/argoproj/argo-cd/v2
-            componentVersion: v2.10.9
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-553q-qqqv-jg6q
-    aliases:
-      - CVE-2025-21613
-      - GHSA-v725-9546-7q7m
-    events:
-      - timestamp: 2025-03-04T17:18:26Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 26ea10fd4501c60d
-            componentName: github.com/go-git/go-git/v5
-            componentVersion: v5.11.0
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-5875-cfhm-6fxh
-    aliases:
-      - CVE-2024-31990
-      - GHSA-2gvw-w6fj-7m3c
-    events:
-      - timestamp: 2024-04-16T07:05:25Z
-        type: fixed
-        data:
-          fixed-version: 2.10.7-r0
+          fixed-version: 2.10.4-r0
 
   - id: CGA-5c7f-x484-w4h7
     aliases:
@@ -144,426 +58,27 @@ advisories:
         data:
           fixed-version: 2.10.3-r1
 
-  - id: CGA-5cxj-7452-xqw6
+  - id: CGA-33gc-vj8r-9xwx
     aliases:
-      - CVE-2024-51744
-      - GHSA-29wx-vh33-7x7r
+      - CVE-2024-28180
+      - GHSA-c5q2-7r4c-mv6g
     events:
-      - timestamp: 2025-03-04T17:17:29Z
+      - timestamp: 2024-03-08T07:04:01Z
         type: detection
         data:
           type: scan/v1
           data:
             subpackageName: argo-cd-2.10
-            componentID: 03e15b6f67928468
-            componentName: github.com/golang-jwt/jwt/v4
-            componentVersion: v4.5.0
+            componentID: 01bb87cfc9651e9f
+            componentName: github.com/go-jose/go-jose/v3
+            componentVersion: v3.0.1
             componentType: go-module
             componentLocation: /usr/bin/argocd
             scanner: grype
-
-  - id: CGA-5ggg-3mq8-5pfr
-    aliases:
-      - CVE-2024-32476
-      - GHSA-9m6p-x4h2-6frq
-    events:
-      - timestamp: 2024-04-27T09:02:19Z
+      - timestamp: 2024-03-08T22:43:36Z
         type: fixed
         data:
-          fixed-version: 2.10.8-r0
-
-  - id: CGA-6g53-6p5p-rf2v
-    aliases:
-      - CVE-2024-34156
-      - GHSA-crqm-pwhx-j97f
-    events:
-      - timestamp: 2025-03-04T17:19:15Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 4aa389658578d3f7
-            componentName: stdlib
-            componentVersion: go1.22.3
-            componentType: go-module
-            componentLocation: /usr/local/bin/argocd
-            scanner: grype
-
-  - id: CGA-6mvx-gw75-98mr
-    aliases:
-      - GHSA-274v-mgcv-cm8j
-    events:
-      - timestamp: 2025-03-04T17:17:21Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 06bb45a842d87143
-            componentName: github.com/argoproj/gitops-engine
-            componentVersion: v0.7.1-0.20240122213038-792124280fcc
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-6vcg-59pq-fgm6
-    aliases:
-      - CVE-2024-35255
-      - GHSA-m5vv-6r4h-3vj9
-    events:
-      - timestamp: 2025-03-04T17:18:06Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 927753d7170f6e98
-            componentName: github.com/Azure/azure-sdk-for-go/sdk/azidentity
-            componentVersion: v1.1.0
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-7rp9-pw33-2m3x
-    aliases:
-      - CVE-2024-45337
-      - GHSA-v778-237x-gjrc
-    events:
-      - timestamp: 2025-03-04T17:17:04Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 3a14de43afeb8c87
-            componentName: golang.org/x/crypto
-            componentVersion: v0.21.0
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-7wcq-xgf6-h47q
-    aliases:
-      - CVE-2025-0426
-      - GHSA-jgfp-53c3-624w
-    events:
-      - timestamp: 2025-03-04T17:17:54Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 0ddf73310db12781
-            componentName: k8s.io/kubernetes
-            componentVersion: v1.26.11
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-c23w-r5gh-769c
-    aliases:
-      - CVE-2024-45338
-      - GHSA-w32m-9786-jp63
-    events:
-      - timestamp: 2025-03-04T17:17:07Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 27ace6300271d854
-            componentName: golang.org/x/net
-            componentVersion: v0.23.0
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-h3j3-6j6x-qx9p
-    aliases:
-      - CVE-2024-34155
-      - GHSA-8xfx-rj4p-23jm
-    events:
-      - timestamp: 2025-03-04T17:19:06Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 4aa389658578d3f7
-            componentName: stdlib
-            componentVersion: go1.22.3
-            componentType: go-module
-            componentLocation: /usr/local/bin/argocd
-            scanner: grype
-
-  - id: CGA-j4pw-m647-5hrp
-    aliases:
-      - CVE-2024-24791
-      - GHSA-hw49-2p59-3mhj
-    events:
-      - timestamp: 2025-03-04T17:18:57Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 4aa389658578d3f7
-            componentName: stdlib
-            componentVersion: go1.22.3
-            componentType: go-module
-            componentLocation: /usr/local/bin/argocd
-            scanner: grype
-
-  - id: CGA-j4vp-7w5c-jqrq
-    aliases:
-      - CVE-2025-23216
-      - GHSA-47g2-qmh2-749v
-    events:
-      - timestamp: 2025-03-04T17:17:34Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 0f0708c265d45181
-            componentName: github.com/argoproj/argo-cd/v2
-            componentVersion: v2.10.9
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-j5rx-wmmf-pg5j
-    aliases:
-      - CVE-2025-22866
-      - GHSA-3whm-j4xm-rv8x
-    events:
-      - timestamp: 2025-03-04T17:19:54Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 4aa389658578d3f7
-            componentName: stdlib
-            componentVersion: go1.22.3
-            componentType: go-module
-            componentLocation: /usr/local/bin/argocd
-            scanner: grype
-
-  - id: CGA-jppp-h9xx-ccmq
-    aliases:
-      - CVE-2024-0793
-      - GHSA-h7wq-jj8r-qm7p
-    events:
-      - timestamp: 2025-03-04T17:17:48Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 0ddf73310db12781
-            componentName: k8s.io/kubernetes
-            componentVersion: v1.26.11
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-jvqw-92xw-c48r
-    aliases:
-      - CVE-2024-5321
-      - GHSA-82m2-cv7p-4m75
-    events:
-      - timestamp: 2025-03-04T17:17:38Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 0ddf73310db12781
-            componentName: k8s.io/kubernetes
-            componentVersion: v1.26.11
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-jx62-6jp5-cjfw
-    aliases:
-      - CVE-2025-22868
-    events:
-      - timestamp: 2025-03-04T17:17:14Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 9f7b501375b4294b
-            componentName: golang.org/x/oauth2
-            componentVersion: v0.11.0
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-mcq2-w5cv-c2rc
-    aliases:
-      - CVE-2024-40634
-      - GHSA-jmvp-698c-4x3w
-    events:
-      - timestamp: 2025-03-04T17:18:00Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 0f0708c265d45181
-            componentName: github.com/argoproj/argo-cd/v2
-            componentVersion: v2.10.9
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-mxrq-rw4f-7h3j
-    aliases:
-      - CVE-2024-24790
-      - GHSA-49gw-vxvf-fc2g
-    events:
-      - timestamp: 2025-03-04T17:18:49Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 4aa389658578d3f7
-            componentName: stdlib
-            componentVersion: go1.22.3
-            componentType: go-module
-            componentLocation: /usr/local/bin/argocd
-            scanner: grype
-
-  - id: CGA-p5m6-36v2-wpj6
-    aliases:
-      - CVE-2024-34158
-      - GHSA-j7vj-rw65-4v26
-    events:
-      - timestamp: 2025-03-04T17:19:24Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 4aa389658578d3f7
-            componentName: stdlib
-            componentVersion: go1.22.3
-            componentType: go-module
-            componentLocation: /usr/local/bin/argocd
-            scanner: grype
-
-  - id: CGA-p6v8-4c6q-p3pq
-    aliases:
-      - CVE-2024-6104
-      - GHSA-v6v8-xj6m-xwqh
-    events:
-      - timestamp: 2025-03-04T17:17:10Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 7fe1f9b8de8d2e79
-            componentName: github.com/hashicorp/go-retryablehttp
-            componentVersion: v0.7.4
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-pv5w-5pfx-33gp
-    aliases:
-      - CVE-2024-45341
-      - GHSA-3f6r-qh9c-x6mm
-    events:
-      - timestamp: 2025-03-04T17:19:44Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 4aa389658578d3f7
-            componentName: stdlib
-            componentVersion: go1.22.3
-            componentType: go-module
-            componentLocation: /usr/local/bin/argocd
-            scanner: grype
-
-  - id: CGA-pvqx-vx7v-rrx8
-    aliases:
-      - CVE-2024-10220
-      - GHSA-27wf-5967-98gx
-    events:
-      - timestamp: 2025-03-04T17:17:25Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 0ddf73310db12781
-            componentName: k8s.io/kubernetes
-            componentVersion: v1.26.11
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
-
-  - id: CGA-q3cc-mh8v-chgw
-    aliases:
-      - CVE-2024-24789
-      - GHSA-236w-p7wf-5ph8
-    events:
-      - timestamp: 2025-03-04T17:18:41Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 4aa389658578d3f7
-            componentName: stdlib
-            componentVersion: go1.22.3
-            componentType: go-module
-            componentLocation: /usr/local/bin/argocd
-            scanner: grype
-
-  - id: CGA-qvrx-45gc-55jm
-    aliases:
-      - CVE-2024-45336
-      - GHSA-7wrw-r4p8-38rx
-    events:
-      - timestamp: 2025-03-04T17:19:34Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 4aa389658578d3f7
-            componentName: stdlib
-            componentVersion: go1.22.3
-            componentType: go-module
-            componentLocation: /usr/local/bin/argocd
-            scanner: grype
-
-  - id: CGA-qw6r-6jvc-xcpw
-    aliases:
-      - GHSA-mh55-gqvf-xfwm
-    events:
-      - timestamp: 2025-03-04T17:18:12Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: a0b83aa0c4306dea
-            componentName: github.com/rs/cors
-            componentVersion: v1.9.0
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
+          fixed-version: 2.10.2-r2
 
   - id: CGA-vj6q-q3x6-mqrw
     aliases:
@@ -587,55 +102,40 @@ advisories:
         data:
           note: Any upgrade on the Kubernetes dependencies causes conflicts due to a strict dependency on github.com/argoproj/gitops-engine which supports Kubernetes v1.23 while the non-vulnerable code is on Kubernetes v1.27.13.
 
-  - id: CGA-wp7q-97gq-qchv
+  - id: CGA-3j7f-7v4g-h2v9
     aliases:
-      - CVE-2025-22869
+      - CVE-2024-31989
+      - GHSA-9766-5277-j5hr
     events:
-      - timestamp: 2025-03-04T17:17:17Z
+      - timestamp: 2024-05-22T07:06:53Z
         type: detection
         data:
           type: scan/v1
           data:
             subpackageName: argo-cd-2.10
-            componentID: 3a14de43afeb8c87
-            componentName: golang.org/x/crypto
-            componentVersion: v0.21.0
+            componentID: 8f20ce86d68597f2
+            componentName: github.com/argoproj/argo-cd/v2
+            componentVersion: v2.10.9
             componentType: go-module
             componentLocation: /usr/bin/argocd
             scanner: grype
 
-  - id: CGA-x23g-ghfj-9jmq
+  - id: CGA-5875-cfhm-6fxh
     aliases:
-      - CVE-2025-21614
-      - GHSA-r9px-m959-cxf4
+      - CVE-2024-31990
+      - GHSA-2gvw-w6fj-7m3c
     events:
-      - timestamp: 2025-03-04T17:18:19Z
-        type: detection
+      - timestamp: 2024-04-16T07:05:25Z
+        type: fixed
         data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 26ea10fd4501c60d
-            componentName: github.com/go-git/go-git/v5
-            componentVersion: v5.11.0
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
+          fixed-version: 2.10.7-r0
 
-  - id: CGA-x42r-8g48-w7pv
+  - id: CGA-5ggg-3mq8-5pfr
     aliases:
-      - CVE-2025-27144
-      - GHSA-c6gw-w398-hv78
+      - CVE-2024-32476
+      - GHSA-9m6p-x4h2-6frq
     events:
-      - timestamp: 2025-03-04T17:17:43Z
-        type: detection
+      - timestamp: 2024-04-27T09:02:19Z
+        type: fixed
         data:
-          type: scan/v1
-          data:
-            subpackageName: argo-cd-2.10
-            componentID: 41f9210caddd1f16
-            componentName: github.com/go-jose/go-jose/v3
-            componentVersion: v3.0.3
-            componentType: go-module
-            componentLocation: /usr/bin/argocd
-            scanner: grype
+          fixed-version: 2.10.8-r0


### PR DESCRIPTION
This reverts commit 32db55b1f56d241e5ac2d5c364ad5ba9523965e3.

These argo-cd-2.10 APKs in wolfi-dev/os were scanned in error and should not have resulted in new detection events.

argo-cd-2.10 is now maintained in entperise-packages where these CVEs have been remediated.

Signed-off-by: philroche <phil.roche@chainguard.dev>
