### PR TITLE
qdrant: add pending-upstream-fix advisory for GHSA-rxf6-323f-44fc

### DIFF
--- a/qdrant.advisories.yaml
+++ b/qdrant.advisories.yaml
@@ -143,6 +143,16 @@ advisories:
         data:
           fixed-version: 1.13.6-r1
 
+  - id: CGA-g958-hm8g-28vv
+    aliases:
+      - CVE-2025-53605
+      - GHSA-rxf6-323f-44fc
+    events:
+      - timestamp: 2025-07-09T01:53:22Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability requires upgrading protobuf from 2.28.0 to 3.7.2. However, qdrant's storage crate depends on raft 0.7.0, which explicitly requires protobuf 2.x. The raft crate is the latest version available and does not support protobuf 3.x. This fix is blocked until either the raft project releases a new version supporting protobuf 3.x, or qdrant replaces raft with an alternative consensus library.
+
   - id: CGA-hxqc-vvc2-qmhw
     aliases:
       - CVE-2024-12224


### PR DESCRIPTION
## Summary
- Adds pending-upstream-fix advisory for protobuf vulnerability GHSA-rxf6-323f-44fc (CVE-2025-53605) in qdrant

## Details
The protobuf vulnerability requires upgrading from version 2.28.0 to 3.7.2. However, this upgrade is blocked by a deep dependency chain:

1. qdrant's storage crate depends on raft 0.7.0
2. raft 0.7.0 explicitly requires protobuf 2.x (has `protobuf = "2"` in its Cargo.toml)
3. There is no newer version of raft that supports protobuf 3.x
4. The raft project closed a PR to remove protobuf support without merging it

## Investigation
- Attempted to use cargobump to force protobuf 3.7.2, but it fails with: `error: failed to select a version for the requirement 'protobuf = "^2.28.0"'` from the storage crate
- Checked qdrant's storage/Cargo.toml - it has `protobuf = "2.28.0" # version of protobuf used by raft`
- Verified raft 0.7.0 is the latest version and requires protobuf 2.x
- Found that raft PR #473 to remove protobuf support was closed without merging

This fix requires either:
- The raft project to release a new version supporting protobuf 3.x, or
- qdrant to replace raft with an alternative consensus library

## Test Plan
- [x] Advisory formatted with yam
- [x] Advisory follows correct format with timestamp and note