### PR TITLE
graphicsmagick/CVE-2025-32460 advisory update

### DIFF
--- a/graphicsmagick.advisories.yaml
+++ b/graphicsmagick.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: graphicsmagick
 
 advisories:
+  - id: CGA-6296-mxv7-3h5m
+    aliases:
+      - CVE-2025-32460
+      - GHSA-hf7q-qx98-4hm7
+    events:
+      - timestamp: 2025-04-14T20:14:56Z
+        type: pending-upstream-fix
+        data:
+          note: 'This CVE affects GraphicsMagick before 8e56520 and does not yet have a fix released. More information can be found on the GitHub advisory page here: https://github.com/advisories/GHSA-hf7q-qx98-4hm7'
+
   - id: CGA-7hmm-3v66-q84h
     aliases:
       - CVE-2008-6621


### PR DESCRIPTION
## 1. **CVE-2025-32460**
- **pending-upstream-fix:** This CVE affects GraphicsMagick before 8e56520 and does not yet have a fix released. More information can be found on the GitHub advisory page here: https://github.com/advisories/GHSA-hf7q-qx98-4hm7