### PR TITLE
feat(celeborn-0.5): update advisory for GHSA-h46c-h94j-95f3

### DIFF
--- a/celeborn-0.5.advisories.yaml
+++ b/celeborn-0.5.advisories.yaml
@@ -153,6 +153,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/hadoop-client-runtime-3.4.1.jar
             scanner: grype
+      - timestamp: 2025-07-01T16:30:33Z
+        type: pending-upstream-fix
+        data:
+          note: The vuln comes from the Hadoop dependency. Jackson-core is pinned at 2.12.7 in Hadoop 3.4.1. Once Hadoop updates it and also upstream update Hadoop to the fixed version, we can update and fix the package too.
 
   - id: CGA-xvv2-g55w-6g8w
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update celeborn-0.5 advisory

Reason:
Even if we update the dependency, the scan fails https://github.com/wolfi-dev/os/pull/57836/checks?check_run_id=45147879054. It fails due to the fact that the not fixed dep comes from `hadoop-client-runtime-3.4.1`.
Hadoop uses `jackson-core` at `v2.12.7` : https://github.com/apache/hadoop/blob/rel/release-3.4.1/LICENSE-binary#L222 for that particular `v3.4.1`.
