### PR TITLE
Advisory update for kubernetes-csi-driver-nfs(GHSA-3wgm-2gw2-vh5m)

### DIFF
--- a/kubernetes-csi-driver-nfs.advisories.yaml
+++ b/kubernetes-csi-driver-nfs.advisories.yaml
@@ -113,3 +113,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/nfsplugin
             scanner: grype
+      - timestamp: 2025-03-20T23:59:11Z
+        type: pending-upstream-fix
+        data:
+          note: 'The k8s.io CVE affecting this package is still under upstream triage. See the related PR at https://github.com/kubernetes/kubernetes/issues/130786. The current upstream build remains on kubernetes@v1.31.x to retain support for k8s.io/kubelet/pkg/apis/dra/v1beta1, which was removed in v1.32.x.'


### PR DESCRIPTION
The k8s.io CVE affecting this package is still under upstream triage. See the related PR at https://github.com/kubernetes/kubernetes/issues/130786. The current upstream build remains on kubernetes@v1.31.x to retain support for `k8s.io/kubelet/pkg/apis/dra/v1beta1`, which was removed in v1.32.x.