### PR TITLE
gitlab-cng-17.11 gem advisory updates

### DIFF
--- a/gitlab-cng-17.11.advisories.yaml
+++ b/gitlab-cng-17.11.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: gitlab-cng-17.11
 
 advisories:
+  - id: CGA-5568-qr89-2cq4
+    aliases:
+      - CVE-2025-32441
+      - GHSA-vpfw-47h7-xj4g
+    events:
+      - timestamp: 2025-05-14T02:29:17Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability relates to a GitLab gem dependency. GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues. Deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.'
+
   - id: CGA-m6wp-8p58-q66q
     aliases:
       - CVE-2024-21510
@@ -47,3 +57,13 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'This vulnerability relates to the GitLab dependency: [gem] puma @ 5.6.8  GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues.  deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.'
+
+  - id: CGA-r88c-6r8j-w9qh
+    aliases:
+      - CVE-2025-46727
+      - GHSA-gjh7-p2fx-99vx
+    events:
+      - timestamp: 2025-05-14T02:28:39Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability relates to a GitLab gem dependency. GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues. Deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.'


### PR DESCRIPTION
These vulnerabilities relate to a GitLab gem dependency. GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues. Deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.