### PR TITLE
feat(mattermost-10.10): update advisory for CVE-2022-4019, CVE-2022-4045

### DIFF
--- a/mattermost-10.10.advisories.yaml
+++ b/mattermost-10.10.advisories.yaml
@@ -38,6 +38,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-24T14:24:41Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This vulnerability was remediated in mattermost v7.x, Specifically, in versions 7.1.4, 7.2.1, 7.3.1, and 7.4.0. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4019'
 
   - id: CGA-xv4x-hp2c-xr68
     aliases:
@@ -56,3 +61,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-07-24T14:25:24Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This vulnerability was remediated in mattermost v7.4.0 and later. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4045'


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for https://github.com/advisories/GHSA-hqqj-g6mv-rw46 and https://github.com/advisories/GHSA-v42f-hq78-8c5m
