### PR TITLE
mattermost-10.9: mark CVE-2022-4019 and CVE-2022-4045 as false positives

### DIFF
--- a/mattermost-10.9.advisories.yaml
+++ b/mattermost-10.9.advisories.yaml
@@ -44,6 +44,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-06-23T21:46:31Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This vulnerability was remediated in mattermost v7.4.0 and later. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4045'
 
   - id: CGA-fxgw-q6fp-6q63
     aliases:
@@ -98,6 +103,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-06-23T21:46:17Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This vulnerability was remediated in mattermost v7.x, Specifically, in versions 7.1.4, 7.2.1, 7.3.1, and 7.4.0. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4019'
 
   - id: CGA-rp79-355v-v275
     aliases:


### PR DESCRIPTION
## Summary
- Mark CVE-2022-4019 and CVE-2022-4045 as false positives for mattermost-10.9
- These vulnerabilities were already remediated in earlier mattermost versions
- Bringing this over from mattermost-10.8 advisories

## Details
- **CVE-2022-4019**: Fixed in mattermost v7.1.4, v7.2.1, v7.3.1, and v7.4.0
- **CVE-2022-4045**: Fixed in mattermost v7.4.0 and later
- Both marked as `component-vulnerability-mismatch` type false positives