### PR TITLE
argo-cd/adv update older packages

### DIFF
--- a/argo-cd-2.10.advisories.yaml
+++ b/argo-cd-2.10.advisories.yaml
@@ -139,3 +139,25 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.10.8-r0
+
+  - id: CGA-j4vp-7w5c-jqrq
+    aliases:
+      - CVE-2025-23216
+      - GHSA-47g2-qmh2-749v
+    events:
+      - timestamp: 2025-01-31T11:17:26Z
+        type: detection
+        data:
+          type: scan/v1
+          data:
+            subpackageName: argo-cd-2.10
+            componentID: 15f0291443c3d907
+            componentName: github.com/argoproj/argo-cd/v2
+            componentVersion: v2.10.18
+            componentType: go-module
+            componentLocation: /usr/bin/argocd
+            scanner: grype
+      - timestamp: 2025-02-03T21:13:28Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life. Due to the fix for this CVE requiring functional changes that will not be backported to the 2.10 branch, recommend customer upgrade to supported version of argo-cd if possible.

--- a/argo-cd-2.12.advisories.yaml
+++ b/argo-cd-2.12.advisories.yaml
@@ -135,3 +135,14 @@ advisories:
         type: fixed
         data:
           fixed-version: 2.12.3-r1
+
+  - id: CGA-pxc7-25w4-xvcr
+    aliases:
+      - CVE-2025-23216
+      - GHSA-47g2-qmh2-749v
+    events:
+      - timestamp: 2025-06-13T03:34:38Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: 'Vulnerability was fixed by upstream, vulnerablility data is not complete. Commit reference with fix: https://github.com/argoproj/argo-cd/commit/a9d8027d4a8bf3230e16063d4a24fbcaa3a8b457'

--- a/argo-cd-2.9.advisories.yaml
+++ b/argo-cd-2.9.advisories.yaml
@@ -731,6 +731,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argocd
             scanner: grype
+      - timestamp: 2025-06-13T02:50:32Z
+        type: fix-not-planned
+        data:
+          note: This package is no longer supported upstream and has reached its end of life. Due to the fix for this CVE requiring functional changes that will not be backported to the 2.10 branch, recommend customer upgrade to supported version of argo-cd if possible.
 
   - id: CGA-v24h-px7p-wgc9
     aliases:


### PR DESCRIPTION
fix-not-planned for older argo-cd advisories. Escalation reference: https://github.com/chainguard-dev/customer-issues/issues/2305
