### PR TITLE
fix: Revert adding detection events for clamav-1.2 and clamav-1.3

### DIFF
--- a/clamav-1.2.advisories.yaml
+++ b/clamav-1.2.advisories.yaml
@@ -4,24 +4,6 @@ package:
   name: clamav-1.2
 
 advisories:
-  - id: CGA-c8w9-m7rj-wvhq
-    aliases:
-      - CVE-2025-20128
-      - GHSA-6j5q-p9xp-3cc6
-    events:
-      - timestamp: 2025-03-04T19:31:18Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: clamav-1.2
-            componentID: e21ed6f882b1d715
-            componentName: clamav-1.2
-            componentVersion: 1.2.3-r0
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
   - id: CGA-hqwv-632q-63jh
     aliases:
       - CVE-2016-1405
@@ -44,39 +26,3 @@ advisories:
         data:
           type: component-vulnerability-mismatch
           note: 'Vulnerable code has been patched in every version of ClamAV since version 0.99: https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160531-wsa-esa'
-
-  - id: CGA-q8xv-w744-25vm
-    aliases:
-      - CVE-2024-20506
-      - GHSA-h5fr-q576-q7rv
-    events:
-      - timestamp: 2025-03-04T19:31:17Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: clamav-1.2
-            componentID: e21ed6f882b1d715
-            componentName: clamav-1.2
-            componentVersion: 1.2.3-r0
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-vx58-fvwf-5hgh
-    aliases:
-      - CVE-2024-20505
-      - GHSA-6qcx-p3rr-pfwf
-    events:
-      - timestamp: 2025-03-04T19:31:16Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: clamav-1.2
-            componentID: e21ed6f882b1d715
-            componentName: clamav-1.2
-            componentVersion: 1.2.3-r0
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype

--- a/clamav-1.3.advisories.yaml
+++ b/clamav-1.3.advisories.yaml
@@ -4,42 +4,6 @@ package:
   name: clamav-1.3
 
 advisories:
-  - id: CGA-3hgh-xwr8-5vrf
-    aliases:
-      - CVE-2025-20128
-      - GHSA-6j5q-p9xp-3cc6
-    events:
-      - timestamp: 2025-03-04T19:12:59Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: clamav-1.3
-            componentID: 2da5065f2ee00e82
-            componentName: clamav-1.3
-            componentVersion: 1.3.1-r0
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
-  - id: CGA-6389-cfh4-prq9
-    aliases:
-      - CVE-2024-20505
-      - GHSA-6qcx-p3rr-pfwf
-    events:
-      - timestamp: 2025-03-04T19:12:56Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: clamav-1.3
-            componentID: 2da5065f2ee00e82
-            componentName: clamav-1.3
-            componentVersion: 1.3.1-r0
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype
-
   - id: CGA-6rr3-qqj2-6wrg
     aliases:
       - CVE-2024-20290
@@ -92,21 +56,3 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.3.0-r0
-
-  - id: CGA-qw2c-vq2r-pwpr
-    aliases:
-      - CVE-2024-20506
-      - GHSA-h5fr-q576-q7rv
-    events:
-      - timestamp: 2025-03-04T19:12:58Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: clamav-1.3
-            componentID: 2da5065f2ee00e82
-            componentName: clamav-1.3
-            componentVersion: 1.3.1-r0
-            componentType: apk
-            componentLocation: /.PKGINFO
-            scanner: grype


### PR DESCRIPTION
These clamav-1.2 and clamav-1.3 APKs in wolfi-dev/os were scanned in error and should not have resulted in new detection events.

clamav-1.2 and clamav-1.3 are now maintained in entperise-packages where these CVEs have been remediated and addressed.

Revert "Adding Advisory CVE-2025-20128 for clamav-1.2 "

This reverts commit 515ecb42d3fd4b48c176e1f8c7c11903c3e434f8.

Revert "Adding Advisory CVE-2024-20506 for clamav-1.2 "

This reverts commit df3a6489d18ac96dca37586e9097b1707f28017e.

Revert "Adding Advisory CVE-2024-20505 for clamav-1.2 "

This reverts commit 6a66fc4e3b035781a2139dd36777e55eff80a93a.

Revert "Adding Advisory CVE-2025-20128 for clamav-1.3 "

This reverts commit 7738966ae2191a78a1b5f93ea84f4abd249f2784.

Revert "Adding Advisory CVE-2024-20506 for clamav-1.3 "

This reverts commit 7ac4ed72a5fb0b13e248001d3455561d6f5dcf38.

Revert "Adding Advisory CVE-2024-20505 for clamav-1.3 "

This reverts commit 99f8593bd735c25e62fa42d8a03323fca0aafa48.
