### PR TITLE
docker-machine-driver-harvester: advisories

### DIFF
--- a/docker-machine-driver-harvester.advisories.yaml
+++ b/docker-machine-driver-harvester.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine-driver-harvester
             scanner: grype
+      - timestamp: 2025-04-08T08:32:12Z
+        type: pending-upstream-fix
+        data:
+          note: "rancher-machine is fork of docker/machine and uses quite old 1.4.2 version of moby/moby dependency that released at 2017. Bumping the moby/moby package to newer versions resulting build failure and we can't mitigate this. "
 
   - id: CGA-5c8h-9m53-6x9c
     aliases:
@@ -39,6 +43,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine-driver-harvester
             scanner: grype
+      - timestamp: 2025-04-08T08:32:12Z
+        type: pending-upstream-fix
+        data:
+          note: "rancher-machine is fork of docker/machine and uses quite old 1.4.2 version of moby/moby dependency that released at 2017. Bumping the moby/moby package to newer versions resulting build failure and we can't mitigate this. "
 
   - id: CGA-7j28-9jxf-qh5j
     aliases:
@@ -57,6 +65,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine-driver-harvester
             scanner: grype
+      - timestamp: 2025-04-08T08:32:12Z
+        type: pending-upstream-fix
+        data:
+          note: "rancher-machine is fork of docker/machine and uses quite old 1.4.2 version of moby/moby dependency that released at 2017. Bumping the moby/moby package to newer versions resulting build failure and we can't mitigate this. "
 
   - id: CGA-f89j-xj7w-9fpx
     aliases:
@@ -74,6 +86,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine-driver-harvester
             scanner: grype
+      - timestamp: 2025-04-08T08:32:12Z
+        type: pending-upstream-fix
+        data:
+          note: "rancher-machine is fork of docker/machine and uses quite old 1.4.2 version of moby/moby dependency that released at 2017. Bumping the moby/moby package to newer versions resulting build failure and we can't mitigate this. "
 
   - id: CGA-h5xq-3x49-2948
     aliases:
@@ -92,6 +108,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine-driver-harvester
             scanner: grype
+      - timestamp: 2025-04-08T08:32:12Z
+        type: pending-upstream-fix
+        data:
+          note: "rancher-machine is fork of docker/machine and uses quite old 1.4.2 version of moby/moby dependency that released at 2017. Bumping the moby/moby package to newer versions resulting build failure and we can't mitigate this. "
 
   - id: CGA-j3q4-7jmq-cg47
     aliases:
@@ -133,6 +153,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine-driver-harvester
             scanner: grype
+      - timestamp: 2025-04-08T08:32:12Z
+        type: pending-upstream-fix
+        data:
+          note: "rancher-machine is fork of docker/machine and uses quite old 1.4.2 version of moby/moby dependency that released at 2017. Bumping the moby/moby package to newer versions resulting build failure and we can't mitigate this. "
 
   - id: CGA-r9gh-4c9m-fm8g
     aliases:
@@ -151,6 +175,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine-driver-harvester
             scanner: grype
+      - timestamp: 2025-04-08T08:32:12Z
+        type: pending-upstream-fix
+        data:
+          note: "rancher-machine is fork of docker/machine and uses quite old 1.4.2 version of moby/moby dependency that released at 2017. Bumping the moby/moby package to newer versions resulting build failure and we can't mitigate this. "
 
   - id: CGA-w634-mr5c-5558
     aliases:
@@ -169,6 +197,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine-driver-harvester
             scanner: grype
+      - timestamp: 2025-04-08T08:32:12Z
+        type: pending-upstream-fix
+        data:
+          note: "rancher-machine is fork of docker/machine and uses quite old 1.4.2 version of moby/moby dependency that released at 2017. Bumping the moby/moby package to newer versions resulting build failure and we can't mitigate this. "
 
   - id: CGA-w8pq-jcf9-5g85
     aliases:
@@ -187,3 +219,8 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine-driver-harvester
             scanner: grype
+      - timestamp: 2025-04-08T08:32:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: v1.4.2 version of moby/moby dependency does not contain WriteProgress() func in the streamformatter.go file.


### PR DESCRIPTION
Mostly same as: https://github.com/wolfi-dev/advisories/pull/16717

```
wolfictl advisory copy rancher-machine docker-machine-driver-harvester
```