### PR TITLE
python-3.10/11/12/13/CVE-2025-4516 adv update

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -189,6 +189,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-05-19T15:14:28Z
+        type: pending-upstream-fix
+        data:
+          note: 'There has been an attempt to cherrypick the fix for this CVE (seen here: https://github.com/python/cpython/pull/129648) However, the automated attempt has failed: https://github.com/python/cpython/pull/129648#issuecomment-2873425136 and will require upstream maintainers to backport the fix to the 3.10 branch.'
 
   - id: CGA-9w4w-94rw-h33x
     aliases:

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -281,6 +281,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-05-19T15:15:22Z
+        type: pending-upstream-fix
+        data:
+          note: 'There has been an attempt to cherrypick the fix for this CVE (seen here: https://github.com/python/cpython/pull/129648) However, the automated attempt has failed: https://github.com/python/cpython/pull/129648#issuecomment-2873425005 and will require upstream maintainers to backport the fix to the 3.11 branch.'
 
   - id: CGA-rc3g-2ww4-mmcq
     aliases:

--- a/python-3.12.advisories.yaml
+++ b/python-3.12.advisories.yaml
@@ -108,6 +108,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-05-19T15:22:27Z
+        type: pending-upstream-fix
+        data:
+          note: 'There has been an attempt to cherrypick the fix for this CVE (seen here: https://github.com/python/cpython/pull/129648) However, the automated attempt has failed: https://github.com/python/cpython/pull/129648#issuecomment-2873424872 and will require upstream maintainers to backport the fix to the 3.12 branch.'
 
   - id: CGA-7fjj-f783-jvrr
     aliases:

--- a/python-3.13.advisories.yaml
+++ b/python-3.13.advisories.yaml
@@ -116,6 +116,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-05-19T15:23:08Z
+        type: pending-upstream-fix
+        data:
+          note: 'There has been an attempt to cherrypick the fix for this CVE (seen here: https://github.com/python/cpython/pull/129648) However, the automated attempt has failed: https://github.com/python/cpython/pull/129648#issuecomment-2873424872 and will require upstream maintainers to backport the fix to the 3.13 branch. A PR has been opened here: https://github.com/python/cpython/pull/133944'
 
   - id: CGA-q98g-97v3-rvq3
     aliases:


### PR DESCRIPTION
## 1. **python-3.10 GHSA-q7pp-wcgr-pffx**
- **pending-upstream-fix:**
There has been an attempt to cherrypick the fix for this CVE (seen here: https://github.com/python/cpython/pull/129648) However, the automated attempt has failed: [https://github.com/python/cpython/pull/129648#issuecomment-2873425136](https://github.com/python/cpython/pull/129648#issuecomment-2873425293) and will require upstream maintainers to backport the fix to the 3.10 branch.

## 1. **python-3.11 GHSA-q7pp-wcgr-pffx**
- **pending-upstream-fix:**
There has been an attempt to cherrypick the fix for this CVE (seen here: https://github.com/python/cpython/pull/129648) However, the automated attempt has failed: [https://github.com/python/cpython/pull/129648#issuecomment-2873425005](https://github.com/python/cpython/pull/129648#issuecomment-2873425293) and will require upstream maintainers to backport the fix to the 3.11 branch.

## 1. **python-3.12 GHSA-q7pp-wcgr-pffx**
- **pending-upstream-fix:** 
There has been an attempt to cherrypick the fix for this CVE (seen here: https://github.com/python/cpython/pull/129648) However, the automated attempt has failed: [https://github.com/python/cpython/pull/129648#issuecomment-2873424872](https://github.com/python/cpython/pull/129648#issuecomment-2873425293) and will require upstream maintainers to backport the fix to the 3.12 branch.  

## 1. **python-3.13 GHSA-q7pp-wcgr-pffx**
- **pending-upstream-fix:** 
There has been an attempt to cherrypick the fix for this CVE (seen here: https://github.com/python/cpython/pull/129648) However, the automated attempt has failed: [https://github.com/python/cpython/pull/129648#issuecomment-2873424872](https://github.com/python/cpython/pull/129648#issuecomment-2873425293) and will require upstream maintainers to backport the fix to the 3.13 branch. A PR has been opened here: https://github.com/python/cpython/pull/133944