### PR TITLE
openjdk/missing advisories for older versions

### DIFF
--- a/openjdk-7.advisories.yaml
+++ b/openjdk-7.advisories.yaml
@@ -1028,6 +1028,16 @@ advisories:
             componentLocation: /.PKGINFO
             scanner: grype
 
+  - id: CGA-w722-rc98-mw4p
+    aliases:
+      - CVE-2019-7317
+      - GHSA-m96g-x499-p5f9
+    events:
+      - timestamp: 2025-06-23T18:02:41Z
+        type: fixed
+        data:
+          fixed-version: 9.0.4-r5
+
   - id: CGA-w7v7-69vj-w359
     aliases:
       - CVE-2023-41993

--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -368,6 +368,16 @@ advisories:
         data:
           fixed-version: 8.412.08-r0
 
+  - id: CGA-w43q-rvg7-wg7f
+    aliases:
+      - CVE-2019-7317
+      - GHSA-m96g-x499-p5f9
+    events:
+      - timestamp: 2025-06-23T18:03:10Z
+        type: fixed
+        data:
+          fixed-version: 9.0.4-r5
+
   - id: CGA-wh4h-q24p-73mj
     aliases:
       - CVE-2023-21938


### PR DESCRIPTION
adding advisories records that are fixed in a newer version