### PR TITLE
fix: Revert "Adding detection events for logstash (#13844)"

### DIFF
--- a/logstash.advisories.yaml
+++ b/logstash.advisories.yaml
@@ -78,24 +78,6 @@ advisories:
         data:
           fixed-version: 8.12.2-r2
 
-  - id: CGA-2rqg-qcgr-hmm8
-    aliases:
-      - CVE-2025-25193
-      - GHSA-389x-839f-4rhx
-    events:
-      - timestamp: 2025-03-06T01:07:29Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: 931d8bd97de83f94
-            componentName: netty-common
-            componentVersion: 4.1.109.Final
-            componentType: java-archive
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/logstash-input-beats-6.8.4-java/vendor/jar-dependencies/io/netty/netty-common/4.1.109.Final/netty-common-4.1.109.Final.jar
-            scanner: grype
-
   - id: CGA-3p4r-wmm9-39fg
     aliases:
       - GHSA-r95h-9x8f-r3f7
@@ -195,24 +177,6 @@ advisories:
         data:
           fixed-version: 8.13.4-r0
 
-  - id: CGA-4m49-r7jc-cpjm
-    aliases:
-      - CVE-2020-16971
-      - GHSA-8q69-pw39-hpqh
-    events:
-      - timestamp: 2025-03-06T01:08:36Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: eb74f37dee7f3c4e
-            componentName: azure-eventhubs
-            componentVersion: 2.3.2
-            componentType: java-archive
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/logstash-input-azure_event_hubs-1.4.7/vendor/jar-dependencies/com/microsoft/azure/azure-eventhubs/2.3.2/azure-eventhubs-2.3.2.jar
-            scanner: grype
-
   - id: CGA-4mjp-5h6x-r3x6
     aliases:
       - CVE-2024-43380
@@ -256,60 +220,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 8.15.2-r1
-
-  - id: CGA-5hq7-5xrf-mxfw
-    aliases:
-      - CVE-2024-21510
-      - GHSA-hxx2-7vcw-mqr3
-    events:
-      - timestamp: 2025-03-06T01:09:04Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: 67b261740469e239
-            componentName: sinatra
-            componentVersion: 4.0.0
-            componentType: gem
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/sinatra-4.0.0.gemspec
-            scanner: grype
-
-  - id: CGA-66c7-8gfq-5mjr
-    aliases:
-      - CVE-2024-47535
-      - GHSA-xq3w-v528-46rv
-    events:
-      - timestamp: 2025-03-06T01:09:51Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: 931d8bd97de83f94
-            componentName: netty-common
-            componentVersion: 4.1.109.Final
-            componentType: java-archive
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/logstash-input-beats-6.8.4-java/vendor/jar-dependencies/io/netty/netty-common/4.1.109.Final/netty-common-4.1.109.Final.jar
-            scanner: grype
-
-  - id: CGA-6jgq-r9jg-wv37
-    aliases:
-      - CVE-2025-22866
-      - GHSA-3whm-j4xm-rv8x
-    events:
-      - timestamp: 2025-03-06T01:06:45Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: a0009e0ce07fae13
-            componentName: stdlib
-            componentVersion: go1.23.2
-            componentType: go-module
-            componentLocation: /usr/bin/env2yaml
-            scanner: grype
 
   - id: CGA-7369-wc68-4626
     aliases:
@@ -371,23 +281,6 @@ advisories:
         type: pending-upstream-fix
         data:
           note: It is a vendor dependency that includes the vulnerable version. awaiting upstream release that includes the fix from https://github.com/logstash-plugins/logstash-input-http/pull/172
-
-  - id: CGA-7wgp-258p-gc3w
-    aliases:
-      - GHSA-vvfq-8hwr-qm4m
-    events:
-      - timestamp: 2025-03-06T01:09:35Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: 082313f4bc335237
-            componentName: nokogiri
-            componentVersion: 1.16.7
-            componentType: gem
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/nokogiri-1.16.7-java.gemspec
-            scanner: grype
 
   - id: CGA-82f4-qhrq-8f2w
     aliases:
