### PR TITLE
tileserver-gl/advisory CVE-2025-46653

### DIFF
--- a/tileserver-gl.advisories.yaml
+++ b/tileserver-gl.advisories.yaml
@@ -157,6 +157,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/src/app/node_modules/formidable/package.json
             scanner: grype
+      - timestamp: 2025-05-02T13:01:24Z
+        type: fixed
+        data:
+          fixed-version: 5.3.0-r1
 
   - id: CGA-wm64-q84f-2hhv
     aliases:


### PR DESCRIPTION
Updates advisory for CVE-2025-46653
