### PR TITLE
GHSA-3wgm-2gw2-vh5m wolfi-dev advisories update

### DIFF
--- a/argo-cd-2.14.advisories.yaml
+++ b/argo-cd-2.14.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/local/bin/argocd
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-5w62-q492-qf55
     aliases:

--- a/argo-rollouts.advisories.yaml
+++ b/argo-rollouts.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubectl-argo-rollouts
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-4x3w-pm5j-g8x7
     aliases:

--- a/argocd-image-updater.advisories.yaml
+++ b/argocd-image-updater.advisories.yaml
@@ -239,6 +239,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argocd-image-updater
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-hrx6-hvq8-xj45
     aliases:

--- a/aws-efs-csi-driver.advisories.yaml
+++ b/aws-efs-csi-driver.advisories.yaml
@@ -318,6 +318,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/aws-efs-csi-driver
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-fp69-p6mm-6mp5
     aliases:

--- a/azuredisk-csi-1.31.advisories.yaml
+++ b/azuredisk-csi-1.31.advisories.yaml
@@ -117,6 +117,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/azurediskplugin
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-hcjv-vr4m-rwhf
     aliases:

--- a/cluster-autoscaler-1.32.advisories.yaml
+++ b/cluster-autoscaler-1.32.advisories.yaml
@@ -236,3 +236,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cluster-autoscaler
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'

--- a/emissary.advisories.yaml
+++ b/emissary.advisories.yaml
@@ -188,6 +188,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/busyambassador
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-rgmr-3fw8-8v5j
     aliases:

--- a/ip-masq-agent.advisories.yaml
+++ b/ip-masq-agent.advisories.yaml
@@ -254,6 +254,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/ip-masq-agent
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-gq4c-2cm9-vj4j
     aliases:

--- a/kapp.advisories.yaml
+++ b/kapp.advisories.yaml
@@ -31,6 +31,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kapp
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-3hvm-mf5g-45mx
     aliases:

--- a/kubernetes-1.32.advisories.yaml
+++ b/kubernetes-1.32.advisories.yaml
@@ -123,6 +123,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubectl-1.32
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-52qq-32xp-43jq
     aliases:

--- a/kubernetes-dns-node-cache.advisories.yaml
+++ b/kubernetes-dns-node-cache.advisories.yaml
@@ -551,3 +551,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/node-cache
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'

--- a/local-static-provisioner.advisories.yaml
+++ b/local-static-provisioner.advisories.yaml
@@ -137,6 +137,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/main
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-86m7-vm4x-8jhv
     aliases:

--- a/node-feature-discovery-0.17.advisories.yaml
+++ b/node-feature-discovery-0.17.advisories.yaml
@@ -117,6 +117,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubectl-nfd
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-vhfc-6c55-jwhp
     aliases:

--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -493,6 +493,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/nodetaint
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-p6xx-pg8g-64f3
     aliases:

--- a/rancher-webhook-0.6.advisories.yaml
+++ b/rancher-webhook-0.6.advisories.yaml
@@ -64,6 +64,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/webhook
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-gr5h-992v-c263
     aliases:

--- a/yunikorn-k8shim.advisories.yaml
+++ b/yunikorn-k8shim.advisories.yaml
@@ -86,6 +86,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/yunikorn-scheduler
             scanner: grype
+      - timestamp: 2025-03-18T01:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-937q-xhxh-m54v
     aliases:


### PR DESCRIPTION
The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786