### PR TITLE
busybox/CVE-2024-58251/CVE-2025-46394 adv updates

### DIFF
--- a/busybox.advisories.yaml
+++ b/busybox.advisories.yaml
@@ -90,6 +90,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-04-29T21:27:41Z
+        type: pending-upstream-fix
+        data:
+          note: There currently is no fix for this CVE. Upstream maintainers must create a fix before this can be remediated.
 
   - id: CGA-mv94-rqj7-28m3
     aliases:
@@ -118,3 +122,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-04-29T21:28:02Z
+        type: pending-upstream-fix
+        data:
+          note: There currently is no fix for this CVE. Upstream maintainers must create a fix before this can be remediated.


### PR DESCRIPTION
There currently is no fix for this CVE. Upstream maintainers must create a fix before this can be remediated