### PR TITLE
fix: argo-cd-2.13 GHSA-274v-mgcv-cm8j re-application of pending-upstream-fix advisory

### DIFF
--- a/argo-cd-2.13.advisories.yaml
+++ b/argo-cd-2.13.advisories.yaml
@@ -84,6 +84,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/local/bin/argocd
             scanner: grype
+      - timestamp: 2025-04-03T15:59:47Z
+        type: pending-upstream-fix
+        data:
+          note: pending-upstream-fix is still applicable. The gitops-engine@v0.7.3 has breaking changes, upstream maintainers will have to address required changes from version v0.7.1-0.20250129155113-faf5a4e5c37d.'
 
   - id: CGA-gc77-5phf-vxm8
     aliases:


### PR DESCRIPTION
A valid redetection with detection type go-module was added and upon investigation pending-upstream-fix is still applicable

> pending-upstream-fix is still applicable. The gitops-engine@v0.7.3 has breaking changes, upstream maintainers will have to address required changes from version v0.7.1-0.20250129155113-faf5a4e5c37d.'

Signed-off-by: philroche <phil.roche@chainguard.dev>
