### PR TITLE
newrelic-fluent-bit-output: update CVE-2025-22871 advisory

### DIFF
--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: go-module
             componentLocation: /fluent-bit/bin/out_newrelic.so
             scanner: grype
+      - timestamp: 2025-04-15T06:17:47Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability cannot be fixed because golang version is pinned to 1.20 for this package.
 
   - id: CGA-348r-36vh-527w
     aliases:


### PR DESCRIPTION
Package has go1.20 pinned and cannot be updated to remediate the CVE.