### PR TITLE
kubernetes-1.28/CVE-2025-22874: add fix-not-planned

### DIFF
--- a/kubernetes-1.28.advisories.yaml
+++ b/kubernetes-1.28.advisories.yaml
@@ -181,3 +181,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubelet
             scanner: grype
+
+  - id: CGA-656f-xq6c-7j7m
+    aliases:
+      - CVE-2025-22874
+      - GHSA-6f52-wpx2-hvf2
+    events:
+      - timestamp: 2025-06-27T10:23:44Z
+        type: fix-not-planned
+        data:
+          note: The affected package has reached end-of-life, and no further fixes will be issued. Users are encouraged to migrate to a supported version.


### PR DESCRIPTION
The package is EOL (no longer in the melange repository) and a fix is not planned.