### PR TITLE
feat: add advisory for CVE-2025-4656

### DIFF
--- a/splunk-otel-collector.advisories.yaml
+++ b/splunk-otel-collector.advisories.yaml
@@ -91,6 +91,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-07-02T10:20:09Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability is fixed in vault Enterprise 1.19.6 (which isn't publicly available) and 1.20.0. Unfortunately, due to 1.20.0's updated dependencies, the application fails to build with this version of the vault module. The upstream maintainers will need to update the codebase to be able to work with vault 1.20.0 and it's dependencies
 
   - id: CGA-5gm8-wjgv-74c2
     aliases:


### PR DESCRIPTION
It's not currently possible to build with Vault bumped to 1.20.0 - it pulls in an updated K8S module which has changes to (at least) one of it's interfaces.