### PR TITLE
feat(advisory): kubernetes-1.31 fix-not-planned GHSA-v778-237x-gjrc

### DIFF
--- a/kubernetes-1.31.advisories.yaml
+++ b/kubernetes-1.31.advisories.yaml
@@ -201,6 +201,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kube-controller-manager-1.31
             scanner: grype
+      - timestamp: 2025-04-09T14:12:44Z
+        type: fix-not-planned
+        data:
+          note: With the introduction of Kubernetes-1.32, Kubernetes-1.31 has migrated to enterprise packages and has been remediated in enterprise-packages and there is no intention to backport to the kubernetes-1.31 package. Customers should use kubernetes-1.32.
 
   - id: CGA-9337-73g8-2x2j
     aliases:


### PR DESCRIPTION
> With the introduction of Kubernetes-1.32, Kubernetes-1.31 has migrated to enterprise packages and has been
> remediated in enterprise-packages and there is no intention to backport to the kubernetes-1.31 package.
> Customers should use kubernetes-1.32.

Signed-off-by: philroche <phil.roche@chainguard.dev>
