### PR TITLE
confluent-kafka/CVE-2025-48734 add advisory

### DIFF
--- a/confluent-kafka.advisories.yaml
+++ b/confluent-kafka.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/kafka/libs/commons-beanutils-1.9.4.jar
             scanner: grype
+      - timestamp: 2025-06-03T09:22:33Z
+        type: pending-upstream-fix
+        data:
+          note: CVE-2025-48734 affects commons-beanutils < 1.10.1, a transitive dependency in confluent-kafka via checkstyle, junit-jupiter-params, and commons-validator. Upstream will need to upgrade these dependencies in order to remediate.
 
   - id: CGA-c87c-r7j2-6c2f
     aliases:


### PR DESCRIPTION
commons-beanutils is a transitive dependency