### PR TITLE
php-8.x/advisory update

### DIFF
--- a/php-8.1.advisories.yaml
+++ b/php-8.1.advisories.yaml
@@ -70,6 +70,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-16T14:31:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only PHP versions 5.2.4 and earlier are affected, and the issue is specific to the MySQL extension. Versions in the 8.x series are not impacted.
 
   - id: CGA-568h-6xvh-f876
     aliases:

--- a/php-8.2.advisories.yaml
+++ b/php-8.2.advisories.yaml
@@ -168,3 +168,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-16T14:31:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only PHP versions 5.2.4 and earlier are affected, and the issue is specific to the MySQL extension. Versions in the 8.x series are not impacted.

--- a/php-8.3.advisories.yaml
+++ b/php-8.3.advisories.yaml
@@ -30,6 +30,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-16T14:31:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only PHP versions 5.2.4 and earlier are affected, and the issue is specific to the MySQL extension. Versions in the 8.x series are not impacted.
 
   - id: CGA-5q74-q9fw-2mf8
     aliases:

--- a/php-8.4.advisories.yaml
+++ b/php-8.4.advisories.yaml
@@ -39,6 +39,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-16T14:31:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: Only PHP versions 5.2.4 and earlier are affected, and the issue is specific to the MySQL extension. Versions in the 8.x series are not impacted.
 
   - id: CGA-gpwg-vmwg-p2mv
     aliases:


### PR DESCRIPTION
php-8.x: false positive determination CVE-2007-4889/GHSA-chpc-3cm4-f9gq