### PR TITLE
nextcloud-server-31 advisories

### DIFF
--- a/nextcloud-server-31.advisories.yaml
+++ b/nextcloud-server-31.advisories.yaml
@@ -20,6 +20,11 @@ advisories:
             componentType: npm
             componentLocation: /usr/src/nextcloud/apps/files_pdfviewer/package.json
             scanner: grype
+      - timestamp: 2025-05-27T08:52:02Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: False positive identified due to naming/version mismatches between Nextcloud-specific packages and unrelated NPM packages. Nextcloud maintains actively updated versions, but inconsistent version tagging may be causing confusion. Needs version/tagging corrections from Nextcloud.
 
   - id: CGA-g44j-pf5j-hrrg
     aliases:
@@ -37,6 +42,11 @@ advisories:
             componentType: npm
             componentLocation: /usr/src/nextcloud/apps/firstrunwizard/package.json
             scanner: grype
+      - timestamp: 2025-05-27T08:59:04Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: False positive identified due to naming/version mismatches between Nextcloud-specific packages and unrelated NPM packages. Nextcloud maintains actively updated versions, but inconsistent version tagging may be causing confusion. Needs version/tagging corrections from Nextcloud.
 
   - id: CGA-gfgj-q47q-phvh
     aliases:
@@ -54,3 +64,8 @@ advisories:
             componentType: npm
             componentLocation: /usr/src/nextcloud/apps/twofactor_totp/package.json
             scanner: grype
+      - timestamp: 2025-05-27T08:59:31Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: False positive identified due to naming/version mismatches between Nextcloud-specific packages and unrelated NPM packages. Nextcloud maintains actively updated versions, but inconsistent version tagging may be causing confusion. Needs version/tagging corrections from Nextcloud.


### PR DESCRIPTION
Nextcloud already maintains its own packages. So those are FP npm packages.

https://github.com/nextcloud/firstrunwizard
https://www.npmjs.com/package/firstrunwizard

https://github.com/nextcloud/twofactor_totp
https://www.npmjs.com/package/twofactor_totp