### PR TITLE
tensorflow-cpu-jupyter/GHSA-33p9-3p43-82vq adv update

### DIFF
--- a/tensorflow-cpu-jupyter.advisories.yaml
+++ b/tensorflow-cpu-jupyter.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: python
             componentLocation: /usr/share/tensorflow/lib/python3.11/site-packages/jupyter_core-5.7.2.dist-info/METADATA, /usr/share/tensorflow/lib/python3.11/site-packages/jupyter_core-5.7.2.dist-info/RECORD
             scanner: grype
+      - timestamp: 2025-06-10T22:03:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: While pip's vendor.txt correctly shows setuptools==70.3.0 (which contains the vulnerability in its full form), pip's vendoring process explicitly drops all components containing the vulnerable code. The PackageIndex.download() vulnerability exists in the setuptools package and easy_install.py, both of which are removed during pip's vendoring process. Only pkg_resources is kept, which does not contain download functionality or the vulnerable code path.
 
   - id: CGA-7x5v-v62c-qg8g
     aliases:


### PR DESCRIPTION
While pip's vendor.txt correctly shows setuptools==70.3.0 (which contains the vulnerability in its full form), pip's vendoring process explicitly drops all components containing the vulnerable code. The PackageIndex.download() vulnerability exists in the setuptools package and easy_install.py, both of which are removed during pip's vendoring process. Only pkg_resources is kept, which does not contain download functionality or the vulnerable code path