### PR TITLE
modelmesh-runtime-adapter/GHSA-mh63-6h87-95cp

### DIFF
--- a/modelmesh-runtime-adapter.advisories.yaml
+++ b/modelmesh-runtime-adapter.advisories.yaml
@@ -114,6 +114,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/mlserver-adapter
             scanner: grype
+      - timestamp: 2025-04-18T14:35:14Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency causing this CVE, golang-jwt/jwt v3.2.1, is brought in via the project's main go.mod. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement.
 
   - id: CGA-ffp6-hq7v-vh2f
     aliases:


### PR DESCRIPTION
## 1. **GHSA-mh63-6h87-95cp**
- **pending-upstream-fix:** The dependency causing this CVE, golang-jwt/jwt v3.2.2, is brought in via the project's main go.mod. Due to functional changes required to move away from v3 to v4/v5, upstream maintainers are required to implement