### PR TITLE
build: fix validate workflow, old new new old style

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -38,7 +38,7 @@ jobs:
         ref: 'main'
 
     - name: 'Get wolfi-advisories HEAD for comparison'
-      id: base-commit
+      id: fork-point
       working-directory: ./wolfi-advisories
       run: |
         # NOTE(shimmerjs): This currently works because of actions/checkout
@@ -48,14 +48,14 @@ jobs:
         # they are different in inconsistent ways for the multiple types of
         # events that we want to trigger this WF: 
         # https://github.com/orgs/community/discussions/40277 
-        commit=$(git rev-parse refs/remotes/origin/main)
+        commit=$(git merge-base --fork-point refs/remotes/origin/main)
         echo "Will validate PR against ${commit}"
-        echo "base-commit=$commit" >> $GITHUB_OUTPUT
+        echo "fork-point=$commit" >> $GITHUB_OUTPUT
 
       # this need to point to main to always get the latest action
     - uses: wolfi-dev/actions/advisories-validate@main # main
       with:
-        fork_point: ${{ steps.base-commit.outputs.base-commit }}
+        fork_point: ${{ steps.fork-point.outputs.fork-point }}
         advisories-directory: './wolfi-advisories'
         packages-directory: './wolfi-packages'
         repository: ${{ github.repository }}


### PR DESCRIPTION
Use `merge-base --fork-point` to get valid ancestor for PR which isn't up to date with latest `main`