### PR TITLE
newrelic-fluent-bit-output: update advisories

### DIFF
--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -91,6 +91,10 @@ advisories:
         type: true-positive-determination
         data:
           note: 'Govulncheck found vulnerable symbols in Go binaries at the following locations: in newrelic-fluent-bit-output-2.4.0-r0.apk, at fluent-bit/bin/out_newrelic.so, fluent-bit/bin/out_newrelic.so.'
+      - timestamp: 2025-06-17T06:57:48Z
+        type: pending-upstream-fix
+        data:
+          note: 'Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning: https://github.com/newrelic/newrelic-fluent-bit-output/blob/5854a3f3cffc49f251c9ef15bec714e44e7969a8/go.mod#L3 which directs to the following conversation: https://github.com/golang/go/issues/62130#issuecomment-1687335898'
 
   - id: CGA-3fw9-g448-cq83
     aliases:
@@ -428,6 +432,10 @@ advisories:
         type: true-positive-determination
         data:
           note: 'Govulncheck found vulnerable symbols in Go binaries at the following locations: in newrelic-fluent-bit-output-2.4.0-r0.apk, at fluent-bit/bin/out_newrelic.so, fluent-bit/bin/out_newrelic.so.'
+      - timestamp: 2025-06-17T06:57:48Z
+        type: pending-upstream-fix
+        data:
+          note: 'Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning: https://github.com/newrelic/newrelic-fluent-bit-output/blob/5854a3f3cffc49f251c9ef15bec714e44e7969a8/go.mod#L3 which directs to the following conversation: https://github.com/golang/go/issues/62130#issuecomment-1687335898'
 
   - id: CGA-wgjf-hp76-8hxw
     aliases:


### PR DESCRIPTION
Update advisories:
* CVE-2025-4673
* CVE-2025-22874

Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning:
https://github.com/newrelic/newrelic-fluent-bit-output/blob/5854a3f3cffc49f251c9ef15bec714e44e7969a8/go.mod#L3 which directs to the following conversation:
https://github.com/golang/go/issues/62130#issuecomment-1687335898