### PR TITLE
feat: add vitess advisory for GHSA-v6h2-p8h4-qcjw

### DIFF
--- a/vitess-22.advisories.yaml
+++ b/vitess-22.advisories.yaml
@@ -38,3 +38,7 @@ advisories:
             componentType: npm
             componentLocation: /vt/web/vtadmin/node_modules/brace-expansion/package.json
             scanner: grype
+      - timestamp: 2025-06-26T19:53:18Z
+        type: pending-upstream-fix
+        data:
+          note: An outdated braces-expansion is pulled in by a transitive dependency, upstream has to update the package to update braces-expansion to >= v2.0.2


### PR DESCRIPTION
Fixes:
https://github.com/chainguard-dev/CVE-Dashboard/issues/25293

An outdated braces-expansion is pulled in by a transitive dependency, upstream has to update the package to [update braces-expansion](https://github.com/vitessio/vitess/blob/fae2b51728617e575b4162f6737fb8f15ed74898/web/vtadmin/package-lock.json#L8960) to >= v2.0.2