### PR TITLE
spark-4.0: Update advisories

### DIFF
--- a/spark-4.0.advisories.yaml
+++ b/spark-4.0.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/hadoop-client-runtime-3.4.1.jar
             scanner: grype
+      - timestamp: 2025-07-17T18:19:18Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream maintainers will need to update the nimbus-jose-jwt versions to newer ones, as there are several different version references that utilize shaded JARs. Attempts to rebuild with newer versions resulted in conflicts and build issues
 
   - id: CGA-53qq-qh98-q7jv
     aliases:
@@ -87,6 +91,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/lib/spark/jars/commons-lang-2.6.jar
             scanner: grype
+      - timestamp: 2025-07-17T18:18:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'As per the advisory commons-lang has no patched version and as per the description, upstream package maintainers of commons-lang recommend to upgrade to commons-lang3 version 3.18.0 or greater. Upstream has to upgrade their dependency in order to fix this CVE. More information on the advisory: https://github.com/advisories/GHSA-j288-q9x7-2f5v'
 
   - id: CGA-9h2q-jvgf-3h42
     aliases:


### PR DESCRIPTION
Update advisories for GHSA-j288-q9x7-2f5v
As per the advisory commons-lang has no patched version and as per the description, upstream package maintainers of commons-lang recommend to upgrade to commons-lang3 version 3.18.0 or greater. Upstream has to upgrade their dependency in order to fix this CVE. More information on the advisory: https://github.com/advisories/GHSA-j288-q9x7-2f5v

Update advisories for GHSA-xwmg-2g98-w7v9
Upstream maintainers will need to update the nimbus-jose-jwt versions to newer ones, as there are several different version references that utilize shaded JARs. Attempts to rebuild with newer versions resulted in conflicts and build issues