### PR TITLE
datadog-agent/advisory update - CVE-2025-50181, CVE-2025-50182

### DIFF
--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -165,6 +165,13 @@ advisories:
             componentType: python
             componentLocation: /opt/datadog-agent/embedded/lib/python3.12/site-packages/pip/_vendor/vendor.txt
             scanner: grype
+      - timestamp: 2025-06-27T20:05:02Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            The outdated version of urllib3 (1.26.20) is included because it's a dependency of py3-pip. Updating it will require the main pip project to release an update.
+            However, the pip maintainers are holding off on that update until Python 3.9 reaches its end-of-life (EOL) at the end of 2025. Once that happens, pip can upgrade, and then kubeflow-katib will also need to update to align with the changes in pip.
+            For more details, see this GitHub issue: https://github.com/pypa/pip/issues/12857
 
   - id: CGA-4cr4-p4pw-xqm5
     aliases:
@@ -656,6 +663,13 @@ advisories:
             componentType: python
             componentLocation: /opt/datadog-agent/embedded/lib/python3.12/site-packages/pip/_vendor/vendor.txt
             scanner: grype
+      - timestamp: 2025-06-27T20:05:02Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            The outdated version of urllib3 (1.26.20) is included because it's a dependency of py3-pip. Updating it will require the main pip project to release an update.
+            However, the pip maintainers are holding off on that update until Python 3.9 reaches its end-of-life (EOL) at the end of 2025. Once that happens, pip can upgrade, and then kubeflow-katib will also need to update to align with the changes in pip.
+            For more details, see this GitHub issue: https://github.com/pypa/pip/issues/12857
 
   - id: CGA-g8hg-7gx4-5ccf
     aliases:


### PR DESCRIPTION
advisory updates for datadog-agent; CVE-2025-50181, CVE-2025-50182