### PR TITLE
chromium: update advisory

### DIFF
--- a/kubeflow.advisories.yaml
+++ b/kubeflow.advisories.yaml
@@ -44,6 +44,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/access-management
             scanner: grype
+      - timestamp: 2025-07-04T07:02:43Z
+        type: true-positive-determination
+        data:
+          note: 'Govulncheck found vulnerable symbols in Go binaries at the following locations: in kubeflow-access-management-1.10.0-r1.apk, at usr/bin/access-management, usr/bin/access-management.'
 
   - id: CGA-76h9-q8mp-8cjp
     aliases:


### PR DESCRIPTION
Update advisory for CVE-2025-6554:
Chromium has been releasing interim releases with the fixes, and we are now waiting for upstream to cut a release with the fix in place for this CVE in order to remediate it.