### PR TITLE
unixodbc: mark CVE-2024-1013 as fixed

### DIFF
--- a/unixodbc.advisories.yaml
+++ b/unixodbc.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-03-27T12:02:42Z
+        type: fixed
+        data:
+          fixed-version: 2.3.12-r7


### PR DESCRIPTION
We backported the fix, so automation isn't going to handle this for us.