### PR TITLE
k8ssandra-client/GHSA-3wgm-2gw2-vh5m advisory update

### DIFF
--- a/k8ssandra-client.advisories.yaml
+++ b/k8ssandra-client.advisories.yaml
@@ -75,6 +75,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubectl-k8ssandra
             scanner: grype
+      - timestamp: 2025-03-20T00:27:56Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
 
   - id: CGA-cjwf-2wfq-3rg6
     aliases:


### PR DESCRIPTION
The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786