### PR TITLE
fix: Revert "Adding detection events for istio-cni-1.22 (#13785)"

### DIFF
--- a/istio-cni-1.22.advisories.yaml
+++ b/istio-cni-1.22.advisories.yaml
@@ -4,24 +4,6 @@ package:
   name: istio-cni-1.22
 
 advisories:
-  - id: CGA-43ff-g8mq-29px
-    aliases:
-      - CVE-2024-34155
-      - GHSA-8xfx-rj4p-23jm
-    events:
-      - timestamp: 2025-03-05T20:06:30Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: 8d0493e39756dfb2
-            componentName: stdlib
-            componentVersion: go1.22.5
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype
-
   - id: CGA-55rm-hr69-g5jx
     aliases:
       - CVE-2021-39155
@@ -44,59 +26,6 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/istio-cni. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.9.8).'
-
-  - id: CGA-64xh-m975-8457
-    aliases:
-      - CVE-2025-22869
-    events:
-      - timestamp: 2025-03-05T20:06:23Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: 6b951bac4a5c7a47
-            componentName: golang.org/x/crypto
-            componentVersion: v0.22.0
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype
-
-  - id: CGA-7h38-g6cr-qrx4
-    aliases:
-      - CVE-2024-45338
-      - GHSA-w32m-9786-jp63
-    events:
-      - timestamp: 2025-03-05T20:06:16Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: 192ac541faccf21c
-            componentName: golang.org/x/net
-            componentVersion: v0.24.0
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype
-
-  - id: CGA-85hx-fm24-xq9q
-    aliases:
-      - CVE-2024-34156
-      - GHSA-crqm-pwhx-j97f
-    events:
-      - timestamp: 2025-03-05T20:06:34Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: 8d0493e39756dfb2
-            componentName: stdlib
-            componentVersion: go1.22.5
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype
 
   - id: CGA-999g-pr48-j5mw
     aliases:
@@ -144,23 +73,6 @@ advisories:
           type: vulnerable-code-version-not-used
           note: This vulnerability affects versions < 1.14.1, but the installed commit corresponds to version 1.21.2.
 
-  - id: CGA-9m7v-mchq-j7f5
-    aliases:
-      - CVE-2025-22868
-    events:
-      - timestamp: 2025-03-05T20:06:19Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: ae1b249bf64d5b10
-            componentName: golang.org/x/oauth2
-            componentVersion: v0.19.0
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype
-
   - id: CGA-c2f3-pv49-vw65
     aliases:
       - CVE-2024-24790
@@ -180,24 +92,6 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.22.0-r3
-
-  - id: CGA-cqr7-9578-98qm
-    aliases:
-      - CVE-2024-34158
-      - GHSA-j7vj-rw65-4v26
-    events:
-      - timestamp: 2025-03-05T20:06:38Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: 8d0493e39756dfb2
-            componentName: stdlib
-            componentVersion: go1.22.5
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype
 
   - id: CGA-fr3q-v7p5-fcq9
     aliases:
@@ -221,42 +115,6 @@ advisories:
         data:
           type: vulnerable-code-version-not-used
           note: 'This vulnerability was matched to the module "istio.io/istio" at the following location(s): /usr/bin/istio-cni. In all cases, the installed version of the module (git commit ed90e14d3473bc3fe54f98298eb16664002d14d1) corresponds to a version tag (1.21.2) that is later than the fixed version (1.11.7).'
-
-  - id: CGA-g95v-frqc-f9xv
-    aliases:
-      - CVE-2024-45337
-      - GHSA-v778-237x-gjrc
-    events:
-      - timestamp: 2025-03-05T20:06:13Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: 6b951bac4a5c7a47
-            componentName: golang.org/x/crypto
-            componentVersion: v0.22.0
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype
-
-  - id: CGA-q3v2-9653-jcvc
-    aliases:
-      - CVE-2024-45341
-      - GHSA-3f6r-qh9c-x6mm
-    events:
-      - timestamp: 2025-03-05T20:06:47Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: 8d0493e39756dfb2
-            componentName: stdlib
-            componentVersion: go1.22.5
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype
 
   - id: CGA-q7pc-wj96-h86j
     aliases:
@@ -290,57 +148,3 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.22.2-r1
-
-  - id: CGA-rpj9-2fwq-32gw
-    aliases:
-      - CVE-2025-27144
-      - GHSA-c6gw-w398-hv78
-    events:
-      - timestamp: 2025-03-05T20:06:26Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: 84ce7a16c293ae19
-            componentName: github.com/go-jose/go-jose/v3
-            componentVersion: v3.0.3
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype
-
-  - id: CGA-w3mp-wgqv-8ff6
-    aliases:
-      - CVE-2024-45336
-      - GHSA-7wrw-r4p8-38rx
-    events:
-      - timestamp: 2025-03-05T20:06:42Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: 8d0493e39756dfb2
-            componentName: stdlib
-            componentVersion: go1.22.5
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype
-
-  - id: CGA-w69g-3mf4-5wm7
-    aliases:
-      - CVE-2025-22866
-      - GHSA-3whm-j4xm-rv8x
-    events:
-      - timestamp: 2025-03-05T20:06:52Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: istio-cni-1.22
-            componentID: 8d0493e39756dfb2
-            componentName: stdlib
-            componentVersion: go1.22.5
-            componentType: go-module
-            componentLocation: /usr/bin/istio-cni
-            scanner: grype


### PR DESCRIPTION
This reverts commit faf64401dd04ec8695b9ef9ba48423e2440b10f9.

These istio-cni-1.22 APKs in wolfi-dev/os were scanned in error and should not have resulted in new detection events.

istio-cni-1.22 is now maintained in entperise-packages where these CVEs have been remediated.

Signed-off-by: philroche <phil.roche@chainguard.dev>
