### PR TITLE
Nack GHSA-3wgm-2gw2-vh5m in all components that import kubernetes.

### DIFF
--- a/argo-cd-2.14.advisories.yaml
+++ b/argo-cd-2.14.advisories.yaml
@@ -25,6 +25,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:29:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-3fhp-pq8h-x539
     aliases:

--- a/argo-rollouts.advisories.yaml
+++ b/argo-rollouts.advisories.yaml
@@ -25,6 +25,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:29:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-4x3w-pm5j-g8x7
     aliases:

--- a/argocd-image-updater.advisories.yaml
+++ b/argocd-image-updater.advisories.yaml
@@ -270,6 +270,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:29:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-hrx6-hvq8-xj45
     aliases:

--- a/aws-efs-csi-driver.advisories.yaml
+++ b/aws-efs-csi-driver.advisories.yaml
@@ -322,6 +322,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:29:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-fp69-p6mm-6mp5
     aliases:

--- a/azuredisk-csi-1.31.advisories.yaml
+++ b/azuredisk-csi-1.31.advisories.yaml
@@ -121,6 +121,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:30:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-hcjv-vr4m-rwhf
     aliases:

--- a/calico-3.29.advisories.yaml
+++ b/calico-3.29.advisories.yaml
@@ -136,6 +136,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: CVE-2025-1767 requires k8s.io/kubernetes to be updated to >= 1.32.3. This results in build failures with other pinned packages. Upstream maintainers will have to update.
+      - timestamp: 2025-04-06T22:30:09Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-vh33-8gwv-88qv
     aliases:

--- a/cluster-autoscaler-1.32.advisories.yaml
+++ b/cluster-autoscaler-1.32.advisories.yaml
@@ -244,6 +244,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:30:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-ww6g-qj5c-3vcw
     aliases:

--- a/docker-machine-driver-harvester.advisories.yaml
+++ b/docker-machine-driver-harvester.advisories.yaml
@@ -110,6 +110,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine-driver-harvester
             scanner: grype
+      - timestamp: 2025-04-06T22:30:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-r58v-r9v9-q57g
     aliases:

--- a/emissary.advisories.yaml
+++ b/emissary.advisories.yaml
@@ -214,6 +214,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:30:35Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-rgmr-3fw8-8v5j
     aliases:

--- a/ip-masq-agent.advisories.yaml
+++ b/ip-masq-agent.advisories.yaml
@@ -258,6 +258,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:30:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-gq4c-2cm9-vj4j
     aliases:

--- a/k8ssandra-client.advisories.yaml
+++ b/k8ssandra-client.advisories.yaml
@@ -79,6 +79,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:30:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-cjwf-2wfq-3rg6
     aliases:

--- a/kapp.advisories.yaml
+++ b/kapp.advisories.yaml
@@ -35,6 +35,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:31:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-3hvm-mf5g-45mx
     aliases:

--- a/kubernetes-csi-driver-hostpath.advisories.yaml
+++ b/kubernetes-csi-driver-hostpath.advisories.yaml
@@ -311,6 +311,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/hostpathplugin
             scanner: grype
+      - timestamp: 2025-04-06T22:33:01Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-rh83-9w4h-m426
     aliases:

--- a/kubernetes-csi-driver-nfs.advisories.yaml
+++ b/kubernetes-csi-driver-nfs.advisories.yaml
@@ -116,4 +116,9 @@ advisories:
       - timestamp: 2025-03-20T23:59:11Z
         type: pending-upstream-fix
         data:
-          note: 'The k8s.io CVE affecting this package is still under upstream triage. See the related PR at https://github.com/kubernetes/kubernetes/issues/130786. The current upstream build remains on kubernetes@v1.31.x to retain support for k8s.io/kubelet/pkg/apis/dra/v1beta1, which was removed in v1.32.x.'
+          note: The k8s.io CVE affecting this package is still under upstream triage. See the related PR at https://github.com/kubernetes/kubernetes/issues/130786. The current upstream build remains on kubernetes@v1.31.x to retain support for k8s.io/kubelet/pkg/apis/dra/v1beta1, which was removed in v1.32.x.
+      - timestamp: 2025-04-06T22:31:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.

--- a/kubernetes-dns-node-cache.advisories.yaml
+++ b/kubernetes-dns-node-cache.advisories.yaml
@@ -559,3 +559,8 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:31:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.

--- a/local-static-provisioner.advisories.yaml
+++ b/local-static-provisioner.advisories.yaml
@@ -145,6 +145,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:31:43Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-86m7-vm4x-8jhv
     aliases:

--- a/node-feature-discovery-0.17.advisories.yaml
+++ b/node-feature-discovery-0.17.advisories.yaml
@@ -121,6 +121,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:31:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-vhfc-6c55-jwhp
     aliases:

--- a/nodetaint.advisories.yaml
+++ b/nodetaint.advisories.yaml
@@ -501,6 +501,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:32:00Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-p6xx-pg8g-64f3
     aliases:

--- a/rancher-agent-2.10.advisories.yaml
+++ b/rancher-agent-2.10.advisories.yaml
@@ -25,6 +25,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: CVE-2025-1767 requires k8s.io/kubernetes to be updated to >= 1.32.3, which requires upstream changes to support.
+      - timestamp: 2025-04-06T22:32:08Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-325m-78cw-f6q3
     aliases:

--- a/rancher-fleet.advisories.yaml
+++ b/rancher-fleet.advisories.yaml
@@ -47,6 +47,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This CVE only affects Kubernetes clusters that utilize the in-tree gitRepo volume to clone git repositories from other pods within the same node and there is no fixed version available yet.
+      - timestamp: 2025-04-06T22:32:17Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-6792-qph2-q47p
     aliases:

--- a/rancher-system-agent.advisories.yaml
+++ b/rancher-system-agent.advisories.yaml
@@ -21,3 +21,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/rancher-system-agent
             scanner: grype
+      - timestamp: 2025-04-06T22:32:25Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.

--- a/rancher-webhook-0.6.advisories.yaml
+++ b/rancher-webhook-0.6.advisories.yaml
@@ -68,6 +68,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:32:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-gr5h-992v-c263
     aliases:

--- a/spark-operator.advisories.yaml
+++ b/spark-operator.advisories.yaml
@@ -730,6 +730,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.1.1-r0
+      - timestamp: 2025-04-06T22:32:42Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-x87p-5crv-79j5
     aliases:

--- a/yunikorn-k8shim.advisories.yaml
+++ b/yunikorn-k8shim.advisories.yaml
@@ -90,6 +90,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The k8s.io CVE affecting this package is currently in the triage stage upstream, PR on the issue can be found here: https://github.com/kubernetes/kubernetes/issues/130786'
+      - timestamp: 2025-04-06T22:32:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-937q-xhxh-m54v
     aliases:


### PR DESCRIPTION
The vulnerability is in the git repo provisioner, not the client.