### PR TITLE
argo-events/GHSA-mh63-6h87-95cp

### DIFF
--- a/argo-events.advisories.yaml
+++ b/argo-events.advisories.yaml
@@ -168,6 +168,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argo-events
             scanner: grype
+      - timestamp: 2025-04-18T04:46:08Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency causing this CVE, golang-jwt/jwt v3.2.2, is brought in via the project's main go.mod. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.
 
   - id: CGA-cr9h-5969-2vw7
     aliases:


### PR DESCRIPTION
## 1. **GHSA-mh63-6h87-95cp**
- **pending-upstream-fix:** The dependency causing this CVE, golang-jwt/jwt v3.2.2, is brought in via the project's main go.mod. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.