### PR TITLE
Mark CVE-2024-47081 as false positive for multiple packages

### DIFF
--- a/dask-kubernetes.advisories.yaml
+++ b/dask-kubernetes.advisories.yaml
@@ -47,3 +47,8 @@ advisories:
         type: fixed
         data:
           fixed-version: 2025.4.3-r2
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable

--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -885,6 +885,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 7.66.1-r3
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable
 
   - id: CGA-pxm7-cgj3-254p
     aliases:

--- a/kserve.advisories.yaml
+++ b/kserve.advisories.yaml
@@ -439,6 +439,11 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.11/site-packages/requests-2.32.3.dist-info/METADATA, /usr/lib/python3.11/site-packages/requests-2.32.3.dist-info/RECORD, /usr/lib/python3.11/site-packages/requests-2.32.3.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable
 
   - id: CGA-xw8q-xp4x-825w
     aliases:

--- a/kubeflow-jupyter-web-app.advisories.yaml
+++ b/kubeflow-jupyter-web-app.advisories.yaml
@@ -177,6 +177,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.10.0-r4
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable
 
   - id: CGA-6445-8x27-cghw
     aliases:

--- a/kubeflow-katib.advisories.yaml
+++ b/kubeflow-katib.advisories.yaml
@@ -205,6 +205,11 @@ advisories:
             componentType: python
             componentLocation: /opt/katib/cmd/earlystopping/medianstop/v1beta1/lib/python3.11/site-packages/pip/_vendor/vendor.txt
             scanner: grype
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable
 
   - id: CGA-9cxh-9fw3-736j
     aliases:

--- a/kubeflow-pipelines.advisories.yaml
+++ b/kubeflow-pipelines.advisories.yaml
@@ -1402,6 +1402,11 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/requests-2.32.0.dist-info/METADATA, /usr/lib/python3.10/site-packages/requests-2.32.0.dist-info/RECORD, /usr/lib/python3.10/site-packages/requests-2.32.0.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable
 
   - id: CGA-xh7w-622r-w594
     aliases:

--- a/kubeflow-volumes-web-app.advisories.yaml
+++ b/kubeflow-volumes-web-app.advisories.yaml
@@ -241,6 +241,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.10.0-r3
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable
 
   - id: CGA-f5h2-p64r-hgpf
     aliases:

--- a/mlflow.advisories.yaml
+++ b/mlflow.advisories.yaml
@@ -99,6 +99,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.1.0-r0
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable
 
   - id: CGA-5qqw-78qf-xfwg
     aliases:

--- a/py3-cassandra-medusa.advisories.yaml
+++ b/py3-cassandra-medusa.advisories.yaml
@@ -47,6 +47,11 @@ advisories:
             componentType: python
             componentLocation: /home/cassandra/.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt
             scanner: grype
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable
 
   - id: CGA-4pr8-qqxf-65pm
     aliases:

--- a/semgrep.advisories.yaml
+++ b/semgrep.advisories.yaml
@@ -25,3 +25,8 @@ advisories:
         type: fixed
         data:
           fixed-version: 1.125.0-r0
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable

--- a/superset.advisories.yaml
+++ b/superset.advisories.yaml
@@ -384,6 +384,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 4.1.2-r4
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable
 
   - id: CGA-xrq9-4hfh-g5jh
     aliases:

--- a/tensorflow-cpu-jupyter.advisories.yaml
+++ b/tensorflow-cpu-jupyter.advisories.yaml
@@ -82,6 +82,11 @@ advisories:
             componentType: python
             componentLocation: /usr/share/tensorflow/lib/python3.11/site-packages/pip/_vendor/vendor.txt
             scanner: grype
+      - timestamp: 2025-06-13T01:02:08Z
+        type: false-positive-determination
+        data:
+          type: inline-mitigations-exist
+          note: py3-pip installs a patched version of 2.32.3 requests.py which contains the upstream fix for CVE-2024-47081, reference https://github.com/wolfi-dev/os/pull/55998/files. The version referenced in the vendor.txt is not vulnerable
 
   - id: CGA-ch38-hm3p-vqfx
     aliases:


### PR DESCRIPTION
## Summary
This PR marks CVE-2024-47081 (GHSA-9hjg-9r4m-mvj7) as a false positive across 12 packages that use py3-pip.

## Details
These packages use py3-pip which installs a patched version of requests 2.32.3 that contains the upstream fix for CVE-2024-47081. The version referenced in vendor.txt is not actually vulnerable.

Reference: https://github.com/wolfi-dev/os/pull/55998/files

## Packages Updated
- dask-kubernetes
- datadog-agent
- kserve
- kubeflow-jupyter-web-app
- kubeflow-katib
- kubeflow-pipelines
- kubeflow-volumes-web-app
- mlflow
- py3-cassandra-medusa
- semgrep
- superset
- tensorflow-cpu-jupyter

All advisories were updated using `wolfictl advisory update` with proper formatting and structure.