### PR TITLE
bind: add advisories for CVE-2025-40776 and CVE-2025-40777

### DIFF
--- a/bind.advisories.yaml
+++ b/bind.advisories.yaml
@@ -458,6 +458,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-23T18:27:00Z
+        type: fixed
+        data:
+          fixed-version: 9.20.11-r1
 
   - id: CGA-jpv5-vvg9-c274
     aliases:
@@ -476,6 +480,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-23T18:26:44Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: CVE-2025-40776 affects only BIND Subscription Edition (-S) versions including 9.11.3-S1 through 9.16.50-S1, 9.18.11-S1 through 9.18.37-S1, and 9.20.9-S1 through 9.20.10-S1. The Wolfi bind package version 9.20.11-r1 is the open-source edition and is not affected by this vulnerability which specifically targets the commercial Subscription Edition with ECS (EDNS Client Subnet) configuration.
 
   - id: CGA-jvwh-8gmp-7w68
     aliases:


### PR DESCRIPTION
## Summary

Adds appropriate advisories for two new BIND CVEs detected in the bind package version 9.20.11-r1.

## CVE-2025-40776 - False Positive Determination

**Type**: `false-positive-determination` with subtype `vulnerable-code-version-not-used`

**Analysis**: This CVE affects only BIND Subscription Edition (-S) versions, not the open-source edition:
- **Vulnerable versions**: 9.11.3-S1 through 9.16.50-S1, 9.18.11-S1 through 9.18.37-S1, and 9.20.9-S1 through 9.20.10-S1
- **Wolfi package**: Uses open-source BIND version 9.20.11-r1
- **Attack vector**: Targets ECS (EDNS Client Subnet) configuration in commercial Subscription Edition

## CVE-2025-40777 - Fixed

**Type**: `fixed` with version `9.20.11-r1`

**Analysis**: Package version is outside the vulnerable range:
- **Vulnerable versions**: 9.20.0 through 9.20.10 and 9.21.0 through 9.21.9  
- **Wolfi package**: Version 9.20.11-r1 is above vulnerable range
- **Vulnerability**: Denial-of-service through assertion failures
## References

- CVE-2025-40776: https://nvd.nist.gov/vuln/detail/CVE-2025-40776
- CVE-2025-40777: https://nvd.nist.gov/vuln/detail/CVE-2025-40777
- BIND Security Matrix: https://kb.isc.org/docs/aa-00913