### PR TITLE
DRAFT: add advisory for rke2-runtime-1.32.2.2.1

### DIFF
--- a/rke2-runtime.advisories.yaml
+++ b/rke2-runtime.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: 2.0.2
+
+package:
+  name: rke2-runtime
+
+advisories:
+  - id: CGA-x356-v6mx-5q28
+    aliases:
+      - CVE-2024-36623
+      - GHSA-gh5c-3h97-2f3q
+    events:
+      - timestamp: 2025-07-22T18:17:59Z
+        type: pending-upstream-fix
+        data:
+          note: rke2-runtime 1.32.2.2.1 uses Docker v25.0.8+incompatible (see https://github.com/rancher/rke2/blob/master/go.mod#L12C55-L12C75), but its go.mod requires Docker v28.3.2+incompatible. cri-docker is not compatible with that version, so upstream must address it.


### PR DESCRIPTION
NOTES:
CVE-2024-36623 come from the upstream github.com/docker/docker dependency
- see: [github.com/rancher/rke2/go.mod - line 12](https://github.com/rancher/rke2/blob/master/go.mod#L12) 

Bumping to latest [v28.3.2+incompatible](https://pkg.go.dev/github.com/docker/docker@v28.3.2+incompatible) breaks build as additional dependency [cri-dockerd](https://github.com/rancher/rke2/blob/master/go.mod#L7) is not compatible with that version, so upstream must address it.

Related:
- https://github.com/wolfi-dev/os/pull/60261