### PR TITLE
advisories: add pending upstream fix for GHSA-4vq8-7jfc-9cvp

### DIFF
--- a/amazon-cloudwatch-agent-operator.advisories.yaml
+++ b/amazon-cloudwatch-agent-operator.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: amazon-cloudwatch-agent-operator
 
 advisories:
+  - id: CGA-25x2-hrv6-wx8x
+    aliases:
+      - CVE-2025-54410
+      - GHSA-4vq8-7jfc-9cvp
+    events:
+      - timestamp: 2025-07-31T22:44:20Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
+
   - id: CGA-4p7p-8qq5-7q7c
     aliases:
       - CVE-2024-36623

--- a/gitlab-runner-18.2.advisories.yaml
+++ b/gitlab-runner-18.2.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: gitlab-runner-18.2
 
 advisories:
+  - id: CGA-8w4p-43rg-gr3p
+    aliases:
+      - CVE-2025-54410
+      - GHSA-4vq8-7jfc-9cvp
+    events:
+      - timestamp: 2025-07-31T22:47:45Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
+
   - id: CGA-gvg9-wv66-5xgp
     aliases:
       - CVE-2024-36623

--- a/k3s.advisories.yaml
+++ b/k3s.advisories.yaml
@@ -490,6 +490,16 @@ advisories:
         data:
           fixed-version: 1.30.4.1-r1
 
+  - id: CGA-hj39-48mm-8vrf
+    aliases:
+      - CVE-2025-54410
+      - GHSA-4vq8-7jfc-9cvp
+    events:
+      - timestamp: 2025-07-31T22:43:52Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
+
   - id: CGA-j4cf-qh37-fvjx
     aliases:
       - CVE-2025-27144

--- a/promxy.advisories.yaml
+++ b/promxy.advisories.yaml
@@ -265,6 +265,16 @@ advisories:
         data:
           fixed-version: 0.0.92-r36
 
+  - id: CGA-vqg5-cfhq-fcw6
+    aliases:
+      - CVE-2025-54410
+      - GHSA-4vq8-7jfc-9cvp
+    events:
+      - timestamp: 2025-07-31T22:44:06Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
+
   - id: CGA-vr36-36hf-xw64
     aliases:
       - CVE-2025-22869

--- a/rancher-2.11.advisories.yaml
+++ b/rancher-2.11.advisories.yaml
@@ -71,6 +71,16 @@ advisories:
           type: vulnerable-code-not-included-in-package
           note: govulncheck analysis shows that the github.com/docker/docker golang package is not used by the rancher-agent binary as there are no symbols referenced for the vulnerable code.
 
+  - id: CGA-7c26-xw66-x936
+    aliases:
+      - CVE-2025-54410
+      - GHSA-4vq8-7jfc-9cvp
+    events:
+      - timestamp: 2025-07-31T22:43:25Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
+
   - id: CGA-f5mh-f7cm-gph9
     aliases:
       - CVE-2024-36621

--- a/rancher-agent-2.11.advisories.yaml
+++ b/rancher-agent-2.11.advisories.yaml
@@ -124,6 +124,16 @@ advisories:
         data:
           note: rancher-agent pins the docker package version to v20.10.27+incompatible for compatibility with rancher-machine. Upstream needs to upgrade package due required functional changes.
 
+  - id: CGA-hv94-97qx-cxvp
+    aliases:
+      - CVE-2025-54410
+      - GHSA-4vq8-7jfc-9cvp
+    events:
+      - timestamp: 2025-07-31T22:47:45Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
+
   - id: CGA-j4qm-j33q-8qrj
     aliases:
       - CVE-2025-1767

--- a/rancher-machine.advisories.yaml
+++ b/rancher-machine.advisories.yaml
@@ -4,6 +4,16 @@ package:
   name: rancher-machine
 
 advisories:
+  - id: CGA-7cr2-j4qj-2mw3
+    aliases:
+      - CVE-2025-54410
+      - GHSA-4vq8-7jfc-9cvp
+    events:
+      - timestamp: 2025-07-31T22:44:35Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
+
   - id: CGA-8vh4-qc29-cxjw
     aliases:
       - CVE-2020-27534


### PR DESCRIPTION
Add pending upstream fix advisories for Docker Engine (Moby) vulnerability GHSA-4vq8-7jfc-9cvp affecting firewalld iptables rules isolation.

This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker's iptables rules that isolate containers in different bridge networks.

Packages updated:
- amazon-cloudwatch-agent-operator
- gitlab-runner-18.2
- k3s
- promxy
- rancher-2.11
- rancher-agent-2.11
- rancher-machine

References:
- 25.x backport PR: https://github.com/moby/moby/pull/50445
- 28.x backport PR: https://github.com/moby/moby/pull/50506