### PR TITLE
keycloak-config-cli: update advisory for GHSA-rc42-6c7j-7h5r

### DIFF
--- a/keycloak-config-cli.advisories.yaml
+++ b/keycloak-config-cli.advisories.yaml
@@ -131,3 +131,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/keycloak-config-cli/keycloak-config-cli.jar
             scanner: grype
+      - timestamp: 2025-05-01T14:26:19Z
+        type: pending-upstream-fix
+        data:
+          note: Any attempts to bump spring-boot to 3.4.5 result in a build failure. We will need for upstream to push a fix and bump the dependency.


### PR DESCRIPTION
Any attempt to build keycloak-config-cli with a new spring-boot version result in build failures.
We will need to wait for upstream to push a fix.