### PR TITLE
code-server/GHSA-8cj5-5rvv-wf4v adv update

### DIFF
--- a/code-server.advisories.yaml
+++ b/code-server.advisories.yaml
@@ -726,3 +726,7 @@ advisories:
             componentType: npm
             componentLocation: /usr/lib/code-server/lib/vscode/node_modules/tar-fs/package.json
             scanner: grype
+      - timestamp: 2025-06-10T00:05:29Z
+        type: pending-upstream-fix
+        data:
+          note: The dependency tar-fs is a transitive dependency that is brought in via vscode, a release of vscode containing the fix version is required.


### PR DESCRIPTION
## DEPENDENCY SOURCE INVESTIGATION: code-server tar-fs

## Summary
- **Vulnerable Component**: tar-fs @ 2.1.1
- **Location**: `/usr/lib/code-server/lib/vscode/node_modules/tar-fs/package.json`
- **CVE/GHSA**: CVE-2024-12905 / GHSA-pq67-2wwv-3xjx
- **Finding**: Transitive dependency via prebuild-install

## EVIDENCE TRAIL

### 1. GitHub Advisory Database
- **Fixed Versions**: 
  - 3.0.7 (for 3.x)
  - 2.1.2 (for 2.x)
  - 1.16.4 (for 1.x)
- **Vulnerable Range**: >= 2.0.0, < 2.1.2
- **Summary**: "tar-fs Vulnerable to Link Following and Path Traversal via Extracting a Crafted tar File"

### 2. Dependency Chain Analysis
Based on the advisory data and location:
- **Location**: `/usr/lib/code-server/lib/vscode/node_modules/tar-fs/`
- **This indicates**: tar-fs is in vscode's node_modules, not code-server's direct dependencies
- **Dependency chain**: vscode → keytar → prebuild-install → tar-fs @ 2.1.1

### 3. Current Remediation Attempt
Code-server already has a patch:
```patch
--- /lib/vscode/package.json-orig
+++ /lib/vscode/package.json
@@ -226,7 +226,10 @@
   "overrides": {
     "node-gyp-build": "4.8.1",
     "kerberos@2.1.1": {
-      "node-addon-api": "7.1.0"
+      "node-addon-api": "7.1.0",
+      "prebuild-install": {
+        "tar-fs": "2.1.3"
+      }
     }
   },
```

## ROOT CAUSE SUMMARY
The vulnerability comes from vscode's dependency chain: vscode uses keytar for credential storage, which depends on prebuild-install for downloading prebuilt binaries. 

## Current Status
- **Patch exists**: GHSA-pq67-2wwv-3xjx.patch
- **Advisory note**: "This vulnerability in tar-fs 2.1.1 is pending a fix from being included in the release version of vscode"
- **This means**: Even though code-server has a patch, the upstream vscode needs to update their dependencies

## REFERENCES
- GitHub Advisory: https://github.com/advisories/GHSA-pq67-2wwv-3xjx
- VSCode Issue (keytar dependencies): https://github.com/microsoft/vscode/issues/143395
- Code-server patch: code-server/GHSA-pq67-2wwv-3xjx.patch