### PR TITLE
minio-operator/GHSA-mh63-6h87-95cp advisory update

### DIFF
--- a/minio-operator.advisories.yaml
+++ b/minio-operator.advisories.yaml
@@ -229,6 +229,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/minio-operator-sidecar
             scanner: grype
+      - timestamp: 2025-04-18T03:45:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'The affected component has been removed from upstream in the following commit: https://github.com/minio/operator/commit/f31aaf4eb7ec92eefd100da0a38e196c2e43dffe#diff-a7570eae54a8935f380bd5efb2e4d05a256bb718d290e9f993aeeab8d84b4506 However, due to functional changes introduced here, this does not apply cleanly to the current release and will require upstream maintainers to cut a new release version.'
 
   - id: CGA-vhxq-cvr8-2xgg
     aliases:


### PR DESCRIPTION
## 1. **GHSA-mh63-6h87-95cp**
- **pending-upstream-fix:** The affected component has been removed from upstream in the following commit: https://github.com/minio/operator/commit/f31aaf4eb7ec92eefd100da0a38e196c2e43dffe#diff-a7570eae54a8935f380bd5efb2e4d05a256bb718d290e9f993aeeab8d84b4506 However, due to functional changes introduced here, this does not apply cleanly to the current release and will require upstream maintainers to cut a new release version.