### PR TITLE
kubescape/snyk-cli/zot: update advisory

### DIFF
--- a/kubescape.advisories.yaml
+++ b/kubescape.advisories.yaml
@@ -1014,6 +1014,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubescape
             scanner: grype
+      - timestamp: 2025-05-08T07:38:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Per the advisory, users are only affected if "OPA is deployed as a standalone server (rather than being used as a Go library)
 
   - id: CGA-qjjx-7rr6-52h2
     aliases:

--- a/snyk-cli.advisories.yaml
+++ b/snyk-cli.advisories.yaml
@@ -96,6 +96,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/snyk
             scanner: grype
+      - timestamp: 2025-05-08T07:38:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Per the advisory, users are only affected if "OPA is deployed as a standalone server (rather than being used as a Go library)
 
   - id: CGA-7qw8-m998-w9qx
     aliases:

--- a/zot.advisories.yaml
+++ b/zot.advisories.yaml
@@ -422,6 +422,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/zot
             scanner: grype
+      - timestamp: 2025-05-08T07:38:36Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Per the advisory, users are only affected if "OPA is deployed as a standalone server (rather than being used as a Go library)
 
   - id: CGA-5c43-hqxh-fm2w
     aliases:


### PR DESCRIPTION
Update advisory for GHSA-6m8w-jc87-6cr7.

Per the advisory, users are only affected if "OPA is deployed as a standalone server (rather than being used as a Go library).