### PR TITLE
logstash-8/GHSA-22h5-pq3x-2gf2/GHSA-mhwm-jh88-3gjf/GHSA-gh9q-2xrm-x6qv advisory updates

### DIFF
--- a/logstash-8.advisories.yaml
+++ b/logstash-8.advisories.yaml
@@ -170,6 +170,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
             scanner: grype
+      - timestamp: 2025-03-07T20:42:49Z
+        type: pending-upstream-fix
+        data:
+          note: The cgi gem at version 0.3.6 is included as a default gem in JRuby’s standard library. Because it’s part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of cgi.
 
   - id: CGA-7g8h-6fqh-f235
     aliases:
@@ -232,6 +236,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/uri-0.12.2.gemspec
             scanner: grype
+      - timestamp: 2025-03-07T20:43:30Z
+        type: pending-upstream-fix
+        data:
+          note: The uri gem at version 0.12.2 is included as a default gem in JRuby’s standard library. Because it’s part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of cgi.
 
   - id: CGA-937h-9qvw-8r89
     aliases:
@@ -344,6 +352,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
             scanner: grype
+      - timestamp: 2025-03-07T20:41:14Z
+        type: pending-upstream-fix
+        data:
+          note: The cgi gem at version 0.3.6 is included as a default gem in JRuby’s standard library. Because it’s part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of cgi.
 
   - id: CGA-rppc-58w9-wv7w
     aliases:


### PR DESCRIPTION
The cgi and uri gems are part of JRuby’s “default gems,” which means it ships alongside the JRuby standard library and can’t be upgraded independently in our Gemfile. Historically, Ruby’s stdlib updates required entirely new Ruby releases—standard gems were strictly bundled with the Ruby version itself. Over time, they’ve begun moving these libraries into “default gems” or “bundled gems,” which allows limited upgrading without a full Ruby bump. However, default gems are still pinned inside Ruby/JRuby and can’t just be removed or replaced. It’s confusing because you might see different versions of the same library depending on how it’s declared in the Gemfile and how JRuby bundles it. Ultimately, fixing security issues in default gems requires a new JRuby patch release, because changing the gem version alone would otherwise break the assumption that “JRuby X.Y.Z” always has the same stdlib codebase.