### PR TITLE
keycloak: add pending-upstream-fix advisory for GHSA-83j7-mhw9-388w

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -236,6 +236,14 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/keycloak/lib/lib/main/org.keycloak.keycloak-services-26.3.1.jar
             scanner: grype
+      - timestamp: 2025-07-24T17:29:12Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Upstream are actively working on, and have a PR open regarding this issue.
+            Upstream maintainers will need to approve and merge the PR.
+            Tracking issue: https://github.com/keycloak/keycloak/issues/41137
+            Fix PR: https://github.com/keycloak/keycloak/pull/41168
 
   - id: CGA-78pc-x38c-7p9v
     aliases:


### PR DESCRIPTION
Add pending upstream fix advisory for keycloak GHSA-83j7-mhw9-388w with upstream tracking information.