### PR TITLE
Advisory updates: ruby-3.2 false positive and keycloak-operator-fips pending upstream fix

### DIFF
--- a/keycloak-operator-fips.advisories.yaml
+++ b/keycloak-operator-fips.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: 2.0.2
+
+package:
+  name: keycloak-operator-fips
+
+advisories:
+  - id: CGA-hc5v-v9cv-qr4m
+    aliases:
+      - CVE-2025-49574
+      - GHSA-9623-mj7j-p9v4
+    events:
+      - timestamp: 2025-07-21T20:37:19Z
+        type: pending-upstream-fix
+        data:
+          note: Bumping to the fix version causes test failures. This requires upstream to implement the necessary functional changes to support the updated quarkus-vertx dependency before the CVE can be resolved.

--- a/ruby-3.2.advisories.yaml
+++ b/ruby-3.2.advisories.yaml
@@ -131,6 +131,11 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.2.8-r3
+      - timestamp: 2025-07-21T20:24:30Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: 'The vulnerable code has been fixed through cherry-picking commit 9f00b8872d3e294312c99150f1c34b6b3fa74985 from upstream ruby_3_2 branch, updating resolv gem from 0.2.2 to 0.2.3. This addresses the ReDoS vulnerability in the resolv gem. Reference: https://github.com/wolfi-dev/os/pull/60032'
 
   - id: CGA-hg25-58p6-ch23
     aliases:


### PR DESCRIPTION
## Summary
- Added false positive advisory for ruby-3.2 CVE-2025-24294 (vulnerability fixed via upstream cherry-pick)
- Added pending upstream fix advisory for keycloak-operator-fips GHSA-9623-mj7j-p9v4 (requires upstream functional changes)

## Details

### ruby-3.2 (CVE-2025-24294)
- Type: `false-positive-determination` with `vulnerable-code-not-included-in-package`
- Fix applied via cherry-pick of commit 9f00b8872d3e294312c99150f1c34b6b3fa74985 from upstream ruby_3_2 branch
- Reference: https://github.com/wolfi-dev/os/pull/60032

### keycloak-operator-fips (GHSA-9623-mj7j-p9v4)
- Type: `pending-upstream-fix`
- Bumping to fix version causes test failures
- Requires upstream to implement necessary functional changes to support updated quarkus-vertx dependency
- Reference: https://github.com/chainguard-dev/CVE-Dashboard/issues/26090

🤖 Generated with [Claude Code](https://claude.ai/code)