### PR TITLE
argo-cd-3.0: update advisory for GHSA-3wgm-2gw2-vh5m

### DIFF
--- a/argo-cd-3.0.advisories.yaml
+++ b/argo-cd-3.0.advisories.yaml
@@ -75,6 +75,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/local/bin/argocd
             scanner: grype
+      - timestamp: 2025-05-13T12:42:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.
 
   - id: CGA-wvr3-qqfv-67h5
     aliases:


### PR DESCRIPTION
This vulnerability applies to the git-repo volume provisioner, not the k8s client itself.