### PR TITLE
grafana-agent-operator: update advisories

### DIFF
--- a/grafana-agent-operator.advisories.yaml
+++ b/grafana-agent-operator.advisories.yaml
@@ -155,6 +155,10 @@ advisories:
         type: true-positive-determination
         data:
           note: 'Govulncheck found vulnerable symbols in Go binaries at the following locations: in grafana-agent-operator-0.44.2-r37.apk, at usr/bin/grafana-agent-operator, usr/bin/grafana-agent-operator.'
+      - timestamp: 2025-06-18T08:42:45Z
+        type: pending-upstream-fix
+        data:
+          note: 'Currently grafana-agent-operator is dependent on golang 1.22. There is work upstream to bump the golang version to 1.24, and we are pending for upstream to cut a version with the new golang version in order to fix this CVE. More information can be found here: https://github.com/grafana/agent/commit/1d3100817f6c84454ee9155c7bdfe6008dd15ef8'
 
   - id: CGA-7cq7-w454-vc9w
     aliases:
@@ -199,6 +203,11 @@ advisories:
         type: true-positive-determination
         data:
           note: 'Govulncheck found vulnerable symbols in Go binaries at the following locations: in grafana-agent-operator-0.44.2-r37.apk, at usr/bin/grafana-agent-operator, usr/bin/grafana-agent-operator.'
+      - timestamp: 2025-06-18T08:37:15Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: 'This vulnerability is part of the policy validation in crypto/x509 which was only introduced in 1.24, earlier golang versions are not affected by this CVE. More information can be found at: https://github.com/golang/go/issues/73612\#issuecomment-2977963004'
 
   - id: CGA-8x4h-m585-6pxf
     aliases:


### PR DESCRIPTION
Update advisory for CVE-2025-22874:
This vulnerability is part of the policy validation in crypto/x509 which was only introduced in 1.24, earlier golang versions are not affected by this CVE. More information can be found at:
https://github.com/golang/go/issues/73612\#issuecomment-2977963004

Update advisory for CVE-2025-4673:
Currently grafana-agent-operator is dependent on golang 1.22. There is work upstream to bump the golang version to 1.24, and we are pending for upstream to cut a version with the new golang version in order to fix this CVE. More information can be found here:
https://github.com/grafana/agent/commit/1d3100817f6c84454ee9155c7bdfe6008dd15ef8