### PR TITLE
pending-upstream-fix for: GHSA-vv39-3w5q-974q

### DIFF
--- a/aws-efs-csi-driver.advisories.yaml
+++ b/aws-efs-csi-driver.advisories.yaml
@@ -427,6 +427,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/aws-efs-csi-driver
             scanner: grype
+      - timestamp: 2025-03-16T07:59:14Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            To remedieate this CVE the code requires upgrading Kubernetes dependencies to v1.29.13 or later, but doing that the build fails due to
+            missing feature flags (genericfeatures.StructuredAuthorizationConfiguration and genericfeatures.ZeroLimitedNominalConcurrencyShares) that were removed in later versions.
+            The package currently depends on k8s.io/kubernetes v1.28.15. This requires upstream changes to support newer Kubernetes API versions and feature gates.
 
   - id: CGA-qv9r-w22w-39xx
     aliases:

--- a/aws-efs-csi-driver.advisories.yaml
+++ b/aws-efs-csi-driver.advisories.yaml
@@ -431,7 +431,7 @@ advisories:
         type: pending-upstream-fix
         data:
           note: |
-            To remedieate this CVE the code requires upgrading Kubernetes dependencies to v1.29.13 or later, but doing that the build fails due to
+            To remediate this CVE the code requires upgrading Kubernetes dependencies to v1.29.13 or later, but doing that the build fails due to
             missing feature flags (genericfeatures.StructuredAuthorizationConfiguration and genericfeatures.ZeroLimitedNominalConcurrencyShares) that were removed in later versions.
             The package currently depends on k8s.io/kubernetes v1.28.15. This requires upstream changes to support newer Kubernetes API versions and feature gates.
 


### PR DESCRIPTION
pending-upstream-fix for: GHSA-vv39-3w5q-974q. aws-efs-csi-driver still depends on older version of kubernetes. We actually had a similar advisory for another CVE, same root cause here.

**_Please close the failed automated remediation PR when this is merged: https://github.com/wolfi-dev/os/pull/46984_**