### PR TITLE
druid/advisory for CVE-2025-46762

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -748,6 +748,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/extensions/druid-parquet-extensions/parquet-avro-1.15.1.jar
             scanner: grype
+      - timestamp: 2025-05-07T13:00:25Z
+        type: pending-upstream-fix
+        data:
+          note: parquet-avro 1.15.2 introduced a requirement to explicitly list which packages are trusted. As such, code changes are required in order to be able to successfully build the project with the latest version of parquet-avro.
 
   - id: CGA-mq7j-q5j2-r64c
     aliases:


### PR DESCRIPTION
This updates the advisory for  CVE-2025-46762 which is introduced into Druid via parquet-avro 1.15.1.

The upstream fix exists in 1.15.2, but requires that callers explicitly enumerate trusted packages, so it's not currently possible to build `druid` with 1.15.2 as a dependency.