### PR TITLE
docs(keycloak): Add advisory for CVE-2025-48924

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -365,6 +365,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/keycloak/lib/lib/main/org.apache.commons.commons-lang3-3.17.0.jar
             scanner: grype
+      - timestamp: 2025-07-16T13:05:48Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE affects all versions of commons-lang and is fixed in commons-lang3 v3.18.0. Upstream will need to update the codebase to use commons-lang3 instead
 
   - id: CGA-gc9r-7467-m772
     aliases:


### PR DESCRIPTION
Keycloak uses commons-lang which doesn't have a fix available.

