### PR TITLE
kubevela: update advisory for CVE-2025-32387

### DIFF
--- a/kubevela.advisories.yaml
+++ b/kubevela.advisories.yaml
@@ -779,3 +779,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/manager
             scanner: grype
+      - timestamp: 2025-04-17T11:28:03Z
+        type: pending-upstream-fix
+        data:
+          note: Kubevela 1.10.2 depends on Helm v3.14.4 https://github.com/kubevela/kubevela/blob/424e433963551eac070b4369829c4c674fce7ff1/go.mod\#L79 - Upgrading to Helm v3.17.3, which addresses this vulnerability, causes build failures due to API incompatibilities. Upstream changes are required to ensure compatibility with the newer Helm version.


### PR DESCRIPTION
When we try top bump helm on kubevela, we start having build issues do to API incompatibilities, we have to wait for upstream to bump the version of the helm dependency in order to remediate this CVE.