### PR TITLE
add note about the CVE-2024-6763 to apache-tika-3.1

### DIFF
--- a/apache-tika-3.1.advisories.yaml
+++ b/apache-tika-3.1.advisories.yaml
@@ -37,3 +37,8 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tika-server-standard-3.1.0.jar
             scanner: grype
+      - timestamp: 2025-03-11T17:06:52Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            "The upstream project has to fix the issue since if we attempt to bump the jetty-http version from '11.0.24' to the fixed version '12.0.12' the project fails at compilation due to error 'Exception in thread "main" java.lang.NoSuchMethodError: 'int org.eclipse.jetty.util.URIUtil.getDefaultPortForScheme(java.lang.String)'"


### PR DESCRIPTION
We tried to fix the CVE but realized it broke our application, so we removed the patch to fix the CVE [here](https://github.com/wolfi-dev/os/pull/44523). This is therefore a supplementary PR to fill an advisory related to the CVE in question.