### PR TITLE
rancher-agent-2.10/GHSA-mh63-6h87-95cp

### DIFF
--- a/rancher-agent-2.10.advisories.yaml
+++ b/rancher-agent-2.10.advisories.yaml
@@ -392,6 +392,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/agent
             scanner: grype
+      - timestamp: 2025-04-18T05:07:55Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency causing this CVE, golang-jwt/jwt v3.2.1, is brought in via the project's main go.mod. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.
 
   - id: CGA-rmh4-52mg-g8pr
     aliases:


### PR DESCRIPTION
## 1. **GHSA-mh63-6h87-95cp**
- **pending-upstream-fix:** The dependency causing this CVE, golang-jwt/jwt v3.2.1, is introduced in several places in the argo-cd project. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.