### PR TITLE
k8ssandra-client-fips: update advisory for GHSA-4hfp-h4cw-hj8p

### DIFF
--- a/k8ssandra-client.advisories.yaml
+++ b/k8ssandra-client.advisories.yaml
@@ -97,6 +97,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubectl-k8ssandra
             scanner: grype
+      - timestamp: 2025-04-17T12:09:36Z
+        type: pending-upstream-fix
+        data:
+          note: K8ssandra-client 0.6.4 depends on Helm v3.14.2 https://github.com/k8ssandra/k8ssandra-client/blob/837b13f687e28c2e2188171bbb9dea26f70c2bbe/go.mod\#L25 - Upgrading to Helm v3.17.3, which addresses this vulnerability, causes build failures due to API incompatibilities. Upstream changes are required to ensure compatibility with the newer Helm version.
 
   - id: CGA-93jw-pr5g-5vjc
     aliases:


### PR DESCRIPTION
We are currently unable to bump the helm version to 3.17.3 as it errors out due to incompatible API changes in k8s.io/api.