### PR TITLE
apache2: updae advisories

### DIFF
--- a/apache2.advisories.yaml
+++ b/apache2.advisories.yaml
@@ -65,6 +65,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-14T13:18:42Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: False positive identified due to the scanners mismatching the version. The CVE in question has been fixed since apache 2.2.6, and the apache version where this is being detected is 2.4.64.
 
   - id: CGA-6wj6-q886-wv49
     aliases:
@@ -105,6 +110,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-14T13:18:42Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: False positive identified due to the scanners mismatching the version. The CVE in question has been fixed since apache 2.2.6, and the apache version where this is being detected is 2.4.64.
 
   - id: CGA-gpfg-33rx-33jc
     aliases:
@@ -190,3 +200,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-14T13:18:42Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: False positive identified due to the scanners mismatching the version. The CVE in question has been fixed since apache 2.2.6, and the apache version where this is being detected is 2.4.64.


### PR DESCRIPTION
Update advisories for:
    * CVE-2008-2168
    * CVE-2007-6422
    * CVE-2007-6421

False positive identified due to the scanners mismatching the version. The CVE in question has been fixed since apache 2.2.6, and the apache version where this is being detected is 2.4.64.