### PR TITLE
argo-workflows/GHSA-hmp7-x699-cvhq-advisory-update

### DIFF
--- a/argo-workflows.advisories.yaml
+++ b/argo-workflows.advisories.yaml
@@ -1557,3 +1557,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/workflow-controller
             scanner: grype
+      - timestamp: 2025-04-16T20:23:25Z
+        type: pending-upstream-fix
+        data:
+          note: 'Upgrading argo-events to 1.9.6 requires the following work to be approved and merged into upstream main, upgrading go from 1.23.x to 1.24.x: https://github.com/argoproj/argo-workflows/pull/14385 and several functional changes here: https://github.com/argoproj/argo-workflows/pull/14395/files A GitHub issue encompassing both requirements can be found here: https://github.com/issues/created?issue=argoproj%7Cargo-workflows%7C14394'


### PR DESCRIPTION
## 1. **GHSA-hmp7-x699-cvhq**
- **pending-upstream-fix:** Upgrading argo-events to 1.9.6 requires the following work to be approved and merged into upstream main, [upgrading go from 1.23.x to 1.24.x ](https://github.com/argoproj/argo-workflows/pull/14385) and several [functional changes here.](https://github.com/argoproj/argo-workflows/pull/14395/files) A GitHub issue encompassing both requirements [can be found here](https://github.com/issues/created?issue=argoproj%7Cargo-workflows%7C14394)