### PR TITLE
zookeeper-3.9: remove incorrect fixed/re-detection events

### DIFF
--- a/zookeeper-3.9.advisories.yaml
+++ b/zookeeper-3.9.advisories.yaml
@@ -66,22 +66,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'While there is a fix that exists upstream in main, the maintainers have deliberately prevented this from being implemented in the current release and are holding it for 3.10.0 as seen here in the conversation: https://github.com/apache/zookeeper/pull/2162#issuecomment-2092233436 and the fix versions in apache’s project page being v3.10.0: https://issues.apache.org/jira/browse/ZOOKEEPER-4831'
-      - timestamp: 2025-03-14T00:04:01Z
-        type: fixed
-        data:
-          fixed-version: 3.9.3.2-r2
-      - timestamp: 2025-03-15T16:32:12Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: zookeeper-3.9
-            componentID: 05251c169af57d9a
-            componentName: logback-core
-            componentVersion: 1.2.13
-            componentType: java-archive
-            componentLocation: /usr/share/java/zookeeper/lib/logback-core-1.2.13.jar
-            scanner: grype
 
   - id: CGA-c8xx-wqr2-vpgm
     aliases:
@@ -149,22 +133,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: Updating jetty to a non-vulnerable version would require 3 major version bumps, which would be a very significant upgrade and should only be undertaken by the upstream maintainers.
-      - timestamp: 2025-03-14T00:04:02Z
-        type: fixed
-        data:
-          fixed-version: 3.9.3.2-r2
-      - timestamp: 2025-03-15T16:32:14Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: zookeeper-3.9
-            componentID: 15fd6deb36b5f6b5
-            componentName: jetty-http
-            componentVersion: 9.4.56.v20240826
-            componentType: java-archive
-            componentLocation: /usr/share/java/zookeeper/lib/jetty-http-9.4.56.v20240826.jar
-            scanner: grype
 
   - id: CGA-j6gx-jgg6-q4cp
     aliases:
@@ -187,22 +155,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'While there is a fix that exists upstream in main, the maintainers have deliberately prevented this from being implemented in the current release and are holding it for 3.10.0 as seen here in the conversation: https://github.com/apache/zookeeper/pull/2162#issuecomment-2092233436 and the fix versions in apache’s project page being v3.10.0: https://issues.apache.org/jira/browse/ZOOKEEPER-4831'
-      - timestamp: 2025-03-14T00:04:02Z
-        type: fixed
-        data:
-          fixed-version: 3.9.3.2-r2
-      - timestamp: 2025-03-15T16:32:08Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: zookeeper-3.9
-            componentID: 05251c169af57d9a
-            componentName: logback-core
-            componentVersion: 1.2.13
-            componentType: java-archive
-            componentLocation: /usr/share/java/zookeeper/lib/logback-core-1.2.13.jar
-            scanner: grype
 
   - id: CGA-p5qq-x3qc-jpwx
     aliases:


### PR DESCRIPTION
There is a known (soon-to-be-fixed) issue with advisories being marked as fixed when we have connectivity issues with Maven Central: restore these to the correct state.