### PR TITLE
Adv(Pending upstream Fix): CVE-2025-30215

### DIFF
--- a/nats-server.advisories.yaml
+++ b/nats-server.advisories.yaml
@@ -36,7 +36,7 @@ advisories:
           note: |
             Upstream has acknowledged the vulnerability (CVE-2025-30215) and published a **binary-only** release that includes a fix binary. However, this binary appears to have been hand-crafted outside of their usual CI process and does not correspond to any visible source code changes or official versioned release in the repository.
             Since Chainguard builds all packages from source, and no corresponding code changes have been published or tagged, we are unable to apply the remediation at this time.
-            Although the upstream has recommended temporarily using their pre-built binary for workflows that depend on the fix, this does not satisfy our security and reproducibility standards. 
+            Although the upstream has recommended temporarily using their pre-built binary for workflows that depend on the fix, this does not satisfy our security and reproducibility standards.
             Therefore, we are marking this CVE as **pending-upstream-fix** until an official source-based release with the necessary patches is available
 
   - id: CGA-47cc-r2mp-w98x

--- a/nats-server.advisories.yaml
+++ b/nats-server.advisories.yaml
@@ -26,6 +26,19 @@ advisories:
           type: vulnerable-code-version-not-used
           note: This package uses a newer version v2.10.14 when the vulnerable code affects an older version.
 
+  - id: CGA-3gq8-gw2r-w388
+    aliases:
+      - CVE-2025-30215
+    events:
+      - timestamp: 2025-04-03T10:11:02Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Upstream has acknowledged the vulnerability (CVE-2025-30215) and published a **binary-only** release that includes a fix binary. However, this binary appears to have been hand-crafted outside of their usual CI process and does not correspond to any visible source code changes or official versioned release in the repository.
+            Since Chainguard builds all packages from source, and no corresponding code changes have been published or tagged, we are unable to apply the remediation at this time.
+            Although the upstream has recommended temporarily using their pre-built binary for workflows that depend on the fix, this does not satisfy our security and reproducibility standards. 
+            Therefore, we are marking this CVE as **pending-upstream-fix** until an official source-based release with the necessary patches is available
+
   - id: CGA-47cc-r2mp-w98x
     aliases:
       - CVE-2024-24783


### PR DESCRIPTION
Upstream has released a binary-only fix outside their CI process. No corresponding source code changes are available, so we cannot apply the remediation. Marking as pending-upstream-fix until an official source release is made.

