### PR TITLE
druid: add pending-upstream-fix for GHSA-jr6h-r7vg-f9mc

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -757,6 +757,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/extensions/aliyun-oss-extensions/aliyun-oss-extensions-33.0.0.jar
             scanner: grype
+      - timestamp: 2025-06-10T01:58:57Z
+        type: pending-upstream-fix
+        data:
+          note: ini4j 0.5.4 has no patch available upstream yet for CVE-2022-41404. The vulnerability affects the fetch() method in BasicProfile class causing potential DoS. Waiting for upstream to release a patched version.
 
   - id: CGA-m2gq-4r7p-hp2x
     aliases:


### PR DESCRIPTION
ini4j 0.5.4 vulnerability CVE-2022-41404 has no upstream patch available yet. This vulnerability affects the fetch() method in the BasicProfile class and can cause DoS attacks. Marking as pending-upstream-fix while waiting for upstream to release a patched version.

Related CVE ticket: https://github.com/chainguard-dev/CVE-Dashboard/issues/24422