### PR TITLE
zot/GHSA-mh63-6h87-95cp/advisory update

### DIFF
--- a/zot.advisories.yaml
+++ b/zot.advisories.yaml
@@ -867,6 +867,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/zot
             scanner: grype
+      - timestamp: 2025-04-18T05:42:04Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency causing this CVE, golang-jwt/jwt v3.2.2, is brought in via the project's main go.mod. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.
 
   - id: CGA-h5qm-7fj6-3548
     aliases:


### PR DESCRIPTION
## 1. **GHSA-mh63-6h87-95cp**
- **pending-upstream-fix:** Remediating this CVE requires removal of github.com/golang-jwt/jwt v3.x from Keda. This requires immense functional changes which can be seen in this PR, https://github.com/kedacore/keda/commit/9299ea9a57e40bae0ca39794df53318315cd5879. Chainguard recommends updating Keda to v2.17.0 or later where this dependency does not exist