### PR TITLE
celeborn-0.5/advisory update

### DIFF
--- a/celeborn-0.5.advisories.yaml
+++ b/celeborn-0.5.advisories.yaml
@@ -157,6 +157,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/commons-lang3-3.12.0.jar
             scanner: grype
+      - timestamp: 2025-07-17T19:43:19Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream needs to upgrade package to latest version. Attempts to update result in build failures and CVEs not being fixed
 
   - id: CGA-rc57-hr6c-69f6
     aliases:
@@ -197,6 +201,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/hadoop-client-runtime-3.4.1.jar
             scanner: grype
+      - timestamp: 2025-07-17T19:43:19Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream needs to upgrade package to latest version. Attempts to update result in build failures and CVEs not being fixed
 
   - id: CGA-xvv2-g55w-6g8w
     aliases:


### PR DESCRIPTION
adv: celeborn GHSA-j288-q9x7-2f5v and GHSA-xwmg-2g98-w7v9