### PR TITLE
kubeflow-pipelines: add advisory for CVE-2025-4565 (protobuf)

### DIFF
--- a/kubeflow-pipelines.advisories.yaml
+++ b/kubeflow-pipelines.advisories.yaml
@@ -551,6 +551,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/protobuf-3.20.3.dist-info/METADATA, /usr/lib/python3.10/site-packages/protobuf-3.20.3.dist-info/RECORD, /usr/lib/python3.10/site-packages/protobuf-3.20.3.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2025-06-26T20:56:30Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE affects protobuf 3.20.3 used in kubeflow-pipelines metadata_writer component. The fix requires upgrading to protobuf 4.25.8+, which is a major version upgrade (3.x → 4.x) that upstream kubeflow-pipelines has not implemented yet. The upstream project still uses protobuf 3.20.3 in their main branch as of June 2025. We are waiting for upstream maintainers to implement this CVE fix to avoid breaking changes.
 
   - id: CGA-cfp4-m4j7-wpm6
     aliases:


### PR DESCRIPTION
## Summary

Add pending-upstream-fix advisory for CVE-2025-4565 affecting protobuf 3.20.3 in kubeflow-pipelines metadata_writer component.

## Issue

- CVE-2025-4565 affects protobuf < 4.25.8
- kubeflow-pipelines uses protobuf 3.20.3 in metadata_writer
- Fix requires major version upgrade (3.x → 4.x) to protobuf 4.25.8+

## Advisory Details

- **Type**: pending-upstream-fix
- **Reason**: Upstream kubeflow-pipelines project still uses protobuf 3.20.3 in main branch
- **Action**: Waiting for upstream maintainers to implement this CVE fix to avoid breaking changes

## Related Work

The urllib3 CVEs for kubeflow-pipelines were fixed separately in: https://github.com/wolfi-dev/os/pull/57697