### PR TITLE
python-{3.10,3.11}: mark CVE-2025-6069 as fixed

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -319,6 +319,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-06-30T16:04:05Z
+        type: fixed
+        data:
+          fixed-version: 3.10.18-r1
 
   - id: CGA-qw6p-5649-8qqv
     aliases:

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -281,6 +281,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-06-30T16:04:57Z
+        type: fixed
+        data:
+          fixed-version: 3.11.13-r1
 
   - id: CGA-r6r7-88xq-68xg
     aliases:


### PR DESCRIPTION
We backported the fix, so automation won't detect it.