### PR TITLE
GHSA-wxr5-93ph-8wr9/adv update

### DIFF
--- a/sonarqube-10.advisories.yaml
+++ b/sonarqube-10.advisories.yaml
@@ -378,6 +378,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/lib/extensions/sonar-iac-plugin-1.46.0.15097.jar
             scanner: grype
+      - timestamp: 2025-05-30T00:15:34Z
+        type: pending-upstream-fix
+        data:
+          note: The commons-beanutil dependency that exists in the sonarqube-10 package is brought in as a transitive dependency from sonar-iac-plugin-1.46.0.15097.jar, sonar-php-plugin-3.45.0.12991.jar, sonar-scanner-engine-shaded-25.5.0.107428-all.jar, and sonar-application-25.5.0.107428.jar . This dependency is not able to be upgraded to a higher version and requires upstream maintainers to implement.
 
   - id: CGA-pv4v-pp6h-6rfh
     aliases:


### PR DESCRIPTION
## 1. **GHSA-wxr5-93ph-8wr9**
- **pending-upstream-fix:** The commons-beanutil dependency that exists in the sonarqube-10 package is brought in as a transitive dependency from sonar-iac-plugin-1.46.0.15097.jar, sonar-php-plugin-3.45.0.12991.jar, sonar-scanner-engine-shaded-25.5.0.107428-all.jar, and sonar-application-25.5.0.107428.jar . This dependency is not able to be upgraded to a higher version and requires upstream maintainers to implement.