### PR TITLE
feat(advisory): keycloak GHSA-2935-2wfm-hhpv pending-upstream-fix advisory

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -443,6 +443,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/keycloak/lib/lib/main/org.keycloak.keycloak-services-26.1.4.jar
             scanner: grype
+      - timestamp: 2025-03-28T11:48:32Z
+        type: pending-upstream-fix
+        data:
+          note: CVE affects component keycloak-services which has no known release mitigating this CVE - see https://github.com/advisories/GHSA-2935-2wfm-hhpv. As such we must wait until an upstream fix of this component is released.
 
   - id: CGA-jfwc-r5wf-xxhp
     aliases:


### PR DESCRIPTION
pending-upstream-fix as there is upstream release of the vulnerable component yet.

> CVE affects component keycloak-services which has no known release mitigating this CVE - see https://github.com/advisories/GHSA-2935-2wfm-hhpv. As such we must wait until an upstream fix of this component is released.

Signed-off-by: philroche <phil.roche@chainguard.dev>
