### PR TITLE
cargo-audit: GHSA-2frx-2596-x5r6 advisory update

### DIFF
--- a/cargo-audit.advisories.yaml
+++ b/cargo-audit.advisories.yaml
@@ -65,6 +65,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/cargo-audit
             scanner: grype
+      - timestamp: 2025-04-10T07:42:21Z
+        type: pending-upstream-fix
+        data:
+          note: Rustsec-admin currently has the gix dependency locked at version 0.70.0, any attempt to update it will cause a breaking change. Upstream maintainers will have to provide a fix by bumping gix to 0.71.0.
 
   - id: CGA-467g-5xq8-cmgr
     aliases:


### PR DESCRIPTION
Unfortunately we are unable to bump gix to 0.71.0 or any of the other gix packages as upstream has it locked to 0.70.0.
We will need to wait for upstream to bump the version to provide the fix.