### PR TITLE
jenkins-plugin-manager/GHSA-wxr5-93ph-8wr9 adv update

### DIFF
--- a/jenkins-plugin-manager.advisories.yaml
+++ b/jenkins-plugin-manager.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/jenkins-plugin-manager/jenkins-plugin-manager.jar
             scanner: grype
+      - timestamp: 2025-06-02T19:04:33Z
+        type: pending-upstream-fix
+        data:
+          note: The commons-beanutil dependency that exists in the jenkins-plugin-manager package is brought in as a transitive dependency from commons-validator.jar v1.9.0. This dependency is at the most recent version and requires upstream maintainers to cut a release containing commons-beanutils v1.11.0


### PR DESCRIPTION
## 1. **GHSA-wxr5-93ph-8wr9**
- **pending-upstream-fix:** The commons-beanutil dependency that exists in the jenkins-plugin-manager package is brought in as a transitive dependency from commons-validator.jar v1.9.0. This dependency is at the most recent version and requires upstream maintainers to cut a release containing commons-beanutils v1.11.0