### PR TITLE
spark-3.5/GHSA-p953-3j66-hg45/CVE-2024-23953

### DIFF
--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -733,6 +733,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hive-llap-common-2.3.9.jar
             scanner: grype
+      - timestamp: 2025-03-27T20:32:08Z
+        type: fix-not-planned
+        data:
+          note: 'Spark-3.5 only supports Hive 2.3.9. An initiative to upgrade Hive to a newer major version exists and is targeting the spark 4.0.0 release. This can be seen in the following PR: https://issues.apache.org/jira/browse/SPARK-44114'
 
   - id: CGA-jwxv-rq2f-pf4p
     aliases:


### PR DESCRIPTION
Spark-3.5 only supports Hive 2.3.9. An initiative to upgrade Hive to a newer major version exists and is targeting the spark 4.0.0 release. This can be seen in the following PR: https://issues.apache.org/jira/browse/SPARK-44114