### PR TITLE
sccache: update rsa advisories

### DIFF
--- a/sccache.advisories.yaml
+++ b/sccache.advisories.yaml
@@ -64,6 +64,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/sccache
             scanner: grype
+      - timestamp: 2025-04-10T08:08:47Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability is related to the 'rsa' dependency, of which sccache is already installing the most recent version (0.9.6).
+            There is no release of 'rsa' today with a fix for this vulnerability. The RSA GitHub project repo is working on pre-releases, so a fix may be expected soon.
+            Waiting for upstream (RSA) to cut a new release with a fix, and for sccache to consume.
 
   - id: CGA-7c85-4m6q-cpmq
     aliases:
@@ -98,6 +105,13 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/sccache
             scanner: grype
+      - timestamp: 2025-04-10T08:08:47Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability is related to the 'rsa' dependency, of which sccache is already installing the most recent version (0.9.6).
+            There is no release of 'rsa' today with a fix for this vulnerability. The RSA GitHub project repo is working on pre-releases, so a fix may be expected soon.
+            Waiting for upstream (RSA) to cut a new release with a fix, and for sccache to consume.
 
   - id: CGA-gmh6-7j6c-32rw
     aliases:


### PR DESCRIPTION
Update advisories for GHSA-4grx-2x9w-596c and GHSA-c38w-74pg-36hr We are still pending RSA to cut a release with a fix.