### PR TITLE
peerdb-flow: add false-positive advisories for tidb CVEs

### DIFF
--- a/peerdb-flow.advisories.yaml
+++ b/peerdb-flow.advisories.yaml
@@ -1,0 +1,27 @@
+schema-version: 2.0.2
+
+package:
+  name: peerdb-flow
+
+advisories:
+  - id: CGA-4r69-4v5q-v2cr
+    aliases:
+      - CVE-2024-37820
+      - GHSA-9g6g-xqv5-8g5w
+    events:
+      - timestamp: 2025-07-22T15:57:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The tidb version used (commit from Jan 2025) is newer than the fixed version 8.2.0 (released July 2024).
+
+  - id: CGA-4vq8-hmg8-29vw
+    aliases:
+      - CVE-2022-3023
+      - GHSA-7fxj-fr3v-r9gj
+    events:
+      - timestamp: 2025-07-22T15:55:49Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: The tidb version used (commit from Jan 2025) is newer than the code where this 2022 vulnerability was fixed.


### PR DESCRIPTION
- **Summary:** This PR creates a new advisory for `peerdb-flow` to mark the following CVEs as `false-positive-determination`:
  - `CVE-2022-3023`
  - `CVE-2024-37820`

- **Reason:** The scanner flags these vulnerabilities in the `github.com/pingcap/tidb` dependency. However, PeerDB uses a Go pseudo-version (`v0.0.0-20250130070702-43f2fb91d740`) which corresponds to a commit date of **January 30, 2025**. This date is newer than the release dates for the fixes for both CVEs (`2022` and `July 2024`, respectively). Therefore, the vulnerable code is not present in the version of the dependency being used, making the findings false positives.

- **References:**
  - Package PR: https://github.com/chainguard-dev/enterprise-packages/pull/27246
  - Image Request: `chainguard-images/image-requests#6256`

- **Workflow:**
  1. Created `peerdb-flow.advisories.yaml` locally.
  2. Ran `wolfictl adv guide` to process the file, generate CGA IDs, and create this PR.