### PR TITLE
False positive: gitlab-runner-18.1: GHSA-gh5c-3h97-2f3q

### DIFF
--- a/gitlab-runner-18.1.advisories.yaml
+++ b/gitlab-runner-18.1.advisories.yaml
@@ -21,3 +21,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine
             scanner: grype
+      - timestamp: 2025-06-24T15:56:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: |
+            This vulnerability affects github.com/docker/docker (also known as github.com/moby/moby) versions up to v25.0.4.
+            The version currently in use is v25.0.6, which already includes the patch: https://github.com/moby/moby/commit/8e3bcf19748838b30e34d612832d1dc9d90363b8
+            However, the CVE detection appears to be incorrectly triggered due to a version parsing mismatch — likely because the module version includes a +incompatible suffix.


### PR DESCRIPTION
This vulnerability affects github.com/docker/docker (also known as github.com/moby/moby) versions up to v25.0.4.

The version currently in use is v25.0.6, which already includes the patch: https://github.com/moby/moby/commit/8e3bcf19748838b30e34d612832d1dc9d90363b8

However, the CVE detection appears to be incorrectly triggered due to a version parsing mismatch — likely because the module version includes a +incompatible suffix.

This is a false positive, as the patched code is already present in the used version.