### PR TITLE
opensearch/advisory update

### DIFF
--- a/opensearch-2.advisories.yaml
+++ b/opensearch-2.advisories.yaml
@@ -256,6 +256,16 @@ advisories:
         data:
           fixed-version: 2.18.0-r0
 
+  - id: CGA-gh4p-9gcr-6mvx
+    aliases:
+      - CVE-2025-48734
+      - GHSA-wxr5-93ph-8wr9
+    events:
+      - timestamp: 2025-06-03T02:24:02Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream will need to make code changes when updating commons-beanutils 1.9.4 to 1.11.0 or newer. Attempts to address the CVE by updating to 1.11.0 result in build failures.
+
   - id: CGA-h94h-f38q-chh8
     aliases:
       - CVE-2024-30172

--- a/opensearch-3.advisories.yaml
+++ b/opensearch-3.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/opensearch/plugins/opensearch-identity-shiro/commons-beanutils-1.9.4.jar
             scanner: grype
+      - timestamp: 2025-06-03T02:24:02Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream will need to make code changes when updating commons-beanutils 1.9.4 to 1.11.0 or newer. Attempts to address the CVE by updating to 1.11.0 result in build failures.


### PR DESCRIPTION
adding advisory for commons-beanutils versin 1.9.4, CVE-2025-48734