### PR TITLE
vitess-21: update advisory

### DIFF
--- a/vitess-21.0.advisories.yaml
+++ b/vitess-21.0.advisories.yaml
@@ -341,3 +341,7 @@ advisories:
             componentType: npm
             componentLocation: /vt/web/vtadmin/node_modules/glob/node_modules/brace-expansion/package.json
             scanner: grype
+      - timestamp: 2025-06-13T18:39:01Z
+        type: pending-upstream-fix
+        data:
+          note: An outdated braces-expansion is pulled in by a transitive dependency, upstream has to update the package to update braces-expansion to >= v2.0.2


### PR DESCRIPTION
Update advisory for GHSA-v6h2-p8h4-qcjw

An outdated braces-expansion is pulled in by a transitive dependency, upstream has to update the package to update braces-expansion to >= v2.0.2