### PR TITLE
openjdk-23: CVEs as fix-not-planned (EOL package)

### DIFF
--- a/openjdk-23.advisories.yaml
+++ b/openjdk-23.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-18T17:11:20Z
+        type: fix-not-planned
+        data:
+          note: Package is end-of-life and will not receive security updates. Users should migrate to a supported Java version.
 
   - id: CGA-5q4c-fm37-ccjf
     aliases:
@@ -79,6 +83,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-18T17:11:05Z
+        type: fix-not-planned
+        data:
+          note: Package is end-of-life and will not receive security updates. Users should migrate to a supported Java version.
 
   - id: CGA-7q9r-6j68-m637
     aliases:
@@ -97,6 +105,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-18T17:11:38Z
+        type: fix-not-planned
+        data:
+          note: Package is end-of-life and will not receive security updates. Users should migrate to a supported Java version.
 
   - id: CGA-p3p4-p9mc-vxp5
     aliases:
@@ -137,6 +149,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-18T17:10:50Z
+        type: fix-not-planned
+        data:
+          note: Package is end-of-life and will not receive security updates. Users should migrate to a supported Java version.
 
   - id: CGA-whxc-3rxq-v3gv
     aliases:


### PR DESCRIPTION
OpenJDK 23 is end-of-life and will not receive security updates for these CVEs:
- CVE-2025-50059: Improve HTTP client header handling
- CVE-2025-30754: Enhance TLS protocol support
- CVE-2025-50106: Better Glyph drawing redux
- CVE-2025-30749: Better Glyph drawing

Users should migrate to a supported Java version (OpenJDK 21 LTS, OpenJDK 24, or OpenJDK 17 LTS).