### PR TITLE
apache-nifi: update advisory for GHSA-rc42-6c7j-7h5r

### DIFF
--- a/apache-nifi.advisories.yaml
+++ b/apache-nifi.advisories.yaml
@@ -1874,6 +1874,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/nifi/nifi-current/lib/nifi-standard-content-viewer-nar-2.3.0.nar
             scanner: grype
+      - timestamp: 2025-05-01T13:36:21Z
+        type: pending-upstream-fix
+        data:
+          note: 'Any attempts to bump spring-boot to 3.4.5 result in a build failure. Upstream has already implemented the newer versions and merged into their 2.4.0-RC1 branch. We will have to wait for upstream to release a new 2.4.0 version, or backport the fixes into 2.3.0. Information about the upstream commit can be found at: https://github.com/apache/nifi/commit/954c9c4bdfc174b4af9a73789b5bdea896d9bd69'
 
   - id: CGA-vh8w-8rfv-rhq9
     aliases:


### PR DESCRIPTION
We have tried to bump boot spring via pombump and later by patching the related pom.xml files to version 3.4.5, but unfortunately they all resulted in build failures.

Upstream has currently a commit in main and in their 2.4.0-RC1 branch, which means that the bump will be available in apache-nifi v2.4.0.
https://github.com/apache/nifi/commit/954c9c4bdfc174b4af9a73789b5bdea896d9bd69

We now need to wait for a new release, or for upstream to backport the fix into their 2.3.0 branch.