### PR TITLE
feat: add fixed advisory for CVE-2023-52971

### DIFF
--- a/mariadb-11.8.advisories.yaml
+++ b/mariadb-11.8.advisories.yaml
@@ -21,6 +21,14 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-06-19T13:53:11Z
+        type: fixed
+        data:
+          fixed-version: 11.8.2-r1
+      - timestamp: 2025-06-19T13:58:34Z
+        type: fixed
+        data:
+          fixed-version: 11.8.2-r1
 
   - id: CGA-qc2h-6fw2-7g27
     aliases:


### PR DESCRIPTION
MariaDB [fixed](https://github.com/MariaDB/server/commit/3b4de4c281cb3e33e6d3ee9537e542bf0a84b83e) the issue on May 6.

The change was subsequently merged into the 11.8.x branch and our package was rebuilt on Tuesday