### PR TITLE
Update pending-upstream-fix for gopkg.in/square/go-jose.v2

### DIFF
--- a/flyte.advisories.yaml
+++ b/flyte.advisories.yaml
@@ -109,6 +109,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/flyte
             scanner: grype
+      - timestamp: 2025-03-24T14:47:30Z
+        type: pending-upstream-fix
+        data:
+          note: gopkg.in/square/go-jose.v2 does not have a version that fixes the vulnerability. Thus upstream needs to move away from gopkg.in/square/go-jose.v2 for this to be fixed.
 
   - id: CGA-c2pp-59hg-v5q9
     aliases:


### PR DESCRIPTION
Related to wolfi-dev/os#47766