### PR TITLE
keycloak-operator-fips: add pending upstream fix advisory for GHSA-9623-mj7j-p9v4

### DIFF
--- a/keycloak-operator-fips.advisories.yaml
+++ b/keycloak-operator-fips.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: 2.0.2
+
+package:
+  name: keycloak-operator-fips
+
+advisories:
+  - id: CGA-rm82-vw74-r4fx
+    aliases:
+      - CVE-2025-49574
+      - GHSA-9623-mj7j-p9v4
+    events:
+      - timestamp: 2025-07-21T20:40:24Z
+        type: pending-upstream-fix
+        data:
+          note: 'Bumping to fix version causes test failures. Requires upstream to implement necessary functional changes to support updated quarkus-vertx dependency. Reference: CVE detection: keycloak-operator-fips/GHSA-9623-mj7j-p9v4 chainguard-dev/CVE-Dashboard#26090'


### PR DESCRIPTION
Add pending upstream fix advisory for keycloak-operator-fips GHSA-9623-mj7j-p9v4.

Bumping to fix version causes test failures. Requires upstream to implement necessary functional changes to support updated quarkus-vertx dependency.

Reference: CVE detection: keycloak-operator-fips/GHSA-9623-mj7j-p9v4 chainguard-dev/CVE-Dashboard#26090