### PR TITLE
feat(dependency-track): update advisory for GHSA-xwmg-2g98-w7v9

### DIFF
--- a/dependency-track.advisories.yaml
+++ b/dependency-track.advisories.yaml
@@ -248,6 +248,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/dependency-track/dependency-track-bundled.jar
             scanner: grype
+      - timestamp: 2025-07-16T10:57:50Z
+        type: pending-upstream-fix
+        data:
+          note: Upgrading nimbus-jose-jwt to a secure version currently results in build failures due to unresolved classpath and dependency conflicts. The upstream project must first reconcile and adjust its dependency tree to support this version correctly. Once upstream dependencies are aligned, we can proceed with the update to remediate the vulnerability and apply the necessary patch.
 
   - id: CGA-w8q8-p4r5-xxg9
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for https://github.com/advisories/GHSA-xwmg-2g98-w7v9
