### PR TITLE
pgcat/advisory update

### DIFF
--- a/pgcat.advisories.yaml
+++ b/pgcat.advisories.yaml
@@ -47,6 +47,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/pgcat
             scanner: grype
+      - timestamp: 2025-05-14T17:00:31Z
+        type: pending-upstream-fix
+        data:
+          note: ring version has been locked to 0.16.x versions; upstream needs to update package and make code changes for newer 0.17.x versions to be used
 
   - id: CGA-6cq9-m2cg-fwjf
     aliases:


### PR DESCRIPTION
adding CVE-2025-4432 advisory for pgcat