### PR TITLE
celeborn-0.5: add pending-upstream-fix advisory for CVE-2024-6763

### DIFF
--- a/celeborn-0.5.advisories.yaml
+++ b/celeborn-0.5.advisories.yaml
@@ -47,6 +47,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: hadoop-runtime-client 3.4.1 is the latest version; jetty-http is a dependency
+      - timestamp: 2025-07-17T17:59:52Z
+        type: pending-upstream-fix
+        data:
+          note: 'The jetty-http vulnerability is present in two locations: bundled inside hadoop-client-runtime-3.4.1.jar (version 9.4.53.v20231009) and as a direct dependency (version 9.4.57.v20241219). Both require jetty-http 12.0.12+ to fix. Since this is a major version jump (9.x to 12.x), it requires upstream changes in both Hadoop and Celeborn.'
 
   - id: CGA-8xcv-pq3f-p4mp
     aliases:


### PR DESCRIPTION
## Description

This PR adds a pending-upstream-fix advisory for CVE-2024-6763 (jetty-http) in celeborn-0.5.

## Details
The jetty-http vulnerability is present in two locations:
- Bundled inside hadoop-client-runtime-3.4.1.jar (version 9.4.53.v20231009)
- As a direct dependency (version 9.4.57.v20241219)

Both versions require jetty-http 12.0.12+ to fix the vulnerability, which is a major version jump (9.x to 12.x) requiring upstream changes in both Hadoop and Celeborn.

## References
- CVE issue: https://github.com/chainguard-dev/CVE-Dashboard/issues/25903
- GHSA: https://github.com/advisories/GHSA-qh8g-58pp-2wxh

## Checklist
- [x] Advisory updated using wolfictl
- [x] Timestamp automatically generated
- [x] Detailed note explaining the blocker