### PR TITLE
teleport-17.4.3/adv update

### DIFF
--- a/teleport.advisories.yaml
+++ b/teleport.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/local/bin/teleport
             scanner: grype
+      - timestamp: 2025-04-16T23:01:57Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: '"teleport 17.4.3 includes ch-go v0.62.0; however the vulnerable code is not in the execution path. Upstream has patched code in mainline but has not yet cut a new release." '
 
   - id: CGA-35qq-v4x7-g8hr
     aliases:


### PR DESCRIPTION
- added false positive for CVE-2025-1386
- go binary was verified with govulncheck