### PR TITLE
trino/advisory update

### DIFF
--- a/trino.advisories.yaml
+++ b/trino.advisories.yaml
@@ -951,6 +951,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/trino/lib/com.clickhouse_clickhouse-jdbc-0.7.1-patch1-all.jar
             scanner: grype
+      - timestamp: 2025-05-09T21:52:46Z
+        type: pending-upstream-fix
+        data:
+          note: Clickhouse-jdbc has a transitive dependency of guava that needs to be updated in clickhouse-jdbc. Subsequently, trino will have to update clickhouse-jdbc
 
   - id: CGA-mfjf-9gqg-2jjr
     aliases:


### PR DESCRIPTION
advisory update for CVE-2020-8908