### PR TITLE
management-api-for-apache-cassandra-5.0/advisory update

### DIFF
--- a/management-api-for-apache-cassandra-5.0.advisories.yaml
+++ b/management-api-for-apache-cassandra-5.0.advisories.yaml
@@ -399,6 +399,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/management-api/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar
             scanner: grype
+      - timestamp: 2025-07-16T12:35:11Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream will need to update commons-lang3 version to 3.18.0. Build time errors show conflicting transitive archives that will require some changes to source.
 
   - id: CGA-v95v-8w2m-8jvx
     aliases:


### PR DESCRIPTION
management-api-for-apache-cassandra advisory update for GHSA-j288-q9x7-2f5v