### PR TITLE
opensearch-2/GHSA-73m2-qfq3-56cx advisory update

### DIFF
--- a/opensearch-2.advisories.yaml
+++ b/opensearch-2.advisories.yaml
@@ -282,6 +282,16 @@ advisories:
         data:
           fixed-version: 2.16.0-r0
 
+  - id: CGA-mv3j-4m6h-xhjg
+    aliases:
+      - CVE-2025-27820
+      - GHSA-73m2-qfq3-56cx
+    events:
+      - timestamp: 2025-04-30T02:45:12Z
+        type: pending-upstream-fix
+        data:
+          note: 'A fix exists in the 3.0 branch for this CVE as can be seen here: https://github.com/opensearch-project/OpenSearch/commit/dc4efa821904cc2d7ea7ef61c0f577d3fc0d8be9. A backport of this fix has been attempted upstream but failed: https://github.com/opensearch-project/OpenSearch/pull/18152#issuecomment-2840499533 This will require upstream maintainers to correctly implement.'
+
   - id: CGA-q576-4g28-x6p5
     aliases:
       - CVE-2024-29025


### PR DESCRIPTION
# opensearch-2
## 1. **GHSA-73m2-qfq3-56cx** 
- **pending-upstream-fix** 
A fix exists in the 3.0 branch for this CVE as can be seen here: https://github.com/opensearch-project/OpenSearch/commit/dc4efa821904cc2d7ea7ef61c0f577d3fc0d8be9. A backport of this fix has been attempted upstream but failed: https://github.com/opensearch-project/OpenSearch/pull/18152#issuecomment-2840499533 This will require upstream maintainers to correctly implement.