### PR TITLE
kyverno-1.13/GHSA-459x-q9hg-4gpq advisory update

### DIFF
--- a/kyverno-1.13.advisories.yaml
+++ b/kyverno-1.13.advisories.yaml
@@ -330,6 +330,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kyvernopre
             scanner: grype
+      - timestamp: 2025-04-18T14:50:30Z
+        type: pending-upstream-fix
+        data:
+          note: There currently is no fix for this CVE, upstream maintainers must create and merge a fix before remediation.
 
   - id: CGA-xr8x-8cg7-4rp7
     aliases:


### PR DESCRIPTION
## 1. **GHSA-459x-q9hg-4gpq**
- **pending-upstream-fix:** There currently is no fix for this CVE, upstream maintainers must create and merge a fix before remediation.