### PR TITLE
logstash-8: update advisory for GHSA-5w6v-399v-w3cc

### DIFF
--- a/logstash-8.advisories.yaml
+++ b/logstash-8.advisories.yaml
@@ -336,6 +336,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/bundle/jruby/3.1.0/specifications/nokogiri-1.18.7-java.gemspec
             scanner: grype
+      - timestamp: 2025-04-24T07:34:36Z
+        type: pending-upstream-fix
+        data:
+          note: The nokogiri gem at version 1.18.7 is included as a default gem in JRuby’s standard library. Because it’s part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of nokogiri.
 
   - id: CGA-hpqc-9w2r-rfj6
     aliases:


### PR DESCRIPTION
Nokogiri is pulled in as a transient dependency from jruby, we need to wait for jruby to bump their nokogiri version and logstash to release a new version with the fix in jruby.