### PR TITLE
dotnet-9: add advisory for CVE-2025-26646

### DIFF
--- a/dotnet-9.advisories.yaml
+++ b/dotnet-9.advisories.yaml
@@ -55,3 +55,17 @@ advisories:
         type: fixed
         data:
           fixed-version: 9.0.2-r0
+
+  - id: CGA-xr48-wrc7-9wmf
+    aliases:
+      - CVE-2025-26646
+      - GHSA-h4j7-5rxr-p4wc
+    events:
+      - timestamp: 2025-05-16T16:46:43Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: |
+            Currently the scanners are detecting that the package has version of Microsoft.Build.Tasks.Core '17.3.4' installed.
+            The scanners are currently not reporting the dll version installed which is the code that gets executed as per: https://github.com/dotnet/msbuild/issues/11846\#issuecomment-2883242143
+            Currently /usr/share/dotnet/sdk/9.0.106/Microsoft.Build.Tasks.Core.dll is at version 17.12.35 which is not a vulnerable version as per the CVE advisory.


### PR DESCRIPTION
This is a false positive, since the version reported by the scanners is 17.3.4. This version that the dll files in the package are all at 17.12.35 as can be verified in the sbom as per some examples below.
```
├── 📄 /usr/share/dotnet/sdk/9.0.106/NuGet.CommandLine.XPlat.deps.json, /usr/share/dotnet/sdk/9.0.106/Microsoft.Build.Tasks.Core.dll
│       📦 Microsoft.Build.Tasks.Core 17.12.35 (dotnet)
── 📄 /usr/share/dotnet/sdk/9.0.106/dotnet.deps.json, /usr/share/dotnet/sdk/9.0.106/Microsoft.Build.Tasks.Core.dll
│       📦 Microsoft.Build.Tasks.Core 17.12.35 (dotnet)
```
Upstream also explains this briefly at https://github.com/dotnet/msbuild/issues/11846#issuecomment-2883242143