### PR TITLE
apache2: add false-positive-determination for CVE-2025-23048

### DIFF
--- a/apache2.advisories.yaml
+++ b/apache2.advisories.yaml
@@ -110,6 +110,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-17T13:25:52Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: False positive due to version mismatch. The CVE in question has been fixed in apache 2.4.64, see https://httpd.apache.org/security/vulnerabilities_24.html
 
   - id: CGA-c9vm-p3vv-7h96
     aliases:


### PR DESCRIPTION
The CVE-2025-23048 has been fixed in apache 2.4.64.

See also:
 * See https://httpd.apache.org/security/vulnerabilities_24.html
 * https://github.com/chainguard-dev/CVE-Dashboard/issues/26035