### PR TITLE
spark-3.5/GHSA-wxr5-93ph-8wr9 adv update

### DIFF
--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -563,6 +563,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hadoop-client-runtime-3.3.6.jar
             scanner: grype
+      - timestamp: 2025-06-03T03:05:35Z
+        type: pending-upstream-fix
+        data:
+          note: This commons-beanutils dependency is brought in as a transitive dependency via hadoop-client-runtime-3.3.6.jar. These transitive dependencies from hadoop-client-runtime-3.3.6.jar are not able to be upgraded to a higher version and require upstream maintainers to implement.
 
   - id: CGA-g5xr-qw5v-2c74
     aliases:


### PR DESCRIPTION
## 1. **GHSA-wxr5-93ph-8wr9**
- **pending-upstream-fix:** This commons-beanutils dependency is brought in as a transitive dependency via hadoop-client-runtime-3.3.6.jar. These transitive dependencies from hadoop-client-runtime-3.3.6.jar are not able to be upgraded to a higher version and require upstream maintainers to implement.