### PR TITLE
wordpress/advisory update

### DIFF
--- a/wordpress.advisories.yaml
+++ b/wordpress.advisories.yaml
@@ -112,6 +112,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-14T13:44:34Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'CVE-2012-3414 references versions of WordPress before 3.3.2 which included swfupload.swf. This was removed in 4.9 and later. Reference: https://github.com/WordPress/WordPress/commit/76296ef6578839c1894fbef56a6846665d1c903f\#diff-a76ce7dcc354a6f0a410e9b8f75aac9c59bafa00b0360641f3d4d992956dad82'
 
   - id: CGA-j295-hqc3-w776
     aliases:


### PR DESCRIPTION
wordpress false-positive-determination CVE-2012-3414