### PR TITLE
wavefront-proxy: add pending-upstream-fix for CVE-2025-48924 GHSA-j288-q9x7-2f5v

### DIFF
--- a/wavefront-proxy.advisories.yaml
+++ b/wavefront-proxy.advisories.yaml
@@ -40,6 +40,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/wavefront/wavefront-proxy/wavefront-proxy.jar
             scanner: grype
+      - timestamp: 2025-07-17T15:50:24Z
+        type: pending-upstream-fix
+        data:
+          note: 'As per the advisory commons-lang has no patched version and as per the description, upstream package maintainers of commons-lang recommend to upgrade to commons-lang3 version 3.18.0 or greater. wavefront-proxy upstream has to upgrade their dependency in order to fixe this CVE. More information on the advisory: https://github.com/advisories/GHSA-j288-q9x7-2f5v'
 
   - id: CGA-6pm4-w9vr-cj5w
     aliases:


### PR DESCRIPTION
Add pending-upstream-fix for CVE-2025-48924 GHSA-j288-q9x7-2f5v

See also:
 * https://github.com/wolfi-dev/os/pull/59059