### PR TITLE
kubernetes-dns-node-cache: add pending-upstream-fix for GHSA-cvx7-x8pj-x2gw

### DIFF
--- a/kubernetes-dns-node-cache.advisories.yaml
+++ b/kubernetes-dns-node-cache.advisories.yaml
@@ -442,6 +442,10 @@ advisories:
         type: true-positive-determination
         data:
           note: Unable to use govulncheck to triage this advisory because the vulnerability was not found in the Go vuln DB. Treating as a true positive since we can't confirm this is a false positive.
+      - timestamp: 2025-06-10T02:38:23Z
+        type: pending-upstream-fix
+        data:
+          note: CoreDNS v1.11.3 vulnerability in github.com/coredns/coredns. Upstream fix in progress at https://github.com/kubernetes/dns/pull/706. Waiting for PR to be merged and new release.
 
   - id: CGA-pp28-cm29-q36g
     aliases:


### PR DESCRIPTION
CoreDNS v1.11.3 vulnerability in github.com/coredns/coredns. Upstream fix in progress at https://github.com/kubernetes/dns/pull/706. Marking as pending-upstream-fix while waiting for PR to be merged and new release.

Related CVE ticket: https://github.com/chainguard-dev/CVE-Dashboard/issues/24441