### PR TITLE
rancher-api-ui: update advisory for GHSA-9mvj-f7w8-pvh2

### DIFF
--- a/rancher-api-ui.advisories.yaml
+++ b/rancher-api-ui.advisories.yaml
@@ -21,3 +21,12 @@ advisories:
             componentType: npm
             componentLocation: /usr/share/rancher/ui/api-ui/node_modules/bootstrap/package.json
             scanner: grype
+      - timestamp: 2025-04-28T06:23:30Z
+        type: pending-upstream-fix
+        data:
+          note: |-
+            This CVE is fixed in bootstrap versions > 3.4.1.
+            The next version is bootstrap 4.0 which introduces breaking changes.
+            Upstream will have to update the dependency manually and adapt the code to use a newer version of bootstrap.
+            Information about fixed versions: https://github.com/jasnow/ruby-advisory-db/blob/4ef0e78d56567561c91cf845e97235dfaed23c13/gems/bootstrap/CVE-2024-6484.yml
+            Information about migrating to bootstrap 4: https://getbootstrap.com/docs/4.0/migration/'


### PR DESCRIPTION
This CVE is fixed in bootstrap versions > 3.4.1.
The next version is bootstrap 4.0 which introduces breaking changes. Upstream will have to update the dependency manually and adapt the code to use a newer version of bootstrap.
Information about fixed versions: https://github.com/jasnow/ruby-advisory-db/blob/4ef0e78d56567561c91cf845e97235dfaed23c13/g    ems/bootstrap/CVE-2024-6484.yml
Information about migrating to bootstrap 4: https://getbootstrap.com/docs/4.0/migration/'