### PR TITLE
fix: Revert "Adding detection events for harbor-2.11 (#13808)"

### DIFF
--- a/harbor-2.11.advisories.yaml
+++ b/harbor-2.11.advisories.yaml
@@ -26,42 +26,6 @@ advisories:
         data:
           fixed-version: 2.11.1-r1
 
-  - id: CGA-25vq-qj22-94hr
-    aliases:
-      - CVE-2025-27144
-      - GHSA-c6gw-w398-hv78
-    events:
-      - timestamp: 2025-03-05T21:38:25Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: harbor-2.11
-            componentID: a2eb07c49def7510
-            componentName: github.com/go-jose/go-jose/v4
-            componentVersion: v4.0.1
-            componentType: go-module
-            componentLocation: /usr/bin/harbor-core
-            scanner: grype
-
-  - id: CGA-27p4-q7c2-qqv8
-    aliases:
-      - CVE-2025-22866
-      - GHSA-3whm-j4xm-rv8x
-    events:
-      - timestamp: 2025-03-05T21:38:37Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: harbor-2.11
-            componentID: fd62ecddfe72e8e7
-            componentName: stdlib
-            componentVersion: go1.23.2
-            componentType: go-module
-            componentLocation: /usr/bin/harbor-jobservice
-            scanner: grype
-
   - id: CGA-2rfh-f76g-2qr8
     aliases:
       - CVE-2024-40464
@@ -88,24 +52,6 @@ advisories:
         data:
           note: This vulnerability can not be remediated by upgrading beego without making additional changes to Harbor. Upstream has merged a fix on main, but this hasn't been backported to released versions of Harbor.
 
-  - id: CGA-4rfp-5r6h-ggwh
-    aliases:
-      - CVE-2024-45338
-      - GHSA-w32m-9786-jp63
-    events:
-      - timestamp: 2025-03-05T21:38:11Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: harbor-2.11
-            componentID: c3982dfaabad63cb
-            componentName: golang.org/x/net
-            componentVersion: v0.24.0
-            componentType: go-module
-            componentLocation: /usr/bin/harbor-jobservice
-            scanner: grype
-
   - id: CGA-4wfp-cpjm-549m
     aliases:
       - CVE-2024-41110
@@ -127,24 +73,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.11.0-r2
-
-  - id: CGA-6473-x38m-6vc8
-    aliases:
-      - CVE-2024-45341
-      - GHSA-3f6r-qh9c-x6mm
-    events:
-      - timestamp: 2025-03-05T21:38:33Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: harbor-2.11
-            componentID: fd62ecddfe72e8e7
-            componentName: stdlib
-            componentVersion: go1.23.2
-            componentType: go-module
-            componentLocation: /usr/bin/harbor-jobservice
-            scanner: grype
 
   - id: CGA-67c8-fqfw-q4q6
     aliases:
@@ -182,23 +110,6 @@ advisories:
         data:
           fixed-version: 2.11.0-r1
 
-  - id: CGA-9c6f-8g42-2hrj
-    aliases:
-      - CVE-2025-22869
-    events:
-      - timestamp: 2025-03-05T21:38:15Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: harbor-2.11
-            componentID: df849c512a2187e2
-            componentName: golang.org/x/crypto
-            componentVersion: v0.22.0
-            componentType: go-module
-            componentLocation: /usr/bin/harbor-jobservice
-            scanner: grype
-
   - id: CGA-9mjp-rrcf-5q2j
     aliases:
       - CVE-2024-34158
@@ -221,60 +132,6 @@ advisories:
         data:
           fixed-version: 2.11.1-r1
 
-  - id: CGA-c2g9-5qm5-m8qh
-    aliases:
-      - CVE-2024-55885
-      - GHSA-9j3m-fr7q-jxfw
-    events:
-      - timestamp: 2025-03-05T21:38:18Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: harbor-2.11
-            componentID: f6b04917dfbc1350
-            componentName: github.com/beego/beego/v2
-            componentVersion: v2.0.6
-            componentType: go-module
-            componentLocation: /usr/bin/harbor-jobservice
-            scanner: grype
-
-  - id: CGA-fj5v-xwr4-4f8w
-    aliases:
-      - CVE-2024-45336
-      - GHSA-7wrw-r4p8-38rx
-    events:
-      - timestamp: 2025-03-05T21:38:29Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: harbor-2.11
-            componentID: fd62ecddfe72e8e7
-            componentName: stdlib
-            componentVersion: go1.23.2
-            componentType: go-module
-            componentLocation: /usr/bin/harbor-jobservice
-            scanner: grype
-
-  - id: CGA-hmfv-g434-76fh
-    aliases:
-      - CVE-2024-45337
-      - GHSA-v778-237x-gjrc
-    events:
-      - timestamp: 2025-03-05T21:38:09Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: harbor-2.11
-            componentID: df849c512a2187e2
-            componentName: golang.org/x/crypto
-            componentVersion: v0.22.0
-            componentType: go-module
-            componentLocation: /usr/bin/harbor-jobservice
-            scanner: grype
-
   - id: CGA-v6j3-j59q-625x
     aliases:
       - CVE-2024-34156
@@ -296,23 +153,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.11.1-r1
-
-  - id: CGA-vqrg-c8xm-w87v
-    aliases:
-      - CVE-2025-22868
-    events:
-      - timestamp: 2025-03-05T21:38:21Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: harbor-2.11
-            componentID: 488519e69e719735
-            componentName: golang.org/x/oauth2
-            componentVersion: v0.19.0
-            componentType: go-module
-            componentLocation: /usr/bin/harbor-core
-            scanner: grype
 
   - id: CGA-wv7m-7w62-684j
     aliases:


### PR DESCRIPTION
This reverts commit c0b5a36d1ce31e621ef0da0972c8ac3ad0f3f923.

These harbor-2.11 APKs in wolfi-dev/os were scanned in error and should not have resulted in new detection events.

harbor-2.11 is now maintained in entperise-packages where these CVEs have been remediated.

Signed-off-by: philroche <phil.roche@chainguard.dev>
