### PR TITLE
Several incorrect Druid advisories fixed

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -201,22 +201,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This vulnerability relates to snappy-java v1.1.8.2, included by the shaded JARs hadoop-client-api-3.3.6.jar. Upgrading to version 3.4.0 will fix the vulnerability, but it requires code changes by the upstream maintainers.
-      - timestamp: 2025-03-15T04:41:36Z
-        type: fixed
-        data:
-          fixed-version: 32.0.0-r6
-      - timestamp: 2025-03-17T07:25:04Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: druid
-            componentID: 02e097f2efbf7d26
-            componentName: snappy-java
-            componentVersion: 1.1.8.2
-            componentType: java-archive
-            componentLocation: /usr/share/java/druid/hadoop-dependencies/hadoop-client-api/3.3.6/snappy-java-1.1.8.2.jar
-            scanner: grype
 
   - id: CGA-7hrq-h45h-6c5f
     aliases:
@@ -279,22 +263,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This is related to libthrift-0.13.0.jar. It requires code changes to remediate this by upstream maintainers
-      - timestamp: 2025-03-15T04:41:39Z
-        type: fixed
-        data:
-          fixed-version: 32.0.0-r6
-      - timestamp: 2025-03-17T07:23:52Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: druid
-            componentID: 4afc704f690e497c
-            componentName: libthrift
-            componentVersion: 0.13.0
-            componentType: java-archive
-            componentLocation: /usr/share/java/druid/extensions/druid-thrift-extensions/libthrift-0.13.0.jar
-            scanner: grype
 
   - id: CGA-976p-p5pv-286x
     aliases:
@@ -502,22 +470,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This is related to libthrift-0.13.0.jar. It requires code changes to remediate this by upstream maintainers
-      - timestamp: 2025-03-15T04:41:44Z
-        type: fixed
-        data:
-          fixed-version: 32.0.0-r6
-      - timestamp: 2025-03-17T07:26:40Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: druid
-            componentID: 0b0aec2b1f5c45a3
-            componentName: libthrift
-            componentVersion: 0.9.3
-            componentType: java-archive
-            componentLocation: /usr/share/java/druid/extensions/druid-iceberg-extensions/libthrift-0.9.3.jar
-            scanner: grype
 
   - id: CGA-fp7c-364q-pvhc
     aliases:
@@ -559,22 +511,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This vulnerability relates to snappy-java v1.1.8.2, included by the shaded JARs hadoop-client-api-3.3.6.jar. Upgrading to version 3.4.0 will fix the vulnerability, but it requires code changes by the upstream maintainers.
-      - timestamp: 2025-03-15T04:41:39Z
-        type: fixed
-        data:
-          fixed-version: 32.0.0-r6
-      - timestamp: 2025-03-17T07:25:28Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: druid
-            componentID: 02e097f2efbf7d26
-            componentName: snappy-java
-            componentVersion: 1.1.8.2
-            componentType: java-archive
-            componentLocation: /usr/share/java/druid/hadoop-dependencies/hadoop-client-api/3.3.6/snappy-java-1.1.8.2.jar
-            scanner: grype
 
   - id: CGA-gmp3-7m33-2h3v
     aliases:
@@ -647,22 +583,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: com.netflix.astyanax:astyanax needs to be replaced with com.datastax.oss:java-driver-core in extensions-contrib/cassandra-storage by upstream maintainers
-      - timestamp: 2025-03-15T04:41:41Z
-        type: fixed
-        data:
-          fixed-version: 32.0.0-r6
-      - timestamp: 2025-03-17T07:26:15Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: druid
-            componentID: 22393df523ef6935
-            componentName: libthrift
-            componentVersion: 0.6.1
-            componentType: java-archive
-            componentLocation: /usr/share/java/druid/extensions/druid-cassandra-storage/libthrift-0.6.1.jar
-            scanner: grype
 
   - id: CGA-hmfp-mpjh-cq5p
     aliases:
@@ -733,22 +653,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This vulnerability relates to snappy-java v1.1.8.2, included by the shaded JARs hadoop-client-api-3.3.6.jar. Upgrading to version 3.4.0 will fix the vulnerability, but it requires code changes by the upstream maintainers.
-      - timestamp: 2025-03-15T04:41:44Z
-        type: fixed
-        data:
-          fixed-version: 32.0.0-r6
-      - timestamp: 2025-03-17T07:22:15Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: druid
-            componentID: 02e097f2efbf7d26
-            componentName: snappy-java
-            componentVersion: 1.1.8.2
-            componentType: java-archive
-            componentLocation: /usr/share/java/druid/hadoop-dependencies/hadoop-client-api/3.3.6/snappy-java-1.1.8.2.jar
-            scanner: grype
 
   - id: CGA-m35f-vgjj-4rrc
     aliases:
@@ -895,22 +799,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This vulnerability relates to snappy-java v1.1.8.2, included by the shaded JARs hadoop-client-api-3.3.6.jar. Upgrading to version 3.4.0 will fix the vulnerability, but it requires code changes by the upstream maintainers.
-      - timestamp: 2025-03-15T04:41:42Z
-        type: fixed
-        data:
-          fixed-version: 32.0.0-r6
-      - timestamp: 2025-03-17T07:23:28Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: druid
-            componentID: 02e097f2efbf7d26
-            componentName: snappy-java
-            componentVersion: 1.1.8.2
-            componentType: java-archive
-            componentLocation: /usr/share/java/druid/hadoop-dependencies/hadoop-client-api/3.3.6/snappy-java-1.1.8.2.jar
-            scanner: grype
 
   - id: CGA-qj62-9qwq-2x3m
     aliases:
@@ -1075,22 +963,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: The fix version of the affected dependency cassandra-all (v3.0.31) is several major versions higher than what is currently included in druid (v1.0.8), upgrading to this version introduces breaking changes, must wait for upstream to implement a fix
-      - timestamp: 2025-03-15T04:41:43Z
-        type: fixed
-        data:
-          fixed-version: 32.0.0-r6
-      - timestamp: 2025-03-17T07:27:29Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: druid
-            componentID: 2671f8230b9bb550
-            componentName: cassandra-all
-            componentVersion: 1.0.8
-            componentType: java-archive
-            componentLocation: /usr/share/java/druid/extensions/druid-cassandra-storage/cassandra-all-1.0.8.jar
-            scanner: grype
 
   - id: CGA-x4qp-2ggp-3xgp
     aliases:


### PR DESCRIPTION
The following advisories have been incorrectly marked as fixed and immediately reopened by automation. 