### PR TITLE
advisories-ingester: policy for the advisories v2 ingester

### DIFF
--- a/.github/chainguard/lifecycle-advisories-v2-ingester.sts.yaml
+++ b/.github/chainguard/lifecycle-advisories-v2-ingester.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://accounts.google.com
+
+# lifecycle-adv-ing-d642yk3csqr@hector-cg-dev-chainguard-dev.iam.gserviceaccount.com
+subject_pattern: "(105719398959163122807)"
+
+# This service needs to clone the advisories repo to import the existing advisories to a db.
+permissions:
+  contents: read


### PR DESCRIPTION
Add the octo sts policy to fetch the advisories from this repo and migrate them to our new advisories schema on the datastore.