@@ -457,24 +350,6 @@ advisories:
         data:
           note: 'To fix the CVE we need to update derby to 10.17.1.0 which requires requires logstash to be built with JDK 21: https://github.com/logstash-plugins/logstash-integration-jdbc/issues/147'
 
-  - id: CGA-9x8q-6xvc-v5xr
-    aliases:
-      - CVE-2024-45336
-      - GHSA-7wrw-r4p8-38rx
-    events:
-      - timestamp: 2025-03-06T01:06:25Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: a0009e0ce07fae13
-            componentName: stdlib
-            componentVersion: go1.23.2
-            componentType: go-module
-            componentLocation: /usr/bin/env2yaml
-            scanner: grype
-
   - id: CGA-f648-gph5-wch6
     aliases:
       - CVE-2024-24789
@@ -484,24 +359,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 8.13.4-r2
-
-  - id: CGA-g9cq-x327-vv78
-    aliases:
-      - CVE-2024-45341
-      - GHSA-3f6r-qh9c-x6mm
-    events:
-      - timestamp: 2025-03-06T01:06:35Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: a0009e0ce07fae13
-            componentName: stdlib
-            componentVersion: go1.23.2
-            componentType: go-module
-            componentLocation: /usr/bin/env2yaml
-            scanner: grype
 
   - id: CGA-ggc7-mqxg-jcjm
     aliases:
@@ -528,24 +385,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 8.15.0-r0
-
-  - id: CGA-gvh5-hw7r-4548
-    aliases:
-      - CVE-2025-27220
-      - GHSA-mhwm-jh88-3gjf
-    events:
-      - timestamp: 2025-03-06T01:09:20Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: d836fd0ca00c4e6c
-            componentName: cgi
-            componentVersion: 0.3.6
-            componentType: gem
-            componentLocation: /usr/share/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
-            scanner: grype
 
   - id: CGA-h6gp-72jh-xc9h
     aliases:
@@ -599,24 +438,6 @@ advisories:
         data:
           fixed-version: 8.14.0-r0
 
-  - id: CGA-j985-6mrx-ff76
-    aliases:
-      - CVE-2025-27219
-      - GHSA-gh9q-2xrm-x6qv
-    events:
-      - timestamp: 2025-03-06T01:08:50Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: d836fd0ca00c4e6c
-            componentName: cgi
-            componentVersion: 0.3.6
-            componentType: gem
-            componentLocation: /usr/share/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
-            scanner: grype
-
   - id: CGA-m7gh-v57j-hjgm
     aliases:
       - CVE-2024-34155
@@ -663,24 +484,6 @@ advisories:
         data:
           fixed-version: 8.15.0-r0
 
-  - id: CGA-pv9p-q463-9682
-    aliases:
-      - CVE-2025-27221
-      - GHSA-22h5-pq3x-2gf2
-    events:
-      - timestamp: 2025-03-06T01:06:55Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: 62fa97cba3787a60
-            componentName: uri
-            componentVersion: 0.12.2
-            componentType: gem
-            componentLocation: /usr/share/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/uri-0.12.2.gemspec
-            scanner: grype
-
   - id: CGA-px8g-qqwm-7v22
     aliases:
       - CVE-2024-39908
@@ -707,24 +510,6 @@ advisories:
         data:
           fixed-version: 8.15.0-r0
 
-  - id: CGA-q4qg-h3xh-rxw6
-    aliases:
-      - CVE-2025-25184
-      - GHSA-7g2v-jj9q-g3rg
-    events:
-      - timestamp: 2025-03-06T01:08:21Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: be7e527c02ef2a3f
-            componentName: rack
-            componentVersion: 3.1.7
-            componentType: gem
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/rack-3.1.7.gemspec
-            scanner: grype
-
   - id: CGA-q682-qhrq-cfhj
     aliases:
       - CVE-2024-24787
