### PR TITLE
Zookeeper: version fix for CVE Data

### DIFF
--- a/zookeeper-3.9.advisories.yaml
+++ b/zookeeper-3.9.advisories.yaml
@@ -30,6 +30,10 @@ advisories:
         data:
           type: vulnerable-code-cannot-be-controlled-by-adversary
           note: Vulnerability affects only Windows systems.
+      - timestamp: 2025-06-05T06:20:01Z
+        type: fixed
+        data:
+          fixed-version: 3.9.3-r0
 
   - id: CGA-7p85-rf95-4g2p
     aliases:
@@ -84,10 +88,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/zookeeper/lib/jetty-server-9.4.53.v20231009.jar
             scanner: grype
-      - timestamp: 2024-11-07T11:33:08Z
+      - timestamp: 2025-06-05T06:20:01Z
         type: fixed
         data:
-          fixed-version: 3.9.3.2-r0
+          fixed-version: 3.9.3-r0
 
   - id: CGA-f7w2-w5x3-xfgj
     aliases:
@@ -183,7 +187,8 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/zookeeper/lib/netty-handler-4.1.115.Final.jar
             scanner: grype
-      - timestamp: 2025-02-19T15:10:32Z
+      - timestamp: 2025-06-05T06:20:01Z
         type: fixed
         data:
-          fixed-version: 3.9.3.2-r2
+          fixed-version: 3.9.3-r0
+


### PR DESCRIPTION
- Zookeeper was accidentally released with wrong versioning format which led to release of `zookeeper-3.9.4.0` which was merely a `release-candidate`
- We are fixing `zookeeper` versioning for `9.x.x.x` to `9.x.x` since the last `.0`,`.1`,`.2` represent release candidates.