### PR TITLE
go-1.22.advisories: add fix-not-planned advisory for CVE-2025-0913

### DIFF
--- a/go-1.22.advisories.yaml
+++ b/go-1.22.advisories.yaml
@@ -202,6 +202,16 @@ advisories:
         data:
           fixed-version: 1.22.5-r0
 
+  - id: CGA-99qg-pc6m-vjhj
+    aliases:
+      - CVE-2025-0913
+      - GHSA-jw54-c8rr-pjpq
+    events:
+      - timestamp: 2025-07-08T09:52:28Z
+        type: fix-not-planned
+        data:
+          note: The affected package has reached end-of-life, and no further fixes will be issued. Users are encouraged to migrate to a supported version or alternative package.
+
   - id: CGA-hc9r-rhqm-jg3h
     aliases:
       - CVE-2025-4673


### PR DESCRIPTION
Add fix-not-planned.