### PR TITLE
py3-cassandra-medusa: update advisory for GHSA-5rjg-fvgr-3xxf

### DIFF
--- a/py3-cassandra-medusa.advisories.yaml
+++ b/py3-cassandra-medusa.advisories.yaml
@@ -598,6 +598,14 @@ advisories:
             componentType: python
             componentLocation: /home/cassandra/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
             scanner: grype
+      - timestamp: 2025-05-26T12:13:13Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |-
+            GHSA-5rjg-fvgr-3xxf is detected because pip vendors setuptools (v70.3.0), but only includes pkg_resources, making it non-vulnerable.
+            More information can be found here: https://github.com/pypa/pip/tree/30807c4d9e62e0ba65ad80d441dba55e76ddf5e4/src/pip/_vendor#modifications
+            We've upgraded setuptools to 78.1.1 in py3-cassandra-medusa to remediate the CVE.
 
   - id: CGA-ww2v-8w75-whg8
     aliases:


### PR DESCRIPTION
GHSA-5rjg-fvgr-3xxf is detected because pip vendors setuptools (v70.3.0), but only includes pkg_resources, making it non-vulnerable. More information can be found here: https://github.com/pypa/pip/tree/30807c4d9e62e0ba65ad80d441dba55e76ddf5e4/src/pip/_vendor#modifications We've upgraded setuptools to 78.1.1 in py3-cassandra-medusa to remediate the CVE.