### PR TITLE
grafana-agent-operator: CVE-2025-22868 and CVE-2025-22869

### DIFF
--- a/grafana-agent-operator.advisories.yaml
+++ b/grafana-agent-operator.advisories.yaml
@@ -30,6 +30,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/grafana-agent-operator
             scanner: grype
+      - timestamp: 2025-03-09T10:53:31Z
+        type: pending-upstream-fix
+        data:
+          note: 'Bumping golang.org/x/crypto >= v0.34.0 requires go >= 1.23.0 but due to known-issue on upstream, we can''t use go >= 1.23: https://github.com/grafana/agent/issues/6972'
 
   - id: CGA-4455-7fg4-qmw9
     aliases:
@@ -239,6 +243,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/grafana-agent-operator
             scanner: grype
+      - timestamp: 2025-03-09T10:50:31Z
+        type: pending-upstream-fix
+        data:
+          note: 'Bumping golang.org/x/oauth2 >= v0.27.0 requires go >= 1.23.0 but due to known-issue on upstream, we can''t use go >= 1.23: https://github.com/grafana/agent/issues/6972'
 
   - id: CGA-vv8p-38h9-qp26
     aliases:


### PR DESCRIPTION
* Closes: https://github.com/wolfi-dev/os/pull/45408
* Closes: https://github.com/wolfi-dev/os/pull/45407