### PR TITLE
docs(tez): add advisory for CVE-2025-48924

### DIFF
--- a/tez.advisories.yaml
+++ b/tez.advisories.yaml
@@ -790,6 +790,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/tez/lib/commons-lang-2.6.jar
             scanner: grype
+      - timestamp: 2025-07-16T16:08:34Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE impacts all versions of commons-lang. The fix is available in commons-lang3, but the upstream maintainers will need to update the codebase to use that library instead.
 
   - id: CGA-fwfm-h859-76rr
     aliases:


### PR DESCRIPTION
`tez` uses the `commons-lang` library.

However, the fix for CVE-2025-48924 is only available in the 3.x series of this library, released under the new name `commons-lang3`

Upstream will need to make code changes to use the newer releases.