### PR TITLE
influxd/GHSA-mh63-6h87-95cp advisory update

### DIFF
--- a/influxd.advisories.yaml
+++ b/influxd.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/influxd
             scanner: grype
+      - timestamp: 2025-04-18T05:28:27Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency causing this CVE, golang-jwt/jwt v3.2.1, is brought in via the project's main go.mod. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.
 
   - id: CGA-4678-r632-m94c
     aliases:


### PR DESCRIPTION
## 1. **GHSA-mh63-6h87-95cp**
- **pending-upstream-fix:** The dependency causing this CVE, golang-jwt/jwt v3.2.1, is introduced in several places in the argo-cd project. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.