### PR TITLE
gitness/GHSA-mh63-6h87-95cp advisory update

### DIFF
--- a/gitness.advisories.yaml
+++ b/gitness.advisories.yaml
@@ -537,6 +537,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gitness
             scanner: grype
+      - timestamp: 2025-04-18T04:49:59Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency causing this CVE, golang-jwt/jwt v3.2.2, is brought in via the project's main go.mod. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.
 
   - id: CGA-w6c7-ch77-gcrc
     aliases:


### PR DESCRIPTION
## 1. **GHSA-mh63-6h87-95cp**
- **pending-upstream-fix:** The dependency causing this CVE, golang-jwt/jwt v3.2.2, is brought in via the project's main go.mod. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.