### PR TITLE
rancher-agent-2.11/GHSA-v23v-6jw2-98fq advisory update

### DIFF
--- a/rancher-agent-2.11.advisories.yaml
+++ b/rancher-agent-2.11.advisories.yaml
@@ -115,6 +115,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/agent
             scanner: grype
+      - timestamp: 2025-04-21T22:53:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'Upstream maintainers state that the vulnerable code is not present in the package for this CVE. More information on this can be found here: https://scans.rancher.com/rancher-v2.11.0.html#:~:text=usr/bin/agent-,github.com/docker/docker%40v20.10.27%2Bincompatible,-CVE%2D2024%2D41110'
 
   - id: CGA-r9j2-gvh9-3qwj
     aliases:


### PR DESCRIPTION
## 1. **GHSA-v23v-6jw2-98fq**
- **vulnerable-code-not-included-in-package:** Upstream maintainers state that the vulnerable code is not present in the package for this CVE. More information on this can be found here: https://scans.rancher.com/rancher-v2.11.0.html#:~:text=usr/bin/agent-,github.com/docker/docker%40v20.10.27%2Bincompatible,-CVE%2D2024%2D41110