### PR TITLE
python-3.13: mark CVE-2025-6069 as fixed

### DIFF
--- a/python-3.13.advisories.yaml
+++ b/python-3.13.advisories.yaml
@@ -274,3 +274,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-06-27T15:25:56Z
+        type: fixed
+        data:
+          fixed-version: 3.13.5-r1


### PR DESCRIPTION
We backported the fix, so automation won't detect it.