### PR TITLE
druid/GHSA-55g7-9cwv-5qfv/GHSA-qcwq-55hx-v3vh

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -558,6 +558,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/hadoop-dependencies/hadoop-client-api/3.3.6/snappy-java-1.1.8.2.jar
             scanner: grype
+      - timestamp: 2025-05-14T03:25:00Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability relates to snappy-java v1.1.8.2, included by the shaded JARs hadoop-client-api-3.3.6.jar. Upgrading to version 3.4.0 will fix the vulnerability, but it requires code changes by the upstream maintainers.
 
   - id: CGA-gmp3-7m33-2h3v
     aliases:
@@ -721,6 +725,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/hadoop-dependencies/hadoop-client-api/3.3.6/snappy-java-1.1.8.2.jar
             scanner: grype
+      - timestamp: 2025-05-14T03:27:02Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability relates to snappy-java v1.1.8.2, included by the shaded JARs hadoop-client-api-3.3.6.jar. Upgrading to version 3.4.0 will fix the vulnerability, but it requires code changes by the upstream maintainers.
 
   - id: CGA-m35f-vgjj-4rrc
     aliases:


### PR DESCRIPTION
## 1. **GHSA-55g7-9cwv-5qfv/GHSA-qcwq-55hx-v3vh**
- **pending-upstream-fix:** These vulnerabilities relate to snappy-java v1.1.8.2, included by the shaded JARs hadoop-client-api-3.3.6.jar. Upgrading to version 3.4.0 will fix the vulnerability, but it requires code changes by the upstream maintainers