### PR TITLE
Added pending-upstream-fix advisory for pgcat GHSA-4p46-pwfr-66x6

### DIFF
--- a/pgcat.advisories.yaml
+++ b/pgcat.advisories.yaml
@@ -46,6 +46,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/pgcat
             scanner: grype
+      - timestamp: 2025-03-12T17:21:57Z
+        type: pending-upstream-fix
+        data:
+          note: This dependency is version locked by several other dependencies, and remediation attempts have lead to build errors. Upstream will need to patch this CVE.
 
   - id: CGA-896q-7j3w-vqv7
     aliases:


### PR DESCRIPTION
Replacement for https://github.com/wolfi-dev/os/pull/45576