### PR TITLE
spark-4.0: add pending-upstream-fix advisories for transitive dependency CVEs

### DIFF
--- a/spark-4.0.advisories.yaml
+++ b/spark-4.0.advisories.yaml
@@ -21,6 +21,12 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hadoop-client-runtime-3.4.1.jar
             scanner: grype
+      - timestamp: 2025-06-25T21:47:44Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Upstream maintainers must cut a Hadoop release with Avro 1.11.4+ to resolve this CVE. The vulnerability is in jackson-core 2.12.7 bundled within hadoop-client-runtime-3.4.1.jar. Spark PR #40933 (SPARK-43263) attempted to upgrade Jackson to 2.15.0 but encountered dependency conflicts with Avro 1.11.1 which still pulls Jackson 2.12.7. The PR discussion confirmed that Avro must be upgraded first, which requires a new Hadoop release. CVE-2025-49128 is fixed in Jackson 2.13.0+.
+            Reference: https://github.com/apache/spark/pull/40933#issuecomment-1536432927
 
   - id: CGA-57mq-pmr4-4pfr
     aliases:
@@ -39,6 +45,12 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hadoop-client-runtime-3.4.1.jar
             scanner: grype
+      - timestamp: 2025-06-25T21:48:16Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Upstream maintainers must cut a Hadoop release with Avro 1.11.4 to resolve these CVEs. PR #7615 (HADOOP-19315) has been merged on 2025-04-15 which upgrades Avro from 1.9.2 to 1.11.4. This addresses both CVE-2024-47561 (critical severity) and CVE-2023-39410 (high severity) in the avro 1.9.2 dependency bundled within hadoop-client-runtime-3.4.1.jar. The PR notes this change is not backwards compatible due to Avro's requirement for setter/getter methods and serializable package declarations.
+            Reference: https://github.com/apache/hadoop/pull/7615
 
   - id: CGA-9h2q-jvgf-3h42
     aliases:
@@ -57,6 +69,12 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/spark-core_2.13-4.0.0.jar
             scanner: grype
+      - timestamp: 2025-06-25T21:47:27Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Upstream maintainers must complete the migration from Jetty 11 to Jetty 12 to resolve this CVE. PR #45500 (SPARK-47086) was opened on 2024-03-13 but was closed without merging. The migration is complex as it requires updating all Jetty multiple dependency and API changes. Spark currently uses jetty-http 11.0.24 in spark-core_2.13-4.0.0.jar. CVE-2024-6763 is fixed in Jetty 12.0.12.
+            Reference: https://github.com/apache/spark/pull/45500
 
   - id: CGA-fc3h-q37m-f2mr
     aliases:
@@ -75,6 +93,12 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hadoop-client-runtime-3.4.1.jar
             scanner: grype
+      - timestamp: 2025-06-25T21:47:11Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Upstream maintainers must cut a Hadoop release with the following changes to resolve this CVE. The fix has already been merged in PR #7524 (HADOOP-18991) which removes the unused commons-beanutils dependency entirely from Hadoop 3. The PR was merged on 2025-03-20. Spark depends on hadoop-client-runtime-3.4.1.jar which bundles this vulnerable dependency.
+            Reference: https://github.com/apache/hadoop/pull/7524
 
   - id: CGA-g97v-9xqj-c4w6
     aliases:
@@ -93,6 +117,12 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hadoop-client-runtime-3.4.1.jar
             scanner: grype
+      - timestamp: 2025-06-25T21:48:16Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Upstream maintainers must cut a Hadoop release with Avro 1.11.4 to resolve these CVEs. PR #7615 (HADOOP-19315) has been merged on 2025-04-15 which upgrades Avro from 1.9.2 to 1.11.4. This addresses both CVE-2024-47561 (critical severity) and CVE-2023-39410 (high severity) in the avro 1.9.2 dependency bundled within hadoop-client-runtime-3.4.1.jar. The PR notes this change is not backwards compatible due to Avro's requirement for setter/getter methods and serializable package declarations.
+            Reference: https://github.com/apache/hadoop/pull/7615
 
   - id: CGA-q4vv-qgcf-g8h6
     aliases:
@@ -111,3 +141,9 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hive-exec-2.3.10-core.jar
             scanner: grype
+      - timestamp: 2025-06-25T21:48:01Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Upstream maintainers must upgrade Hive from 2.3.10 to 4.0.1+ to resolve this CVE. JIRA ticket SPARK-52408 tracks this upgrade request. The vulnerability CVE-2024-29869 affects hive-exec 2.3.10 which is bundled in hive-exec-2.3.10-core.jar. This is a significant upgrade as Hive 4.x has major API changes compared to 2.x series.
+            Reference: https://issues.apache.org/jira/browse/SPARK-52408


### PR DESCRIPTION
## Summary
Document pending upstream fixes for spark-4.0 transitive dependency CVEs that require upstream releases.

## CVEs Addressed
- **CVE-2025-48734** (commons-beanutils) - Requires Hadoop release with merged PR apache/hadoop#7524
- **CVE-2024-6763** (jetty-http) - Requires Spark to complete Jetty 11→12 migration (PR apache/spark#45500 closed)
- **CVE-2025-49128** (jackson-core) - Requires Hadoop release with Avro upgrade to resolve dependency conflict
- **CVE-2024-29869** (hive-exec) - Requires Spark to upgrade Hive 2.3.10→4.0.1+ (SPARK-52408)
- **CVE-2024-47561 & CVE-2023-39410** (avro) - Requires Hadoop release with merged PR apache/hadoop#7615

All CVEs are in transitive dependencies bundled within Spark JARs and require upstream maintainer action.