### PR TITLE
feat(advisory): xorg-server CVE-2022-49737 pending-upstream advisory

### DIFF
--- a/xorg-server.advisories.yaml
+++ b/xorg-server.advisories.yaml
@@ -196,6 +196,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-03-27T17:30:56Z
+        type: pending-upstream-fix
+        data:
+          note: 'xorg-server versions <= 21.1.16 are vulnerable and we build directly from upstream. Patches have been merged upstream but no 21.1.17 release yet - see https://gitlab.freedesktop.org/xorg/xserver/-/commit/dc7cb45482cea6ccec22d117ca0b489500b4d0a0. We need to wait until a 21.1.17 release is made or at the very least until there is a tested release candidate branch with the commit present.'
 
   - id: CGA-jfwv-9247-m3jf
     aliases:


### PR DESCRIPTION
pending-upstream-fix as there is no tested or supported patch available yet.

> xorg-server versions <= 21.1.16 are vulnerable and we build directly from upstream. Patches have been merged upstream but no 21.1.17 release yet - see https://gitlab.freedesktop.org/xorg/xserver/-/commit/dc7cb45482cea6ccec22d117ca0b489500b4d0a0. We need to wait until a 21.1.17 release is made or at the very least until there is a tested release candidate branch with the commit present.

Signed-off-by: philroche <phil.roche@chainguard.dev>
