### PR TITLE
gitlab-cng-18.2: update advisory

### DIFF
--- a/gitlab-cng-18.2.advisories.yaml
+++ b/gitlab-cng-18.2.advisories.yaml
@@ -37,6 +37,10 @@ advisories:
             componentType: gem
             componentLocation: /usr/lib/ruby/gems/3.2.0/specifications/sinatra-2.2.4.gemspec
             scanner: grype
+      - timestamp: 2025-07-28T09:17:02Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability relates to the GitLab dependency: [gem] sinatra @ 2.2.4, which was fixed upstream on version 4.1.0.  However, GitLab advises that maintainers should NOT upgrade dependency versions manually, as their automation would have already applied this in cases of simple version increments. If a dependency version has not yet been upgraded, there is usually a good reason. Additionally, past attempts to upgrade GitLab dependencies ahead of the upstream release have resulted in build issues.  deferring to upstream (GitLab) to address this CVE in a subsequent update. See: https://docs.gitlab.com/ee/development/dependencies.html.'
 
   - id: CGA-x7j6-p48g-3rh9
     aliases:


### PR DESCRIPTION
This vulnerability relates to the GitLab dependency: [gem] sinatra @
2.2.4, which was fixed upstream on version 4.1.0.  However, GitLab
advises that maintainers should NOT upgrade dependency versions
manually, as their automation would have already applied this in cases
of simple version increments. If a dependency version has not yet been
upgraded, there is usually a good reason. Additionally, past attempts to
upgrade GitLab dependencies ahead of the upstream release have resulted
in build issues.  deferring to upstream (GitLab) to address this CVE in
a subsequent update. See:
https://docs.gitlab.com/ee/development/dependencies.html.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
