### PR TITLE
parseable: add pending-upstream-fix advisory for GHSA-rxf6-323f-44fc

### DIFF
--- a/parseable.advisories.yaml
+++ b/parseable.advisories.yaml
@@ -42,6 +42,11 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/parseable
             scanner: grype
+      - timestamp: 2025-07-09T00:40:00Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            This vulnerability requires upgrading protobuf from 2.28.0 to 3.7.2. However, parseable depends on prometheus 0.13, which only supports protobuf 2.x. The newer prometheus 0.14.0+ supports protobuf 3.x, but parseable has not yet upgraded to this version. This fix is blocked until upstream parseable upgrades to prometheus 0.14.0 or later.
 
   - id: CGA-3993-pvwh-4q44
     aliases:


### PR DESCRIPTION
## Summary
- Adds pending-upstream-fix advisory for protobuf vulnerability GHSA-rxf6-323f-44fc (CVE-2025-53605) in parseable

## Details
The protobuf vulnerability requires upgrading from version 2.28.0 to 3.7.2. However, this upgrade is blocked because:

1. parseable depends on prometheus 0.13.x
2. prometheus 0.13.x only supports protobuf 2.x (has a `^2.0` requirement)
3. prometheus 0.14.0+ supports protobuf 3.x, but parseable hasn't upgraded yet

## Investigation
- Attempted to use cargobump to force protobuf 3.7.2, but it fails due to version incompatibility
- Checked upstream parseable - still uses prometheus 0.13
- Verified that prometheus 0.14.0 uses protobuf 3.7.2

This fix requires upstream parseable to upgrade to prometheus 0.14.0 or later.

## Test Plan
- [x] Advisory formatted with yam
- [x] Advisory follows correct format with timestamp and note