### PR TITLE
apache2: update advisory for CVE-2025-3891

### DIFF
--- a/apache2.advisories.yaml
+++ b/apache2.advisories.yaml
@@ -167,6 +167,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-05-14T11:54:26Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: This vulnerability affects the third-party Apache2 module mod_auth_openidc and does not impact Apache2 itself unless the module is intentionally installed and enabled.
 
   - id: CGA-pp8r-m5xc-wg3q
     aliases:


### PR DESCRIPTION
This vulnerability affects the third-party Apache2 module mod_auth_openidc and does not impact Apache2 itself unless the module is intentionally installed and enabled.