### PR TITLE
Add fixed event for opentofu CGA-9w9x-6qq5-fmhf

### DIFF
--- a/opentofu.advisories.yaml
+++ b/opentofu.advisories.yaml
@@ -160,6 +160,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/tofu
             scanner: grype
+      - timestamp: 2025-05-24T12:07:58Z
+        type: fixed
+        data:
+          fixed-version: 1.6.0-r1
 
   - id: CGA-c8cm-gwjx-qm8v
     aliases:


### PR DESCRIPTION
The CGA-9w9x-6qq5-fmhf is aliased to GHSA-9763-4f94-gfch which was fixed in:
- https://github.com/wolfi-dev/os/commit/e7b72fb8afd7c48b030af7072dd3f57442b1a6e6

This should resolve the oldest Under Investigation at https://images.chainguard.dev/security?status=Under+investigation