### PR TITLE
feat(filebrowser): update advisory for CVE-2025-53893

### DIFF
--- a/filebrowser.advisories.yaml
+++ b/filebrowser.advisories.yaml
@@ -217,6 +217,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-21T13:12:41Z
+        type: pending-upstream-fix
+        data:
+          note: FileBrowser version 2.38.0 is affected by a denial-of-service (DoS) vulnerability stemming from uncontrolled memory allocation when processing file reads. At this time, no upstream patch or mitigation has been released. We are actively monitoring the upstream repository for remediation and will evaluate patching or mitigation strategies once a fix becomes available.
 
   - id: CGA-gx95-q2xj-chf6
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update Filebrowser advisory about https://github.com/advisories/GHSA-7xqm-7738-642x
