### PR TITLE
rancher-agent-2.11: update advisory for GHSA-3wgm-2gw2-vh5m

### DIFF
--- a/rancher-agent-2.11.advisories.yaml
+++ b/rancher-agent-2.11.advisories.yaml
@@ -97,6 +97,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/agent
             scanner: grype
+      - timestamp: 2025-04-24T09:14:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-p6vp-vpv3-42xg
     aliases:


### PR DESCRIPTION
The vulnerability is in the git repo provisioner, not the client.