### PR TITLE
libarchive: manually mark CVEs fixed via backport as fixed

### DIFF
--- a/libarchive.advisories.yaml
+++ b/libarchive.advisories.yaml
@@ -31,6 +31,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-03-18T17:14:12Z
+        type: fixed
+        data:
+          fixed-version: 3.7.7-r2
+          note: 'Fixed via backport of upstream fix: https://github.com/libarchive/libarchive/commit/82912103214506316bd9990d73f33d743d55f570'
 
   - id: CGA-fr7r-qfwj-mf66
     aliases:
@@ -69,6 +74,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-03-18T17:15:25Z
+        type: fixed
+        data:
+          fixed-version: 3.7.7-r2
+          note: 'Fixed via backport of upstream fix: https://github.com/libarchive/libarchive/commit/c9bc934e7e91d302e0feca6e713ccc38d6d01532'
 
   - id: CGA-pwpv-gfcr-gq38
     aliases:
@@ -79,6 +89,17 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.6.1-r2
+
+  - id: CGA-vqg2-49pm-h25g
+    aliases:
+      - CVE-2025-1632
+      - GHSA-cw9m-pj72-3cj5
+    events:
+      - timestamp: 2025-03-18T17:16:44Z
+        type: fixed
+        data:
+          fixed-version: 3.7.7-r2
+          note: 'Fixed via backport of upstream fix: https://github.com/libarchive/libarchive/commit/c9bc934e7e91d302e0feca6e713ccc38d6d01532'
 
   - id: CGA-w62q-v974-62r3
     aliases:

--- a/libarchive.advisories.yaml
+++ b/libarchive.advisories.yaml
@@ -34,8 +34,8 @@ advisories:
       - timestamp: 2025-03-18T17:14:12Z
         type: fixed
         data:
+          #note: 'Fixed via backport of upstream fix: https://github.com/libarchive/libarchive/commit/82912103214506316bd9990d73f33d743d55f570'
           fixed-version: 3.7.7-r2
-          note: 'Fixed via backport of upstream fix: https://github.com/libarchive/libarchive/commit/82912103214506316bd9990d73f33d743d55f570'
 
   - id: CGA-fr7r-qfwj-mf66
     aliases:
@@ -77,8 +77,8 @@ advisories:
       - timestamp: 2025-03-18T17:15:25Z
         type: fixed
         data:
+          #note: 'Fixed via backport of upstream fix: https://github.com/libarchive/libarchive/commit/c9bc934e7e91d302e0feca6e713ccc38d6d01532'
           fixed-version: 3.7.7-r2
-          note: 'Fixed via backport of upstream fix: https://github.com/libarchive/libarchive/commit/c9bc934e7e91d302e0feca6e713ccc38d6d01532'
 
   - id: CGA-pwpv-gfcr-gq38
     aliases:
@@ -98,8 +98,8 @@ advisories:
       - timestamp: 2025-03-18T17:16:44Z
         type: fixed
         data:
+          #note: 'Fixed via backport of upstream fix: https://github.com/libarchive/libarchive/commit/c9bc934e7e91d302e0feca6e713ccc38d6d01532'
           fixed-version: 3.7.7-r2
-          note: 'Fixed via backport of upstream fix: https://github.com/libarchive/libarchive/commit/c9bc934e7e91d302e0feca6e713ccc38d6d01532'
 
   - id: CGA-w62q-v974-62r3
     aliases:


### PR DESCRIPTION
Including adding CVE-2025-1632, which we haven't detected (yet?).