### PR TITLE
wizer/zed/zellij: update advisory

### DIFF
--- a/wizer.advisories.yaml
+++ b/wizer.advisories.yaml
@@ -86,6 +86,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/wizer
             scanner: grype
+      - timestamp: 2025-07-22T09:07:09Z
+        type: pending-upstream-fix
+        data:
+          note: Any attempts to bump the wasmtime dependency to a fixed version result in build failures. Upstream will have to bump the wasmtime dependency and cut a new release with the fixed version.
 
   - id: CGA-82pj-77h5-rh52
     aliases:

--- a/zed.advisories.yaml
+++ b/zed.advisories.yaml
@@ -224,6 +224,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/libexec/zed
             scanner: grype
+      - timestamp: 2025-07-22T09:07:09Z
+        type: pending-upstream-fix
+        data:
+          note: Any attempts to bump the wasmtime dependency to a fixed version result in build failures. Upstream will have to bump the wasmtime dependency and cut a new release with the fixed version.
 
   - id: CGA-g6ph-r6xm-x22c
     aliases:

--- a/zellij.advisories.yaml
+++ b/zellij.advisories.yaml
@@ -286,6 +286,10 @@ advisories:
             componentType: rust-crate
             componentLocation: /usr/bin/zellij
             scanner: grype
+      - timestamp: 2025-07-22T09:07:09Z
+        type: pending-upstream-fix
+        data:
+          note: Any attempts to bump the wasmtime dependency to a fixed version result in build failures. Upstream will have to bump the wasmtime dependency and cut a new release with the fixed version.
 
   - id: CGA-wwr7-2chc-98v2
     aliases:


### PR DESCRIPTION
Update advisory for GHSA-fm79-3f68-h2fc
Any attempts to bump the wasmtime dependency to a fixed version result in build failures. Upstream will have to bump the wasmtime dependency and cut a new release with the fixed version.