### PR TITLE
feat(newrelic-fluent-bit-output): update advisory for CVE-2025-4674

### DIFF
--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -65,6 +65,10 @@ advisories:
             componentType: go-module
             componentLocation: /fluent-bit/bin/out_newrelic.so
             scanner: grype
+      - timestamp: 2025-08-01T13:51:27Z
+        type: pending-upstream-fix
+        data:
+          note: 'Affected Go 1.20.x version can not be updated to fix version due to upstream version pinning: https://github.com/newrelic/newrelic-fluent-bit-output/blob/cc6bcc1e735a8812dd2eab8022a575b44f8366c8/go.mod#L3 which directs to the following conversation: ''https://github.com/golang/go/issues/62130#issuecomment-1687335898'''
 
   - id: CGA-348r-36vh-527w
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for CVE-2025-4674
