### PR TITLE
python-3.10/CVE-2025-1795 advisory update

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -359,6 +359,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'A fix for this CVE exists upstream in the 3.12 and 3.11 branches. There is a PR open and ready for review to backport this fix to 3.10 which can be seen here: https://github.com/python/cpython/pull/129111'
+      - timestamp: 2025-07-29T12:58:00Z
+        type: fixed
+        data:
+          fixed-version: 3.10.17-r0
 
   - id: CGA-rh6v-8553-f92w
     aliases:


### PR DESCRIPTION
adv: fixed version 3.10.17-r0 for python-3.10 - CVE-2025-1795