### PR TITLE
druid/advisory update

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -125,6 +125,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/extensions/druid-deltalake-extensions/hadoop-client-runtime-3.3.4.jar
             scanner: grype
+      - timestamp: 2025-06-10T21:56:40Z
+        type: pending-upstream-fix
+        data:
+          note: jackson-core is both a direct and transitive dependency. Attempts to update the direct dependency result in test failures; upstreams need to upgrade jackson-core to the latest version
 
   - id: CGA-48pw-w48m-hrfg
     aliases:


### PR DESCRIPTION
 GHSA-wf8f-6423-gfxg adv: druid needs to upgrade jackson-core and transitive dependencies need to upgrade it