### PR TITLE
Update CVE-2024-36623:Pending-upstream-fix

### DIFF
--- a/k3s.advisories.yaml
+++ b/k3s.advisories.yaml
@@ -232,6 +232,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/containerd-shim-runc-v2
             scanner: grype
+      - timestamp: 2025-03-14T17:50:18Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability requires an upgrade in a separate project 'https://github.com/k3s-io/containerd' on which the vulnerable dependency still uses an affected version.
 
   - id: CGA-7jcp-vfhv-643j
     aliases:
@@ -424,7 +428,7 @@ advisories:
       - timestamp: 2025-03-14T17:16:45Z
         type: pending-upstream-fix
         data:
-          note: 'k3s 1.32.2.1 uses Docker 25.0.6 (see https://github.com/k3s-io/k3s/blob/v1.32.3-rc1%2Bk3s1/go.mod#L15), but its go.mod requires Docker 27.1.1+incompatible. cri-docker is not compatible with that version, so upstream must address it.'
+          note: k3s 1.32.2.1 uses Docker 25.0.6 (see https://github.com/k3s-io/k3s/blob/v1.32.3-rc1%2Bk3s1/go.mod#L15), but its go.mod requires Docker 27.1.1+incompatible. cri-docker is not compatible with that version, so upstream must address it.
 
   - id: CGA-hh86-4p27-6vwp
     aliases:

--- a/k3s.advisories.yaml
+++ b/k3s.advisories.yaml
@@ -421,6 +421,10 @@ advisories:
             componentType: go-module
             componentLocation: /bin/k3s
             scanner: grype
+      - timestamp: 2025-03-14T17:16:45Z
+        type: pending-upstream-fix
+        data:
+          note: 'k3s 1.32.2.1 uses Docker 25.0.6 (see https://github.com/k3s-io/k3s/blob/v1.32.3-rc1%2Bk3s1/go.mod#L15), but its go.mod requires Docker 27.1.1+incompatible. cri-docker is not compatible with that version, so upstream must address it.'
 
   - id: CGA-hh86-4p27-6vwp
     aliases:


### PR DESCRIPTION
**CVE-2024-36623**
k3s 1.32.2.1 is built to work with Docker 25.0.6 (as indicated in its [go.mod file](https://github.com/k3s-io/k3s/blob/v1.32.3-rc1%2Bk3s1/go.mod#L15)), yet the go.mod requires Docker to be at v27.1.1+incompatible. This version mismatch causes a compatibility issue since cri-docker does not work with Docker 27.1.1+incompatible, meaning that upstream maintainers will need to update cri-docker to resolve this discrepancy.
Error logs - 
`/var/cache/melange/gomodcache/github.com/k3s-io/cri-dockerd@v0.3.15-k3s1.32-1/libdocker/client.go:57:46: undefined: dockertypes.ContainerRemoveOptions`


**CVE-2024-36623**
Its coming from `containerd `project and needs fixing there.