### PR TITLE
Added pending-upstream-fix advisory event for qdrant GHSA-2gh3-rmm4-6rq5

### DIFF
--- a/qdrant.advisories.yaml
+++ b/qdrant.advisories.yaml
@@ -84,6 +84,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/qdrant
             scanner: grype
+      - timestamp: 2025-03-10T19:40:09Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            While there is a fix for rust-protobuf v3, v2 claims "only most critical bugfixes will be applied to 2.x version, otherwise it
+            won't be maintained". It remains to be seen if the fix will be backported to the v2 line, or if ztunnel's maintainers
+            will update to v3. Either way, Chainguard is unable to mitigate this CVE.
 
   - id: CGA-fvv9-9gwx-2fj7
     aliases:


### PR DESCRIPTION
https://github.com/chainguard-dev/CVE-Dashboard/issues/20034