### PR TITLE
gradle-8: update advisory

### DIFF
--- a/gradle-8.advisories.yaml
+++ b/gradle-8.advisories.yaml
@@ -226,6 +226,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/gradle/lib/commons-lang-2.6.jar
             scanner: grype
+      - timestamp: 2025-07-17T07:50:50Z
+        type: pending-upstream-fix
+        data:
+          note: 'As per the advisory commons-lang has no patched version and as per the description, upstream package maintainers of commons-lang recommend to upgrade to commons-lang3 version 3.18.0 or greater. Upstream has to upgrade their dependency in order to fix this CVE. More information on the advisory: https://github.com/advisories/GHSA-j288-q9x7-2f5v'
 
   - id: CGA-hq55-qp37-gwm6
     aliases:


### PR DESCRIPTION
Update advisory for GHSA-j288-q9x7-2f5v
As per the advisory commons-lang has no patched version and as per the description, upstream package maintainers of commons-lang recommend to upgrade to commons-lang3 version 3.18.0 or greater. Upstream has to upgrade their dependency in order to fix this CVE. More information on the advisory: https://github.com/advisories/GHSA-j288-q9x7-2f5v