### PR TITLE
zipkin: update advisory

### DIFF
--- a/zipkin.advisories.yaml
+++ b/zipkin.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /zipkin/BOOT-INF/lib/spring-context-6.2.6.jar
             scanner: grype
+      - timestamp: 2025-06-05T16:28:34Z
+        type: pending-upstream-fix
+        data:
+          note: spring-context is a transitive dependency and trying to upgrade it results in build failures, upstream will have to bump it.
 
   - id: CGA-7h42-x664-53j9
     aliases:


### PR DESCRIPTION
Update advisory for CVE-2025-22233
spring-context is a transitive dependency and trying to upgrade it results in build failures, upstream will have to bump it.