### PR TITLE
minio: add fixed event for GHSA-wg47-6jq2-q2hh

### DIFF
--- a/minio.advisories.yaml
+++ b/minio.advisories.yaml
@@ -108,6 +108,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-04-07T07:37:47Z
+        type: fixed
+        data:
+          fixed-version: 0.20250403.145628-r0
 
   - id: CGA-54fm-xgf9-w295
     aliases:


### PR DESCRIPTION
It seems that our automation detected
https://github.com/advisories/GHSA-wg47-6jq2-q2hh as not being fixed since the versions there do not match what we have. Upstream has pointed to the advisory
https://github.com/minio/minio/security/advisories/GHSA-wg47-6jq2-q2hh which points to the version we have in our package and was merged on: https://github.com/wolfi-dev/os/pull/48995 hence marked as fixed.