### PR TITLE
argo-cd-3.0: update advisory for GHSA-274v-mgcv-cm8j

### DIFF
--- a/argo-cd-3.0.advisories.yaml
+++ b/argo-cd-3.0.advisories.yaml
@@ -92,3 +92,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/local/bin/argocd
             scanner: grype
+      - timestamp: 2025-05-13T12:27:59Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |
+            The fixed version of GitOps Engine was integrated before 2.14
+            released in
+            https://github.com/argoproj/argo-cd/commit/d59c85c5eb55d5ccba3ef5ce6624306a1113ce00


### PR DESCRIPTION
The fixed version of GitOps Engine was integrated before 2.14 released in
https://github.com/argoproj/argo-cd/commit/d59c85c5eb55d5ccba3ef5ce6624306a1113ce00