### PR TITLE
spark-3.5: mark jackson-core GHSA-wf8f-6423-gfxg as pending-upstream-fix

### DIFF
--- a/spark-3.5.advisories.yaml
+++ b/spark-3.5.advisories.yaml
@@ -239,6 +239,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hadoop-client-runtime-3.3.6.jar
             scanner: grype
+      - timestamp: 2025-06-11T22:29:39Z
+        type: pending-upstream-fix
+        data:
+          note: jackson-core upgrade to 2.13.0+ requires incompatible Hadoop infrastructure changes including DynConstructors utility class. Waiting for Apache Spark and Hadoop to officially support jackson-core 2.13.0+ in future releases.
 
   - id: CGA-5hff-fh2h-5q22
     aliases:


### PR DESCRIPTION
## Summary
This PR marks jackson-core vulnerability GHSA-wf8f-6423-gfxg as pending-upstream-fix for spark-3.5.

## Technical Details
The vulnerability affects jackson-core's `JsonLocation._appendSourceDesc` method, which can leak up to 500 bytes of unintended memory content in exception messages when parsing JSON from byte arrays with offsets.

### Why We Can't Fix This Now
Upgrading to jackson-core 2.13.0+ (which fixes this vulnerability) requires significant code changes in Hadoop including:
1. Introduction of `org.apache.hadoop.util.dynamic.DynConstructors` utility class
2. Refactoring of exception handling in multiple core components (`NetUtils`, `WebHdfsFileSystem`)
3. Changes to import organization and method signatures

The patch from [HADOOP-19259](https://github.com/apache/hadoop/pull/7428) cannot be cleanly applied to Hadoop 3.3.6 (used by Spark) due to these missing infrastructure components.

## Resolution
Waiting for Apache Spark and Hadoop to officially support jackson-core 2.13.0+ in future releases.

## References
- [GHSA-wf8f-6423-gfxg Advisory](https://github.com/advisories/GHSA-wf8f-6423-gfxg)
- [Jackson PR #652 (Fix implementation)](https://github.com/FasterXML/jackson-core/pull/652)
- [HADOOP-19259 PR](https://github.com/apache/hadoop/pull/7428)