### PR TITLE
kyverno-policy-reporter: CVE-2024-44906 pending upstream fix

### DIFF
--- a/kyverno-policy-reporter.advisories.yaml
+++ b/kyverno-policy-reporter.advisories.yaml
@@ -270,6 +270,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/policyreporter
             scanner: grype
+      - timestamp: 2025-06-26T18:56:49Z
+        type: pending-upstream-fix
+        data:
+          note: No fix is available in github.com/uptrace/bun at this time.
 
   - id: CGA-mxm7-9r6v-8m7j
     aliases:


### PR DESCRIPTION
No fix yet, there is a PR opened in the last hour, but it needs review, landing, and a release.