### PR TITLE
chartmuseum: update advisory GHSA-mh63-6h87-95cp

### DIFF
--- a/chartmuseum.advisories.yaml
+++ b/chartmuseum.advisories.yaml
@@ -341,6 +341,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/chartmuseum
             scanner: grype
+      - timestamp: 2025-04-25T08:08:20Z
+        type: pending-upstream-fix
+        data:
+          note: The CVE related to the version 'github.com/golang-jwt/jwt v3.2.2+incompatible' is due to a transient dependency of github.com/chartmuseum/auth@v0.5.0. Upstream is required to do code changes to change the depencendy, or the dependency needs to be udpated to stop making use of github.com/golang-jwt/jwt v3.x.
 
   - id: CGA-c73w-j4vf-x9rc
     aliases:

--- a/chartmuseum.advisories.yaml
+++ b/chartmuseum.advisories.yaml
@@ -344,7 +344,7 @@ advisories:
       - timestamp: 2025-04-25T08:08:20Z
         type: pending-upstream-fix
         data:
-          note: The CVE related to the version 'github.com/golang-jwt/jwt v3.2.2+incompatible' is due to a transient dependency of github.com/chartmuseum/auth@v0.5.0. Upstream is required to do code changes to change the dependency, or the dependency needs to be udpated to stop making use of github.com/golang-jwt/jwt v3.x.
+          note: The CVE related to the version 'github.com/golang-jwt/jwt v3.2.2+incompatible' is due to a transient dependency of github.com/chartmuseum/auth@v0.5.0. Upstream is required to do code changes to change the dependency, or the dependency needs to be updated to stop making use of github.com/golang-jwt/jwt v3.x.
 
   - id: CGA-c73w-j4vf-x9rc
     aliases:

--- a/chartmuseum.advisories.yaml
+++ b/chartmuseum.advisories.yaml
@@ -344,7 +344,7 @@ advisories:
       - timestamp: 2025-04-25T08:08:20Z
         type: pending-upstream-fix
         data:
-          note: The CVE related to the version 'github.com/golang-jwt/jwt v3.2.2+incompatible' is due to a transient dependency of github.com/chartmuseum/auth@v0.5.0. Upstream is required to do code changes to change the depencendy, or the dependency needs to be udpated to stop making use of github.com/golang-jwt/jwt v3.x.
+          note: The CVE related to the version 'github.com/golang-jwt/jwt v3.2.2+incompatible' is due to a transient dependency of github.com/chartmuseum/auth@v0.5.0. Upstream is required to do code changes to change the dependency, or the dependency needs to be udpated to stop making use of github.com/golang-jwt/jwt v3.x.
 
   - id: CGA-c73w-j4vf-x9rc
     aliases:


### PR DESCRIPTION
The `github.com/golang-jwt/jwt@v3.2.2+incompatible` transient dependency is brought by `github.com/chartmuseum/auth@v0.5.0`. chartmuseum/auth is not updated for a long time, so upstream of chartmuseum should either update their dependency to not make use of `chartmuseum/auth` or fixing `chartmuseum/auth` with a new version that doesn't depend on `golang-jwt/jwt@v3.x`.

```
╰─$ go mod graph | grep 'jwt@v3'
helm.sh/chartmuseum github.com/golang-jwt/jwt@v3.2.2+incompatible
github.com/chartmuseum/auth@v0.5.0 github.com/golang-jwt/jwt@v3.2.2+incompatible
```