### PR TITLE
jenkins-2: update advisory

### DIFF
--- a/jenkins-2.advisories.yaml
+++ b/jenkins-2.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/jenkins/jenkins.war
             scanner: grype
+      - timestamp: 2025-07-16T16:32:36Z
+        type: pending-upstream-fix
+        data:
+          note: 'As per the advisory commons-lang has no patched version and as per the description, upstream package maintainers of commons-lang recommend to upgrade to commons-lang3 version 3.18.0 or greater. Jenkins-2 has to upgrade their dependency in order to fix this CVE. More information on the advisory: https://github.com/advisories/GHSA-j288-q9x7-2f5v'
 
   - id: CGA-6294-j3wv-p997
     aliases:


### PR DESCRIPTION
Update advisory for GHSA-j288-q9x7-2f5v
As per the advisory commons-lang has no patched version and as per the description, upstream package maintainers of commons-lang recommend to upgrade to commons-lang3 version 3.18.0 or greater. Jenkins-2 has to upgrade their dependency in order to fix this CVE. More information on the advisory: https://github.com/advisories/GHSA-j288-q9x7-2f5v