@@ -747,41 +532,6 @@ advisories:
         data:
           fixed-version: 8.13.4-r0
 
-  - id: CGA-qqh2-q54x-7mgj
-    aliases:
-      - CVE-2025-24970
-      - GHSA-4g8c-wm8x-jfhw
-    events:
-      - timestamp: 2025-03-06T01:07:42Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: 1fb33525800944db
-            componentName: netty-handler
-            componentVersion: 4.1.109.Final
-            componentType: java-archive
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/logstash-input-beats-6.8.4-java/vendor/jar-dependencies/io/netty/netty-handler/4.1.109.Final/netty-handler-4.1.109.Final.jar
-            scanner: grype
-
-  - id: CGA-r496-9j2f-339p
-    aliases:
-      - GHSA-5mwf-688x-mr7x
-    events:
-      - timestamp: 2025-03-06T01:07:55Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: 082313f4bc335237
-            componentName: nokogiri
-            componentVersion: 1.16.7
-            componentType: gem
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/nokogiri-1.16.7-java.gemspec
-            scanner: grype
-
   - id: CGA-r4hw-v886-jw4q
     aliases:
       - CVE-2024-47561
@@ -798,24 +548,6 @@ advisories:
             componentVersion: 1.11.3
             componentType: java-archive
             componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/logstash-integration-kafka-11.5.1-java/vendor/jar-dependencies/org/apache/avro/avro/1.11.3/avro-1.11.3.jar
-            scanner: grype
-
-  - id: CGA-rv2c-f5g7-rhv9
-    aliases:
-      - CVE-2025-25186
-      - GHSA-7fc5-f82f-cx69
-    events:
-      - timestamp: 2025-03-06T01:08:08Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: 366567c03addc763
-            componentName: net-imap
-            componentVersion: 0.4.16
-            componentType: gem
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/net-imap-0.4.16.gemspec
             scanner: grype
 
   - id: CGA-vmqc-gfrm-xfxp
@@ -876,24 +608,6 @@ advisories:
         data:
           fixed-version: 8.12.2-r2
 
-  - id: CGA-wrmg-9x65-g9w3
-    aliases:
-      - CVE-2024-31141
-      - GHSA-2x2g-32r7-p4x8
-    events:
-      - timestamp: 2025-03-06T01:07:18Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: 8964154a84b1ceb0
-            componentName: kafka-clients
-            componentVersion: 3.4.1
-            componentType: java-archive
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/logstash-integration-kafka-11.5.1-java/vendor/jar-dependencies/org/apache/kafka/kafka-clients/3.4.1/kafka-clients-3.4.1.jar
-            scanner: grype
-
   - id: CGA-x9w3-w89h-p3x5
     aliases:
       - CVE-2024-24790
@@ -903,21 +617,3 @@ advisories:
         type: fixed
         data:
           fixed-version: 8.13.4-r2
-
-  - id: CGA-xrw4-f89q-m7jh
-    aliases:
-      - CVE-2024-49761
-      - GHSA-2rxp-v6pw-ch6m
-    events:
-      - timestamp: 2025-03-06T01:07:06Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: logstash
-            componentID: 1a53b713db9f253e
-            componentName: rexml
-            componentVersion: 3.3.6
-            componentType: gem
-            componentLocation: /usr/share/logstash/vendor/bundle/jruby/3.1.0/specifications/rexml-3.3.6.gemspec
-            scanner: grype


### PR DESCRIPTION
This reverts commit 23562e897d63b190d1b09d3cdfca5b0e6e426ce7.

These logstash APKs in wolfi-dev/os were scanned in error and should not have resulted in new detection events.

logstash was renamed to logstash-8 and being maintained using that name. The rename occurred in https://github.com/wolfi-dev/os/pull/30436

Signed-off-by: philroche <phil.roche@chainguard.dev>
