### PR TITLE
Missing go fixed events

### DIFF
--- a/go-1.23.advisories.yaml
+++ b/go-1.23.advisories.yaml
@@ -14,6 +14,26 @@ advisories:
         data:
           fixed-version: 1.23.1-r0
 
+  - id: CGA-6qrq-9xfm-27m9
+    aliases:
+      - CVE-2025-22874
+      - GHSA-6f52-wpx2-hvf2
+    events:
+      - timestamp: 2025-06-21T14:45:27Z
+        type: fixed
+        data:
+          fixed-version: 1.23.10-r0
+
+  - id: CGA-96x5-g6xp-m6g4
+    aliases:
+      - CVE-2025-4673
+      - GHSA-62jj-gr2r-5c34
+    events:
+      - timestamp: 2025-06-21T14:44:31Z
+        type: fixed
+        data:
+          fixed-version: 1.23.10-r0
+
   - id: CGA-p9x4-3652-r6hr
     aliases:
       - CVE-2024-34156

--- a/go-1.24.advisories.yaml
+++ b/go-1.24.advisories.yaml
@@ -1,0 +1,25 @@
+schema-version: 2.0.2
+
+package:
+  name: go-1.24
+
+advisories:
+  - id: CGA-7489-q43w-vc3x
+    aliases:
+      - CVE-2025-22874
+      - GHSA-6f52-wpx2-hvf2
+    events:
+      - timestamp: 2025-06-21T14:47:52Z
+        type: fixed
+        data:
+          fixed-version: 1.24.4-r0
+
+  - id: CGA-r4qr-9h49-gcrc
+    aliases:
+      - CVE-2025-4673
+      - GHSA-62jj-gr2r-5c34
+    events:
+      - timestamp: 2025-06-21T14:47:39Z
+        type: fixed
+        data:
+          fixed-version: 1.24.4-r0


### PR DESCRIPTION
Add missing fixed events for the 1.24.4 and 1.23.10 upstream releases.

In grype results, this should then populate this CVE fixed column when
scanning 1.24.3 and 1.23.9 images.
