### PR TITLE
advisories: add pending upstream fix for GHSA-4vq8-7jfc-9cvp

### DIFF
--- a/amazon-cloudwatch-agent-operator.advisories.yaml
+++ b/amazon-cloudwatch-agent-operator.advisories.yaml
@@ -87,6 +87,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/manager
             scanner: grype
+      - timestamp: 2025-07-31T22:54:41Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
 
   - id: CGA-6p3c-mp25-jx5w
     aliases:

--- a/gitlab-runner-18.2.advisories.yaml
+++ b/gitlab-runner-18.2.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine
             scanner: grype
+      - timestamp: 2025-07-31T22:54:41Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
 
   - id: CGA-gvg9-wv66-5xgp
     aliases:

--- a/k3s.advisories.yaml
+++ b/k3s.advisories.yaml
@@ -906,6 +906,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/k3s
             scanner: grype
+      - timestamp: 2025-07-31T22:54:41Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
 
   - id: CGA-wg26-4574-7j6c
     aliases:

--- a/promxy.advisories.yaml
+++ b/promxy.advisories.yaml
@@ -195,6 +195,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/promxy
             scanner: grype
+      - timestamp: 2025-07-31T22:54:41Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
 
   - id: CGA-prgg-wpw3-4mjv
     aliases:

--- a/rancher-2.11.advisories.yaml
+++ b/rancher-2.11.advisories.yaml
@@ -253,6 +253,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/rancher
             scanner: grype
+      - timestamp: 2025-07-31T22:54:41Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
 
   - id: CGA-x55r-rv2f-94w4
     aliases:

--- a/rancher-agent-2.11.advisories.yaml
+++ b/rancher-agent-2.11.advisories.yaml
@@ -306,6 +306,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/agent
             scanner: grype
+      - timestamp: 2025-07-31T22:54:41Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
 
   - id: CGA-x56q-ffg8-vvxv
     aliases:

--- a/rancher-machine.advisories.yaml
+++ b/rancher-machine.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/rancher-machine
             scanner: grype
+      - timestamp: 2025-07-31T22:54:41Z
+        type: pending-upstream-fix
+        data:
+          note: 'This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker''s iptables rules that isolate containers in different bridge networks. Upstream maintainers must cut a release with the fix. References: 25.x backport PR: https://github.com/moby/moby/pull/50445 28.x backport PR: https://github.com/moby/moby/pull/50506'
 
   - id: CGA-8vh4-qc29-cxjw
     aliases:


### PR DESCRIPTION
Add pending upstream fix advisories for Docker Engine (Moby) vulnerability GHSA-4vq8-7jfc-9cvp affecting firewalld iptables rules isolation.

This vulnerability affects Docker Engine (Moby) versions <= 25.0.12 where firewalld reload removes Docker's iptables rules that isolate containers in different bridge networks.

Packages updated:
- amazon-cloudwatch-agent-operator
- gitlab-runner-18.2
- k3s
- promxy
- rancher-2.11
- rancher-agent-2.11
- rancher-machine

References:
- 25.x backport PR: https://github.com/moby/moby/pull/50445
- 28.x backport PR: https://github.com/moby/moby/pull/50506