### PR TITLE
open-webui: add pending-upstream-fix advisory for CVE-2025-53643

### DIFF
--- a/open-webui.advisories.yaml
+++ b/open-webui.advisories.yaml
@@ -109,6 +109,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/open-webui/lib/python3.11/site-packages/aiohttp-3.11.11.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-07-17T22:26:25Z
+        type: pending-upstream-fix
+        data:
+          note: Bumping aiohttp to 3.12.14+ causes build failures. No upstream PRs currently address this incompatibility. Upstream maintainers must implement changes to accommodate aiohttp 3.12.14+ before this CVE can be resolved.
 
   - id: CGA-qg34-qp8g-rhvg
     aliases:


### PR DESCRIPTION
## Summary

This PR adds a pending-upstream-fix advisory for CVE-2025-53643 (GHSA-9548-qrrj-x5pj) in the open-webui package.

## Details

- **CVE**: CVE-2025-53643 / GHSA-9548-qrrj-x5pj
- **Component**: aiohttp < 3.12.14
- **Issue**: Bumping aiohttp to 3.12.14+ to fix the vulnerability causes build failures
- **Upstream Status**: No open PRs addressing this incompatibility

## Advisory Note

> Bumping aiohttp to 3.12.14+ causes build failures. No upstream PRs currently address this incompatibility. Upstream maintainers must implement changes to accommodate aiohttp 3.12.14+ before this CVE can be resolved.

## Related

- Failed remediation PR: https://github.com/wolfi-dev/os/pull/59599