### PR TITLE
openjdk-23: add fix-not-planned advisories for CVE-2025-30691, CVE-2025-30698, CVE-2025-21587

### DIFF
--- a/openjdk-23.advisories.yaml
+++ b/openjdk-23.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-14T21:23:56Z
+        type: fix-not-planned
+        data:
+          note: Package is end-of-life and will not receive security updates. Users should migrate to a supported Java version.
 
   - id: CGA-p3p4-p9mc-vxp5
     aliases:
@@ -39,6 +43,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-14T21:23:42Z
+        type: fix-not-planned
+        data:
+          note: Package is end-of-life and will not receive security updates. Users should migrate to a supported Java version.
 
   - id: CGA-whxc-3rxq-v3gv
     aliases:
@@ -67,3 +75,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-14T21:23:27Z
+        type: fix-not-planned
+        data:
+          note: Package is end-of-life and will not receive security updates. Users should migrate to a supported Java version.


### PR DESCRIPTION
## Summary

This PR adds fix-not-planned advisories for three CVEs affecting openjdk-23:
- CVE-2025-30691
- CVE-2025-30698
- CVE-2025-21587

## Justification

OpenJDK 23 is end-of-life and will not receive security updates. Users should migrate to a supported Java version (e.g., OpenJDK 21 LTS or OpenJDK 25).

## Changes

- Added fix-not-planned events to openjdk-23.advisories.yaml for all three CVEs
- Each advisory includes a note explaining the package is EOL and users should migrate