### PR TITLE
kube-metrics-adapter/GHSA-mh63-6h87-95cp advisory update

### DIFF
--- a/kube-metrics-adapter.advisories.yaml
+++ b/kube-metrics-adapter.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kube-metrics-adapter
             scanner: grype
+      - timestamp: 2025-04-18T05:31:25Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency causing this CVE, golang-jwt/jwt v3.2.2, is brought in via the project's main go.mod. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.
 
   - id: CGA-56xx-qh5q-gw66
     aliases:


### PR DESCRIPTION
## 1. **GHSA-mh63-6h87-95cp**
- **pending-upstream-fix:** The dependency causing this CVE, golang-jwt/jwt v3.2.1, is introduced in several places in the argo-cd project. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.