### PR TITLE
tez: add pending-upstream-fix advisory for GHSA-h46c-h94j-95f3

### DIFF
--- a/tez.advisories.yaml
+++ b/tez.advisories.yaml
@@ -105,6 +105,13 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tez/lib/jackson-core-2.12.7.jar
             scanner: grype
+      - timestamp: 2025-07-02T17:35:00Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            The jackson-core vulnerability cannot be upgraded to the fix version (2.15.0+) due to Java 8 compatibility requirements.
+            Tez 0.10.5 requires Java 8 (openjdk-8-default-jvm) while jackson-core 2.15.0+ requires Java 11+.
+            This requires either an upstream Tez release that supports Java 11+ or a jackson-core backport that maintains Java 8 compatibility with the security fix.
 
   - id: CGA-2v7f-j393-2r48
     aliases:


### PR DESCRIPTION
Adds pending-upstream-fix event to tez advisory file for GHSA-h46c-h94j-95f3 (jackson-core StackOverflowError vulnerability).

## Background
Automated PR wolfi-dev/os#57909 attempted to fix this CVE by updating jackson-core 2.12.7 → 2.15.0, but this cannot work due to Java compatibility requirements.

## Root Cause
- **Tez 0.10.5** requires Java 8 (openjdk-8-default-jvm)
- **jackson-core 2.15.0+** (fix version) requires Java 11+

## Resolution Options
1. Upstream Tez release that supports Java 11+
2. jackson-core backport that maintains Java 8 compatibility with the security fix

## Related
- Supersedes automated PR wolfi-dev/os#57909