### PR TITLE
logstash-9: add pending-upstream-fix advisories for JRuby CVEs

### DIFF
--- a/logstash-9.advisories.yaml
+++ b/logstash-9.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
             scanner: grype
+      - timestamp: 2025-07-02T19:50:00Z
+        type: pending-upstream-fix
+        data:
+          note: The cgi gem at version 0.3.6 is included as a default gem in JRuby's standard library. Because it's part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of cgi (0.3.7+).
 
   - id: CGA-4wm4-mg4v-92rh
     aliases:
@@ -39,6 +43,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/stdlib/jopenssl.jar
             scanner: grype
+      - timestamp: 2025-07-02T19:50:00Z
+        type: pending-upstream-fix
+        data:
+          note: The jruby-openssl component at version 0.15.0 is bundled within JRuby's standard library as jopenssl.jar. Because it's part of JRuby itself rather than a separately managed dependency, an updated JRuby release is required to incorporate the remediated version of jruby-openssl (0.15.4+).
 
   - id: CGA-hrf8-h5p2-f5r9
     aliases:
@@ -57,6 +65,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/uri-0.12.2.gemspec
             scanner: grype
+      - timestamp: 2025-07-02T19:50:00Z
+        type: pending-upstream-fix
+        data:
+          note: The uri gem at version 0.12.2 is included as a default gem in JRuby's standard library. Because it's part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of uri (0.12.4+).
 
   - id: CGA-v5rf-cjpm-q5f6
     aliases:
@@ -75,3 +87,7 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
             scanner: grype
+      - timestamp: 2025-07-02T19:50:00Z
+        type: pending-upstream-fix
+        data:
+          note: The cgi gem at version 0.3.6 is included as a default gem in JRuby's standard library. Because it's part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of cgi (0.3.7+).


### PR DESCRIPTION
## Summary

Add pending-upstream-fix advisory events for four CVEs affecting JRuby default gems in logstash-9.

## CVEs Addressed

- **CVE-2025-27219** (GHSA-gh9q-2xrm-x6qv): cgi gem 0.3.6 → fixed in 0.3.7+
- **CVE-2025-27220** (GHSA-mhwm-jh88-3gjf): cgi gem 0.3.6 → fixed in 0.3.7+  
- **CVE-2025-27221** (GHSA-22h5-pq3x-2gf2): uri gem 0.12.2 → fixed in 0.12.4+
- **CVE-2025-46551** (GHSA-72qj-48g4-5xgx): jruby-openssl 0.15.0 → fixed in 0.15.4+

## Analysis

These vulnerabilities exist in JRuby default gems and bundled components that are part of JRuby's standard library. Since logstash-9 uses JRuby 9.4.13.0 which includes these vulnerable gem versions, the fixes require an updated JRuby release to incorporate the remediated versions.

## Testing

Confirmed vulnerable gem versions present in logstash-9 via wolfictl scan:
- cgi 0.3.6 detected at vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
- uri 0.12.2 detected at vendor/jruby/lib/ruby/gems/shared/specifications/default/uri-0.12.2.gemspec
- jruby-openssl 0.15.0 detected at vendor/jruby/lib/ruby/stdlib/jopenssl.jar