### PR TITLE
chore(sts): add policy for eol-mover to read

### DIFF
--- a/.github/chainguard/lifecycle-eol-mover.sts.yaml
+++ b/.github/chainguard/lifecycle-eol-mover.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://accounts.google.com
+
+# prod-images: lifecycle-eol-mover@prod-images-c6e5.iam.gserviceaccount.com
+subject: "105314035764875766195"
+
+permissions:
+  contents: read # to clone the repository


### PR DESCRIPTION
This will enable the job to clone the repo as a first step in rebasing to enterprise data.