### PR TITLE
docs(ceph): Add advisories for old CVEs

### DIFF
--- a/ceph.advisories.yaml
+++ b/ceph.advisories.yaml
@@ -24,7 +24,7 @@ advisories:
       - timestamp: 2025-07-23T13:55:23Z
         type: fixed
         data:
-          fixed-version: 12.1.1-r0
+          fixed-version: 19.2.1-r0
 
   - id: CGA-5m4c-g76f-rrvc
     aliases:
@@ -46,7 +46,7 @@ advisories:
       - timestamp: 2025-07-23T14:01:22Z
         type: fixed
         data:
-          fixed-version: 15.1.1-r0
+          fixed-version: 19.2.1-r0
 
   - id: CGA-gp9c-75mp-6x7v
     aliases:
@@ -91,4 +91,4 @@ advisories:
       - timestamp: 2025-07-23T13:57:58Z
         type: fixed
         data:
-          fixed-version: 15.2.0-r0
+          fixed-version: 19.2.1-r0

--- a/ceph.advisories.yaml
+++ b/ceph.advisories.yaml
@@ -84,3 +84,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-23T13:57:58Z
+        type: fixed
+        data:
+          fixed-version: 15.2.0-r0

--- a/ceph.advisories.yaml
+++ b/ceph.advisories.yaml
@@ -57,6 +57,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-23T13:50:39Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability affects older versions of the tripleo-heat-template which is EOL and not included within the package. Tracking of the original fixes can be found at https://bugs.launchpad.net/tripleo/+bug/1720787
 
   - id: CGA-m562-9hv8-6x62
     aliases:

--- a/ceph.advisories.yaml
+++ b/ceph.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-23T13:55:23Z
+        type: fixed
+        data:
+          fixed-version: 12.1.1-r0
 
   - id: CGA-5m4c-g76f-rrvc
     aliases:

--- a/ceph.advisories.yaml
+++ b/ceph.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-23T14:01:22Z
+        type: fixed
+        data:
+          fixed-version: 15.1.1-r0
 
   - id: CGA-gp9c-75mp-6x7v
     aliases:


### PR DESCRIPTION
APK scans have flagged some old CVEs in Ceph

The vulnerability data doesn't have fix versions attached, so they'll fire for every version.

This PR adds advisories for each

* CVE-2017-12155: false positive, affected the (now EOL) [tripleo-heat-template](https://github.com/openstack-archive/tripleo-heat-templates)
* CVE-2017-7519 fixed [here](https://github.com/ceph/ceph/pull/15674), first introduced under tag v12.1.1
* CVE-2019-10222: tracked in this [upstream ticket](https://tracker.ceph.com/issues/40018), fix released in v15.2.0
* CVE-2020-1700: fixed [here](https://github.com/ceph/ceph/commit/55ad9b6937f09bbf81dea27b017ffa4e63d4f044) and released in v15.1.1