### PR TITLE
add: new advisory for CVE-2025-49574 on apicurio-registry

### DIFF
--- a/apicurio-registry.advisories.yaml
+++ b/apicurio-registry.advisories.yaml
@@ -246,6 +246,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/apicurio-registry/lib/io.quarkus.quarkus-vertx-3.15.4.jar
             scanner: grype
+      - timestamp: 2025-07-02T14:33:07Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability is fixed in quarkus-vertx v3.24.0. At this time, apicurio-registry does not support this version, and as such fails to build on the new version.
 
   - id: CGA-p3w3-hrxv-jqqf
     aliases:


### PR DESCRIPTION
Adding initial advisory for `apicurio-registry`, `quarkus-vertx` affected by CVE-2025-49574. At this time we cannot bump the package as it results in a build failure.

```
└── 📄 /usr/share/java/apicurio-registry/lib/io.quarkus.quarkus-vertx-3.15.4.jar
        📦 quarkus-vertx 3.15.4 (java-archive)
            Medium CVE-2025-49574 GHSA-9623-mj7j-p9v4
```