### PR TITLE
rancher-helm-3: update advisory for GHSA-5xqw-8hwv-wg92

### DIFF
--- a/rancher-helm-3.advisories.yaml
+++ b/rancher-helm-3.advisories.yaml
@@ -61,3 +61,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/rancher-helm
             scanner: grype
+      - timestamp: 2025-04-22T15:43:20Z
+        type: pending-upstream-fix
+        data:
+          note: 'This CVE is fixed in upstream Helm but not yet in Rancher Helm. Due to differences in file structure and code organization, the upstream patch doesn''t apply cleanly. Rancher Helm needs to create a custom patch to address the issue. Details on the upstream fix: https://github.com/helm/helm/commit/d8ca55fc669645c10c0681d49723f4bb8c0b1ce7'


### PR DESCRIPTION
Upstream helm is not the same as rancher helm, even though there are some similarities, we are unable to apply the patch cleanly. We need for rancher helm to work on a fix themselves and patch it within their own fork.