### PR TITLE
druid/GHSA-wxr5-93ph-8wr9 adv update

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -146,6 +146,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/extensions/druid-deltalake-extensions/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+      - timestamp: 2025-05-29T23:09:12Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency responsible for this CVE is a transitive dependency where the version is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.
 
   - id: CGA-53rj-39m2-53xg
     aliases:


### PR DESCRIPTION
## 1. **GHSA-wxr5-93ph-8wr9**
- **pending-upstream-fix:** The dependency responsible for this CVE is a transitive dependency where the version is not explicitly defined in the project but rather brought in under the hadoop-client-runtime jar. This requires upstream maintainers to implement a fix.