### PR TITLE
docs: update druid advisories for CVE-2022-40152 and CVE-2022-3509 

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -594,6 +594,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This vulnerability relates to protobuf-java 3.7.1, included by the shaded JAR hadoop-client-runtime-3.3.6.jar.
+      - timestamp: 2025-04-23T10:58:41Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Upstream note that this is a false positive as it does not affect clients. See https://github.com/apache/druid/pull/13590
 
   - id: CGA-hg68-rm6h-6m37
     aliases:

--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -1004,6 +1004,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This vulnerability is related to hadoop-client-runtime 3.3.4 included in druid-deltalake-extensions, requiring code changes by the upstream maintainers to remediate
+      - timestamp: 2025-04-23T10:53:52Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Upstream suppressed this match, noting that it does not affect clients. See https://github.com/apache/druid/pull/13590
 
   - id: CGA-x4rr-rgp6-pm43
     aliases:


### PR DESCRIPTION
Upstream [suppressions](https://github.com/apache/druid/pull/13590) note that these do not affect the client. 

A later [update](https://github.com/apache/druid/commit/a469c53c0c8bc96171eb27eeda50fdcfc380ea27) to the suppressions file also notes that "other" scanners are no longer reporting as vulnerable.

Additionally, [Maven Central](https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-client-runtime/3.3.4) no longer reports this CVE as arising from dependencies.