### PR TITLE
juicefs-1.3: update advisory

### DIFF
--- a/juicefs-1.3.advisories.yaml
+++ b/juicefs-1.3.advisories.yaml
@@ -25,6 +25,10 @@ advisories:
         type: true-positive-determination
         data:
           note: 'Govulncheck found vulnerable symbols in Go binaries at the following locations: in juicefs-1.3-1.3.0-r1.apk, at usr/bin/juicefs, usr/bin/juicefs.'
+      - timestamp: 2025-07-24T14:21:09Z
+        type: pending-upstream-fix
+        data:
+          note: This dependency is brought in via a transient dependency. Any attempts to bump to a fixed version of this dependency result in a build failure, hence we will need upstream to update their dependencies in order to fix this issue.
 
   - id: CGA-5mh8-6mhm-c4m4
     aliases:
@@ -114,6 +118,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/juicefs
             scanner: grype
+      - timestamp: 2025-07-24T09:19:13Z
+        type: pending-upstream-fix
+        data:
+          note: This package must be removed from upstream dependencies. Upstream already consumes the fixed version, and trying to bump the vulnerable version will cause build failures due to duplication.
 
   - id: CGA-qj22-3gm9-5w4p
     aliases:


### PR DESCRIPTION
Update advisory for GHSA-wf43-55jj-vwq8
This package must be removed from upstream dependencies. Upstream already consumes the fixed version, and trying to bump the vulnerable version will cause build failures due to duplication.