### PR TITLE
Update samba advisories

### DIFF
--- a/samba.advisories.yaml
+++ b/samba.advisories.yaml
@@ -121,6 +121,11 @@ advisories:
         type: true-positive-determination
         data:
           note: Issue has been found in all 4.x versions of samba, Upstream has no plan to resolve.
+      - timestamp: 2025-04-17T15:28:12Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This issue was fixed upstream in version 4.17.0. See https://gitlab.com/samba-team/samba/-/commit/15c86028a861139cee4560fe093c965ffc30eb13
 
   - id: CGA-92mp-q8q9-xcp2
     aliases:

--- a/samba.advisories.yaml
+++ b/samba.advisories.yaml
@@ -169,6 +169,10 @@ advisories:
         type: true-positive-determination
         data:
           note: 'Fix must be delivered by upstream, PR is two years old: https://gitlab.com/samba-team/samba/-/merge_requests/2778'
+      - timestamp: 2025-04-17T14:26:28Z
+        type: pending-upstream-fix
+        data:
+          note: Fix must be delivered by upstream, possible fixes have been discussed in https://gitlab.com/samba-team/samba/-/merge_requests/2778
 
   - id: CGA-j5gp-5hp6-j9m7
     aliases:


### PR DESCRIPTION
This updates advisories for two CVEs:

**CVE-2022-1615**

This remains unfixed upstream - https://gitlab.com/samba-team/samba/-/merge_requests/2778. Searching around confirms that the issue does not seem to have been separately addressed in some other PR/commit


**CVE-2022-32743**

This was [fixed upstream](https://gitlab.com/samba-team/samba/-/commit/15c86028a861139cee4560fe093c965ffc30eb13) in 4.17.0-rc0 (click `tags` on the commit page to see which tags the commit was included in), but the (previously embargoed) ticket [indicates](https://bugzilla.samba.org/show_bug.cgi?id=14833#c12) that it was treated as a bugfix rather than using their normal security release process (which is probably why NVD still reports this as unfixed). 

