### PR TITLE
rancher-2.11: update advisory

### DIFF
--- a/rancher-2.11.advisories.yaml
+++ b/rancher-2.11.advisories.yaml
@@ -160,6 +160,10 @@ advisories:
         type: fix-not-planned
         data:
           note: v3 is not supported any longer (the last commit on https://github.com/golang-jwt/jwt/tree/v3 was 4 years ago), so it won't be fixed.
+      - timestamp: 2025-07-08T12:09:28Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream still relies on this outdated dependency. Since there's no jwt v3 fix for the CVE, upstream must update their code and dependencies to use a newer jwt version.
 
   - id: CGA-q34j-c3m9-m32j
     aliases:


### PR DESCRIPTION
Update advisory for CVE-2025-30204
Upstream still relies on this outdated dependency. Since there's no jwt v3 fix for the CVE, upstream must update their code and dependencies to use a newer jwt version.