### PR TITLE
kubeflow-pipelines/GHSA-9gqv-wp59-fq42/GHSA-4www-5p9h-95mh advisory updates

### DIFF
--- a/kubeflow-pipelines.advisories.yaml
+++ b/kubeflow-pipelines.advisories.yaml
@@ -160,6 +160,16 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: govulncheck confirms the affected code is not present in the compiled binary.
 
+  - id: CGA-3qv8-5p92-vj49
+    aliases:
+      - CVE-2025-32997
+      - GHSA-9gqv-wp59-fq42
+    events:
+      - timestamp: 2025-04-18T19:15:32Z
+        type: pending-upstream-fix
+        data:
+          note: 'There is an open PR upstream regarding the required dependency bump to remediate this CVE seen here: https://github.com/kubeflow/pipelines/pull/11837 However, it is currently failing CI checks and so upstream maintainers will need to implement compatibility. '
+
   - id: CGA-3v2g-qxr9-6p2f
     aliases:
       - CVE-2025-27152
@@ -487,6 +497,16 @@ advisories:
         data:
           type: vulnerable-code-not-included-in-package
           note: Only affects Windows
+
+  - id: CGA-cfp4-m4j7-wpm6
+    aliases:
+      - CVE-2025-32996
+      - GHSA-4www-5p9h-95mh
+    events:
+      - timestamp: 2025-04-18T19:14:41Z
+        type: pending-upstream-fix
+        data:
+          note: 'There is an open PR upstream regarding the required dependency bump to remediate this CVE seen here: https://github.com/kubeflow/pipelines/pull/11837 However, it is currently failing CI checks and so upstream maintainers will need to implement compatibility. '
 
   - id: CGA-f4mr-p4pg-j4xf
     aliases:


### PR DESCRIPTION
## 1. **GHSA-9gqv-wp59-fq42/GHSA-4www-5p9h-95mh**
- **pending-upstream-fix:** There is an open PR upstream regarding the required dependency bump to remediate this CVE seen here: https://github.com/kubeflow/pipelines/pull/11837 However, it is currently failing CI checks and so upstream maintainers will need to implement compatibility.