### PR TITLE
argo-cd-2.7/advisory update for CVE-2025-23216

### DIFF
--- a/argo-cd-2.7.advisories.yaml
+++ b/argo-cd-2.7.advisories.yaml
@@ -432,6 +432,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/argocd
             scanner: grype
+      - timestamp: 2025-06-17T00:15:38Z
+        type: fix-not-planned
+        data:
+          note: Argo-CD 2.7 is no longer supported upstream.
 
   - id: CGA-hh36-8gcc-wcq3
     aliases:


### PR DESCRIPTION
updating argo-cd advisories for CVE-2025-23216. Related escalation: https://github.com/chainguard-dev/customer-issues/issues/2305