### PR TITLE
Mark CVE-2025-4516 as fixed for Python 3.12 and 3.13

### DIFF
--- a/python-3.12.advisories.yaml
+++ b/python-3.12.advisories.yaml
@@ -112,6 +112,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'There has been an attempt to cherrypick the fix for this CVE (seen here: https://github.com/python/cpython/pull/129648) However, the automated attempt has failed: https://github.com/python/cpython/pull/129648#issuecomment-2873424872 and will require upstream maintainers to backport the fix to the 3.12 branch.'
+      - timestamp: 2025-05-29T17:11:20Z
+        type: fixed
+        data:
+          fixed-version: 3.12.10-r2
 
   - id: CGA-7fjj-f783-jvrr
     aliases:

--- a/python-3.13.advisories.yaml
+++ b/python-3.13.advisories.yaml
@@ -120,6 +120,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'There has been an attempt to cherrypick the fix for this CVE (seen here: https://github.com/python/cpython/pull/129648) However, the automated attempt has failed: https://github.com/python/cpython/pull/129648#issuecomment-2873424872 and will require upstream maintainers to backport the fix to the 3.13 branch. A PR has been opened here: https://github.com/python/cpython/pull/133944'
+      - timestamp: 2025-05-29T17:11:20Z
+        type: fixed
+        data:
+          fixed-version: 3.13.3-r1
 
   - id: CGA-q98g-97v3-rvq3
     aliases:

--- a/python-3.13.advisories.yaml
+++ b/python-3.13.advisories.yaml
@@ -123,7 +123,7 @@ advisories:
       - timestamp: 2025-05-29T17:11:20Z
         type: fixed
         data:
-          fixed-version: 3.13.3-r1
+          fixed-version: 3.13.3-r2
 
   - id: CGA-q98g-97v3-rvq3
     aliases:


### PR DESCRIPTION
## Summary
This PR updates the advisories for Python 3.12 and 3.13 to mark CVE-2025-4516 as fixed. The fixes were applied in wolfi-dev/os#54620.

## Details
- **CVE-2025-4516**: Use-after-free crash when using `bytes.decode("unicode_escape", error="ignore|replace")`
- **Python 3.12**: Fixed in version 3.12.10-r2
- **Python 3.13**: Fixed in version 3.13.3-r1
- **Python 3.10 & 3.11**: Still pending upstream fixes

## Related Issues
- https://github.com/chainguard-dev/internal-dev/issues/12589
- https://github.com/wolfi-dev/os/pull/54620

## Test Plan
Advisory format has been validated against existing entries.

Fixes https://github.com/chainguard-dev/internal-dev/issues/12589