### PR TITLE
jitsucom-jitsu: add advisory for CVE-2025-22871

### DIFF
--- a/jitsucom-jitsu.advisories.yaml
+++ b/jitsucom-jitsu.advisories.yaml
@@ -59,6 +59,16 @@ advisories:
         data:
           fixed-version: 2.8.5-r0
 
+  - id: CGA-8q9x-xfcc-6grq
+    aliases:
+      - CVE-2025-22871
+      - GHSA-g9pc-8g42-g6vq
+    events:
+      - timestamp: 2025-04-15T16:53:39Z
+        type: pending-upstream-fix
+        data:
+          note: 'The package currently builds esbuild from upstream which is compiled with go1.23.7. There is already an issue open in esbuild to update go to 1.23.8: https://github.com/evanw/esbuild/issues/4133'
+
   - id: CGA-9ph2-9r6m-2j4q
     aliases:
       - CVE-2024-39338


### PR DESCRIPTION
Currently the package is pulling esbuild from npm and building it locally. This also brings esbuild from upstream which is currently compiled using go1.23.7.
esbuild already has an issue and PR open to have this fixed.
More details here: https://github.com/evanw/esbuild/issues/4133