### PR TITLE
tez: update advisory for CVE-2024-8184

### DIFF
--- a/tez.advisories.yaml
+++ b/tez.advisories.yaml
@@ -57,6 +57,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tez/lib/jetty-server-9.4.53.v20231009.jar
             scanner: grype
+      - timestamp: 2025-05-15T06:52:46Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version of said dependency is not explicitly defined in the project but rather brought in under the hadoop-client-r    untime jar. This requires upstream maintainers to implement a fix.
 
   - id: CGA-2hvc-45v7-8f34
     aliases:


### PR DESCRIPTION
Jetty is a transitive dependency for Hadoop.
Hadoop has to release a version with a fixed Jetty dependency version, and Tez has to update their dependencies to use the new Hadoop version.