### PR TITLE
The metadata in the NVD is a bit imprecise - .92 was released for Win…

### DIFF
--- a/chromium.advisories.yaml
+++ b/chromium.advisories.yaml
@@ -420,6 +420,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-06T17:20:04Z
+        type: fixed
+        data:
+          fixed-version: 138.0.7204.92-r0
 
   - id: CGA-4mm2-vgrg-hqvx
     aliases:


### PR DESCRIPTION
…dows/Mac at the same time as .96 for windows.

Two links mentioning the fix is in .92 for Linux:
https://chromereleases.googleblog.com/2025/06/stable-channel-update-for-desktop_30.html https://www.helpnetsecurity.com/2025/07/01/google-patches-actively-exploited-chrome-cve-2025-6554/