### PR TITLE
open-webui: update advisory

### DIFF
--- a/open-webui.advisories.yaml
+++ b/open-webui.advisories.yaml
@@ -65,6 +65,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/open-webui/lib/python3.11/site-packages/pillow-11.2.1.dist-info/METADATA, /usr/share/open-webui/lib/python3.11/site-packages/pillow-11.2.1.dist-info/RECORD, /usr/share/open-webui/lib/python3.11/site-packages/pillow-11.2.1.dist-info/top_level.txt
             scanner: grype
+      - timestamp: 2025-07-04T16:42:46Z
+        type: pending-upstream-fix
+        data:
+          note: Any attempts to upgrade pillow to >=11.3.0 result in a build failure, we will need to wait for upstream to update their code and bump the pillow dependency in order to resolve the CVE.
 
   - id: CGA-mmqg-f57g-9jcp
     aliases:


### PR DESCRIPTION
Update advisory for GHSA-xg8h-j46f-w952
Any attempts to upgrade pillow to >=11.3.0 result in a build failure, we will need to wait for upstream to update their code and bump the pillow dependency in order to resolve the CVE.