### PR TITLE
python-3.10, python-3.11, python-3.12: add pending-upstream-fix advisories for CVE-2025-8194

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -44,6 +44,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-01T00:32:23Z
+        type: pending-upstream-fix
+        data:
+          note: 'Upstream maintainers must release the backport PR for Python 3.10. The tarfile validation fix from gh-130577 is ready for 3.10 via PR #137176 but not yet merged and released. CVE-2025-8194 is fixed in Python 3.13.5+ but requires backporting to 3.10 branch. Reference: https://github.com/python/cpython/pull/137176'
 
   - id: CGA-5pmm-mmg3-pfp3
     aliases:

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -184,6 +184,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-01T00:32:04Z
+        type: pending-upstream-fix
+        data:
+          note: 'Upstream maintainers must release the backport PR for Python 3.11. The tarfile validation fix from gh-130577 is ready for 3.11 via PR #137172 but not yet merged and released. CVE-2025-8194 is fixed in Python 3.13.5+ but requires backporting to 3.11 branch. Reference: https://github.com/python/cpython/pull/137172'
 
   - id: CGA-h6qq-2p9f-rrpx
     aliases:

--- a/python-3.12.advisories.yaml
+++ b/python-3.12.advisories.yaml
@@ -278,6 +278,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-01T00:31:45Z
+        type: pending-upstream-fix
+        data:
+          note: 'Upstream maintainers must release the backport PR for Python 3.12. The tarfile validation fix from gh-130577 is ready for 3.12 via PR #137171 but not yet merged and released. CVE-2025-8194 is fixed in Python 3.13.5+ but requires backporting to 3.12 branch. Reference: https://github.com/python/cpython/pull/137171'
 
   - id: CGA-q3qc-6cj9-jg33
     aliases:

--- a/python-3.13.advisories.yaml
+++ b/python-3.13.advisories.yaml
@@ -296,3 +296,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-01T01:03:45Z
+        type: pending-upstream-fix
+        data:
+          note: The tarfile validation fix from gh-130577 has been cherry-picked from Python 3.13 main branch to our python-3.13 package. However, this remains a pending-upstream-fix until an official Python 3.13.6+ release includes this security fix. The cherry-pick provides immediate protection while waiting for the upstream release.


### PR DESCRIPTION
Adds pending-upstream-fix advisories for CVE-2025-8194 tarfile validation vulnerability across Python 3.10, 3.11, and 3.12.

Each advisory references the respective upstream backport PR:
- python-3.10: PR #137176 
- python-3.11: PR #137172
- python-3.12: PR #137171

The advisories track that the tarfile validation fix from gh-130577 is ready for backporting but waiting for upstream maintainers to merge and release.