### PR TITLE
open-webui:  updating advisories

### DIFF
--- a/open-webui.advisories.yaml
+++ b/open-webui.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/open-webui/lib/python3.11/site-packages/open_webui/frontend/pyodide/pillow-10.2.0-cp312-cp312-pyodide_2024_0_wasm32.whl
             scanner: grype
+      - timestamp: 2025-06-09T14:11:47Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest compatible pillow version built using pyodide is 10.2.0: https://pyodide.org/en/stable/usage/packages-in-pyodide.html'
 
   - id: CGA-vp8f-xf9w-8jwj
     aliases:
@@ -39,3 +43,7 @@ advisories:
             componentType: python
             componentLocation: /usr/share/open-webui/lib/python3.11/site-packages/open_webui/frontend/pyodide/requests-2.31.0-py3-none-any.whl
             scanner: grype
+      - timestamp: 2025-06-09T15:02:00Z
+        type: pending-upstream-fix
+        data:
+          note: 'The latest compatible requests version built using pyodide is 2.31.0: https://pyodide.org/en/stable/usage/packages-in-pyodide.html'


### PR DESCRIPTION
Adding advisory events for `open-webui`

- `CVE-2024-28219` - `pillow` (Python pkg): pending upstream fix
- `CVE-2024-35195` - `requests` (Python pkg): pending upstream fix

These are restricted by `pyodide` whose latest compatible versions of these packages are shown in their docs: https://pyodide.org/en/stable/usage/packages-in-pyodide.html