### PR TITLE
zarf: update advisory for GHSA-6m8w-jc87-6cr7

### DIFF
--- a/zarf.advisories.yaml
+++ b/zarf.advisories.yaml
@@ -212,6 +212,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/zarf
             scanner: grype
+      - timestamp: 2025-05-08T07:33:22Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Per the advisory, users are only affected if "OPA is deployed as a standalone server (rather than being used as a Go library)
 
   - id: CGA-5qpw-rjrw-58hm
     aliases:


### PR DESCRIPTION
Update advisory for GHSA-6m8w-jc87-6cr7.

Per the advisory, users are only affected if "OPA is deployed as a standalone server (rather than being used as a Go library).