### PR TITLE
nextflow: add pending-upstream-fix for GHSA-j288-q9x7-2f5v

### DIFF
--- a/nextflow.advisories.yaml
+++ b/nextflow.advisories.yaml
@@ -43,3 +43,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/nextflow/nextflow-25.04.6-one.jar
             scanner: grype
+      - timestamp: 2025-07-17T09:35:14Z
+        type: pending-upstream-fix
+        data:
+          note: 'As per the advisory commons-lang has no patched version and as per the description, upstream package maintainers of commons-lang recommend to upgrade to commons-lang3 version 3.18.0 or greater. Nextflow has to upgrade their dependency in order to fixe this CVE. More information on the advisory: https://github.com/advisories/GHSA-j288-q9x7-2f5v'


### PR DESCRIPTION
We are pending an upstream fix for nextflow.