### PR TITLE
temporal/temporal-ui-server: update advisory for CVE-2025-30204

### DIFF
--- a/temporal-ui-server.advisories.yaml
+++ b/temporal-ui-server.advisories.yaml
@@ -332,6 +332,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/ui-server
             scanner: grype
+      - timestamp: 2025-04-16T12:40:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: The Function `parse.ParseUnverified` which is the vulnerable function for this CVE, is not used in any of the temporal-ui-server code.
 
   - id: CGA-qjh2-8m68-grrw
     aliases:

--- a/temporal.advisories.yaml
+++ b/temporal.advisories.yaml
@@ -494,6 +494,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/temporal
             scanner: grype
+      - timestamp: 2025-04-16T12:39:18Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: The Function `parse.ParseUnverified` which is the vulnerable function for this CVE, is not used in any of the temporal code.
 
   - id: CGA-qw4f-5m8f-q3w8
     aliases:


### PR DESCRIPTION
As per GHSA-mh63-6h87-95cp the vulnerable code is in the `parse.ParseUnverified` function, and it is currently not used by temporal or temporal-ui-server.


```
╭─dnegreira@cg-vm-dev ~/git/upstream/temporal/ui-server ‹v2.37.1›
╰─$ git remote -v
origin	https://github.com/temporalio/ui-server (fetch)
origin	https://github.com/temporalio/ui-server (push)
╭─dnegreira@cg-vm-dev ~/git/upstream/temporal/ui-server ‹v2.37.1›
╰─$ git describe --exact-match --tags
v2.37.1
╭─dnegreira@cg-vm-dev ~/git/upstream/temporal/ui-server ‹v2.37.1›
╰─$ grep -ri ParseUnverified
╭─dnegreira@cg-vm-dev ~/git/upstream/temporal/ui-server ‹v2.37.1›
╰─$ 
```

https://github.com/search?q=repo%3Atemporalio%2Fui-server%20ParseUnverified&type=code