### PR TITLE
dotnet-9 FPs

### DIFF
--- a/dotnet-9.advisories.yaml
+++ b/dotnet-9.advisories.yaml
@@ -25,6 +25,10 @@ advisories:
         type: fixed
         data:
           fixed-version: 9.0.101-r0
+      - timestamp: 2025-03-11T06:49:20Z
+        type: fixed
+        data:
+          fixed-version: 9.0.2-r0
 
   - id: CGA-x92v-q46w-q69x
     aliases:
@@ -47,3 +51,7 @@ advisories:
         type: fixed
         data:
           fixed-version: 9.0.101-r0
+      - timestamp: 2025-03-11T06:50:20Z
+        type: fixed
+        data:
+          fixed-version: 9.0.2-r0


### PR DESCRIPTION
There was a problem here with browsers regarding semantic versioning because browsers assumed that 9.0.101 came before 9.0.2, it should be the other way around.

So @pdeslaur suggested that it'd great to create an advisories instead making changes at package level like: https://github.com/wolfi-dev/os/pull/44704#issuecomment-2702205477

cc @EyeCantCU 