### PR TITLE
cargo-c-0.10.12/advisory update

### DIFF
--- a/cargo-c.advisories.yaml
+++ b/cargo-c.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/cargo-capi
             scanner: grype
+      - timestamp: 2025-04-09T20:28:24Z
+        type: pending-upstream-fix
+        data:
+          note: 'upstream maintainers have pinned gix to version 0.70.0 due to testing issues. All other associated gix-xxx packages are also pinned and cannot be upgraded independently due to restrictions. Source: https://github.com/rust-lang/cargo/pull/15391'
 
   - id: CGA-m6pp-f2j6-wwpp
     aliases:


### PR DESCRIPTION
added cargo-c advisories for CVE-2025-31130/GHSA-2frx-2596-x5r6 gix issue. Upstream maintainers attempted a [fix](https://github.com/rust-lang/cargo/pull/15391) but tests failed. They will most like remove the gix tests at some point in the very near future but this needs to be an upstream fix since gix and it's transitive dependencies and packages are very closely tide to each other. 