### PR TITLE
kubernetes-1.28: add fix-not-planned for CVE-2025-4673

### DIFF
--- a/kubernetes-1.28.advisories.yaml
+++ b/kubernetes-1.28.advisories.yaml
@@ -181,3 +181,13 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/kubelet
             scanner: grype
+
+  - id: CGA-rp9g-fp5x-w5w6
+    aliases:
+      - CVE-2025-4673
+      - GHSA-62jj-gr2r-5c34
+    events:
+      - timestamp: 2025-06-27T14:16:37Z
+        type: fix-not-planned
+        data:
+          note: The affected package has reached end-of-life, and no further fixes will be issued. Users are encouraged to migrate to a supported ion or alternative package.


### PR DESCRIPTION
This package is EOL.

See also: https://github.com/chainguard-dev/CVE-Dashboard/issues/25272