### PR TITLE
feat(splunk-otel-collector): update advisory for several vulnerabilities

### DIFF
--- a/splunk-otel-collector.advisories.yaml
+++ b/splunk-otel-collector.advisories.yaml
@@ -95,6 +95,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-08-04T13:02:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability originates from the Vault dependency. Upgrading Vault breaks the build due to a transitive conflict with k8s.io/client-go, which introduces incompatibility with Prometheus libraries. Once Prometheus addresses this (see issue #16767 and PR #16768) and the upstream resolves the issue, we’ll be able to upgrade and remediate the vulnerability.'
 
   - id: CGA-5fjc-fxmq-vggm
     aliases:
@@ -179,6 +183,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-08-04T13:02:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability originates from the Vault dependency. Upgrading Vault breaks the build due to a transitive conflict with k8s.io/client-go, which introduces incompatibility with Prometheus libraries. Once Prometheus addresses this (see issue #16767 and PR #16768) and the upstream resolves the issue, we’ll be able to upgrade and remediate the vulnerability.'
 
   - id: CGA-8226-gq6c-h5h6
     aliases:
@@ -299,6 +307,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-08-04T13:02:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability originates from the Vault dependency. Upgrading Vault breaks the build due to a transitive conflict with k8s.io/client-go, which introduces incompatibility with Prometheus libraries. Once Prometheus addresses this (see issue #16767 and PR #16768) and the upstream resolves the issue, we’ll be able to upgrade and remediate the vulnerability.'
 
   - id: CGA-crqj-9642-5m2w
     aliases:
@@ -406,6 +418,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-08-04T13:02:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability originates from the Vault dependency. Upgrading Vault breaks the build due to a transitive conflict with k8s.io/client-go, which introduces incompatibility with Prometheus libraries. Once Prometheus addresses this (see issue #16767 and PR #16768) and the upstream resolves the issue, we’ll be able to upgrade and remediate the vulnerability.'
 
   - id: CGA-jr6h-pq36-654c
     aliases:
@@ -511,6 +527,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-08-04T13:02:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability originates from the Vault dependency. Upgrading Vault breaks the build due to a transitive conflict with k8s.io/client-go, which introduces incompatibility with Prometheus libraries. Once Prometheus addresses this (see issue #16767 and PR #16768) and the upstream resolves the issue, we’ll be able to upgrade and remediate the vulnerability.'
 
   - id: CGA-v69g-6284-r2qx
     aliases:
@@ -564,6 +584,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-08-04T13:02:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability originates from the Vault dependency. Upgrading Vault breaks the build due to a transitive conflict with k8s.io/client-go, which introduces incompatibility with Prometheus libraries. Once Prometheus addresses this (see issue #16767 and PR #16768) and the upstream resolves the issue, we’ll be able to upgrade and remediate the vulnerability.'
 
   - id: CGA-xgcq-m8cr-rf2h
     aliases:
@@ -582,6 +606,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-08-04T13:02:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability originates from the Vault dependency. Upgrading Vault breaks the build due to a transitive conflict with k8s.io/client-go, which introduces incompatibility with Prometheus libraries. Once Prometheus addresses this (see issue #16767 and PR #16768) and the upstream resolves the issue, we’ll be able to upgrade and remediate the vulnerability.'
 
   - id: CGA-xpgr-wj46-h3fx
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for vulns:
- GHSA-6c5r-4wfc-3mcx
- GHSA-6h4p-m86h-hhgh
- GHSA-mr4h-qf9j-f665
- GHSA-mwgr-84fv-3jh9
- GHSA-qgj7-fmq2-6cc4
- GHSA-qv3p-fmv3-9hww
- GHSA-v6r4-35f9-9rpw

The problem comes from Vault at v1.20.x that pulls down a version of k8s.io/client-go that it is not compatible with the Prometheus lib version used by this package.
More here, https://github.com/prometheus/prometheus/issues/16767 and here https://github.com/prometheus/prometheus/pull/16768.
We would need to wait on Prometheus and upstream to fix this.

the error on building phase is:
```
2025/08/04 11:23:03 WARN # github.com/prometheus/prometheus/discovery/kubernetes
2025/08/04 11:23:03 WARN /var/cache/melange/gomodcache/github.com/prometheus/prometheus@v0.304.3-0.20250703114031-419d436a447a/discovery/kubernetes/kubernetes.go:763:36: not enough arguments
in call to cache.DefaultWatchErrorHandler
2025/08/04 11:23:03 WARN     have (*"k8s.io/client-go/tools/cache".Reflector, error)
2025/08/04 11:23:03 WARN     want (context.Context, *"k8s.io/client-go/tools/cache".Reflector, error)
```

any forced replace was not enough. Probably only forking Prometheus and fixing the function could solve this.
