### PR TITLE
celeborn/CVE-2025-48734 add advisory

### DIFF
--- a/celeborn-0.5.advisories.yaml
+++ b/celeborn-0.5.advisories.yaml
@@ -65,6 +65,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/hadoop-client-runtime-3.4.1.jar
             scanner: grype
+      - timestamp: 2025-06-03T12:26:40Z
+        type: pending-upstream-fix
+        data:
+          note: CVE-2025-48734 affects commons-beanutils, which is brought into celeborn-0.5 as a shaded dependency of hadoop-client-runtime. The upstream maintainers will need to update this dependency to remediate this CVE
 
   - id: CGA-95f5-f357-578h
     aliases:


### PR DESCRIPTION
Adding advisory: `commons-beanutils` is a shaded dependency of hadoop client:
```
└── 📄 /usr/share/java/celeborn/jars/hadoop-client-runtime-3.4.1.jar
        📦 commons-beanutils 1.9.4 (java-archive)
            High CVE-2025-48734 GHSA-wxr5-93ph-8wr9 fixed in 1.11.0
```