### PR TITLE
ruby-3.3: add pending-upstream-fix advisory for CVE-2025-24294

### DIFF
--- a/ruby-3.3.advisories.yaml
+++ b/ruby-3.3.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.3.0/specifications/default/resolv-0.3.0.gemspec
             scanner: grype
+      - timestamp: 2025-07-18T20:30:00Z
+        type: pending-upstream-fix
+        data:
+          note: The resolv gem at version 0.3.0 is included as a default gem in Ruby's standard library. The fix for this CVE requires updating resolv to include security patches. Ruby upstream has an open PR (https://github.com/ruby/ruby/pull/13817) awaiting review to address this vulnerability. Once upstream maintainers approve the functional changes, this fix will be implemented in the ruby_3_3 branch.
 
   - id: CGA-3fx7-h7mc-hmv8
     aliases:


### PR DESCRIPTION
Add advisory noting that the resolv gem vulnerability requires an upstream fix. Ruby has an open PR (https://github.com/ruby/ruby/pull/13817) to address this CVE that is awaiting review.

The resolv gem is a default gem bundled with Ruby's standard library, so it cannot be updated independently. We must wait for upstream to merge the fix and backport it to the ruby_3_3 branch.

## Test plan
- [ ] Advisory file is properly formatted
- [ ] Advisory correctly documents the pending upstream fix