### PR TITLE
datadog-agent/GHSA-5rjg-fvgr-3xxf advisory update

### DIFF
--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -816,6 +816,11 @@ advisories:
             componentType: python
             componentLocation: /opt/datadog-agent/embedded/lib/python3.12/site-packages/pip/_vendor/vendor.txt
             scanner: grype
+      - timestamp: 2025-06-09T23:43:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: While pip's vendor.txt correctly shows setuptools==70.3.0 (which contains the vulnerability in its full form), pip's vendoring process explicitly drops all components containing the vulnerable code. The PackageIndex.download() vulnerability exists in the setuptools package and easy_install.py, both of which are removed during pip's vendoring process. Only pkg_resources is kept, which does not contain download functionality or the vulnerable code path.
 
   - id: CGA-p9r8-3fcm-ppmp
     aliases:


### PR DESCRIPTION
## BLUF
While pip's vendor.txt correctly shows setuptools==70.3.0 (which contains the vulnerability in its full form), pip's vendoring process explicitly drops all components containing the vulnerable code. The PackageIndex.download() vulnerability exists in the setuptools package and easy_install.py, both of which are removed during pip's vendoring process. Only pkg_resources is kept, which does not contain download functionality or the vulnerable code path.
## Summary
- **Vulnerable Component**: setuptools @ 70.3.0
- **Location**: `/opt/datadog-agent/embedded/lib/python3.12/site-packages/pip/_vendor/vendor.txt`
- **CVE/GHSA**: GHSA-5rjg-fvgr-3xxf / CVE-2025-47273
- **Finding**: FALSE POSITIVE - Vulnerable code not included

## Evidence Trail

### 1. GitHub Advisory Database
- **Fixed Version**: 78.1.1
- **Vulnerable Component**: PackageIndex.download() in setuptools
- **Query**: `gh api graphql -f query='{ securityAdvisory(ghsaId: "GHSA-5rjg-fvgr-3xxf") { ... } }'`
- **Key Detail**: "As easy_install and package_index are deprecated, the exploitation surface is reduced"
- **Link**: https://github.com/advisories/GHSA-5rjg-fvgr-3xxf

### 2. Understanding the Vulnerability
- **Vulnerable code**: setuptools/package_index.py, line 823, in `_download_url()`
- **Link**: https://github.com/pypa/setuptools/issues/4946
- **Purpose**: Used by easy_install to download packages
- **Attack vector**: Malicious package index URLs causing path traversal
- **Evidence**: "via malicious URLs present on the pages of a package index"
- **Specific file**: https://github.com/pypa/setuptools/blob/main/setuptools/package_index.py

### 3. pip's Vendoring Configuration
- **Evidence**: pip's pyproject.toml `[tool.vendoring]` section
- **Link**: https://github.com/pypa/pip/blob/main/pyproject.toml
- **Configuration shows**:
  ```toml
  [tool.vendoring]
  namespace = "pip._vendor"
  drop = [
      "easy_install.py",
      "setuptools",
      "pkg_resources/_vendor/",
      "_distutils_hack",
      "distutils-precedence.pth", 
      "pkg_resources/extern/"
  ]
  ```

### 4. What pip Actually Vendors
- **Evidence**: "setuptools is completely stripped to only keep pkg_resources"
- **Link**: https://pip.pypa.io/en/stable/development/vendoring-policy/
- **Direct quote**: "setuptools is completely stripped to only keep pkg_resources"
- **The "drop" list explicitly removes**:
  - `setuptools` - entire package containing PackageIndex
  - `easy_install.py` - the tool that uses PackageIndex
- **Only keeps**: stripped pkg_resources for metadata operations

### 5. Proof the Vulnerable Code is NOT in pip
- **PackageIndex location**: `setuptools/package_index.py` (not `pkg_resources/`)
- **This file is in**: the "setuptools" package which is DROPPED per pyproject.toml
- **pip uses**: its own download infrastructure, not PackageIndex
- **Evidence**: pip has `src/pip/_internal/network/download.py`, not setuptools' PackageIndex
- **Vulnerable line**: https://github.com/pypa/setuptools/blob/main/setuptools/package_index.py#L823
- **Key fact**: The vulnerable file is NOT in `pkg_resources/`, it's in `setuptools/` which pip drops

## Why This Is A False Positive
1. **Scanner sees**: vendor.txt contains "setuptools==70.3.0"
2. **Scanner flags**: This version has CVE-2025-47273
3. **Reality**: pip dropped all vulnerable code during vendoring
4. **Result**: No exploitable vulnerability exists in pip's vendored setuptools

## Verification Results: pip Vendored setuptools

### Package Tested
- **File**: datadog-agent-core-integrations-7.66.1-r0.apk
- **Source**: https://packages.wolfi.dev/os/x86_64/

### STEP 1: Check for vulnerable components
```bash
tar -tf datadog-agent-core-integrations-7.66.1-r0.apk | grep -E "pip/_vendor/setuptools|pip/_vendor/easy_install|PackageIndex"
```
**Result**: 0 matches found
-  No `pip/_vendor/setuptools/` directory
-  No `pip/_vendor/easy_install.py`
-  No `PackageIndex` files

### STEP 2: Verify only pkg_resources exists
```bash
tar -tf datadog-agent-core-integrations-7.66.1-r0.apk | grep "pip/_vendor/pkg_resources/__init__.py"
```
**Result**: Found
- `opt/datadog-agent/embedded/lib/python3.12/site-packages/pip/_vendor/pkg_resources/__init__.py`

### STEP 3: Confirm vendor.txt shows the version
```bash
tar -xf datadog-agent-core-integrations-7.66.1-r0.apk -O opt/datadog-agent/embedded/lib/python3.12/site-packages/pip/_vendor/vendor.txt | grep setuptools
```
**Result**: `setuptools==70.3.0`

## The verification confirms our analysis:

1. **Scanner sees**: `vendor.txt` contains `setuptools==70.3.0`
2. **Scanner assumes**: Full setuptools is present (including vulnerable PackageIndex)
3. **Reality**: Only `pkg_resources/` is present, NOT the vulnerable `setuptools/` package
4. **Vulnerable code location**: `setuptools/package_index.py` - NOT PRESENT in the package

This proves the vulnerability is a **FALSE POSITIVE** because:
- The vulnerable code (`setuptools/package_index.py`) is NOT included
- Only `pkg_resources` is vendored, which doesn't contain the vulnerable PackageIndex class
- pip's vendoring policy explicitly drops the setuptools package

## What pip/_vendor/ Actually Contains
- cachecontrol/
- certifi/
- distlib/
- packaging/
- pkg_resources/  ← Only this part from setuptools
- requests/
- (and other vendored dependencies)

But NOT:
- setuptools/  ← Where the vulnerability lives
- easy_install.py  ← Uses the vulnerable code

## References
- pip vendoring policy: https://pip.pypa.io/en/stable/development/vendoring-policy/
- pip pyproject.toml: https://github.com/pypa/pip/blob/main/pyproject.toml
- GitHub Advisory: https://github.com/advisories/GHSA-5rjg-fvgr-3xxf
- pip vendoring code: https://github.com/pypa/pip/tree/main/src/pip/_vendor