### PR TITLE
py3-pip: mark GHSA-9hjg-9r4m-mvj7 as false positive

### DIFF
--- a/py3-pip.advisories.yaml
+++ b/py3-pip.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.12/site-packages/pip/_vendor/vendor.txt
             scanner: grype
+      - timestamp: 2025-06-11T22:18:53Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: CVE-2024-47081 is patched via py3-pip/fix-CVE-2024-47081.patch. The scanner detects requests 2.32.3 in vendor.txt, but the actual vulnerability (using ri.netloc instead of ri.hostname) has been fixed. The patched code uses ri.hostname for netrc lookups, preventing credential leakage.
 
   - id: CGA-p6wh-jxvc-2c6c
     aliases:


### PR DESCRIPTION
## Summary

This PR marks CVE-2024-47081 (GHSA-9hjg-9r4m-mvj7) as a false positive for py3-pip.

## Details

The vulnerability in pip's vendored requests library (version 2.32.3) has been patched via a security patch in the wolfi-packages/os repository. The patch fixes the netrc credential leakage vulnerability by changing the code to use hostname instead of netloc for netrc lookups.

While scanners will still detect requests 2.32.3 in the vendor.txt file, the actual vulnerable code has been patched, making this a false positive.

## Related PRs

- Fix PR: https://github.com/jamie-albert/os/pull/4 (py3-pip: patch CVE-2024-47081 in vendored requests library)

## Testing

The fix is verified in the py3-pip package tests, which confirm that the patched code uses the secure hostname method for netrc lookups.