### PR TITLE
zola/GHSA-rr8g-9fpq-6wmg advisory update

### DIFF
--- a/zola.advisories.yaml
+++ b/zola.advisories.yaml
@@ -79,6 +79,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zola
             scanner: grype
+      - timestamp: 2025-04-10T02:11:58Z
+        type: pending-upstream-fix
+        data:
+          note: A Pull Request with a fix has been provided over a year ago but the maintainer seems to be unreachable and the last release of atty was almost 3 years ago. We must wait for upstream maintainers to approve and merge this request.
 
   - id: CGA-hf34-7v39-6pvq
     aliases:


### PR DESCRIPTION
## 1. **GHSA-rr8g-9fpq-6wmg**
- **pending-upstream-fix:** A Pull Request with a fix has been provided over a year ago but the maintainer seems to be unreachable and the last release of atty was almost 3 years ago. We must wait for upstream maintainers to approve and merge this request.
