### PR TITLE
cluster-api-helm-controller: add pending-upstream-fix advisories for GHSA-5xqw-8hwv-wg92 and GHSA-4hfp-h4cw-hj8p

### DIFF
--- a/cluster-api-helm-controller.advisories.yaml
+++ b/cluster-api-helm-controller.advisories.yaml
@@ -88,6 +88,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cluster-api-helm-controller
             scanner: grype
+      - timestamp: 2025-08-04T17:20:24Z
+        type: pending-upstream-fix
+        data:
+          note: "Upstream needs to make code changes in order to upgrade helm.sh/helm/v3 to 3.18.4. Pending PR is inflight awaiting upstream approval: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/pull/420"
       - timestamp: 2025-08-02T00:37:37Z
         type: pending-upstream-fix
         data:
@@ -132,6 +136,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cluster-api-helm-controller
             scanner: grype
+      - timestamp: 2025-08-04T17:20:24Z
+        type: pending-upstream-fix
+        data:
+          note: "Upstream needs to make code changes in order to upgrade helm.sh/helm/v3 to 3.18.4. Pending PR is inflight awaiting upstream approval: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/pull/420"
       - timestamp: 2025-08-02T00:37:37Z
         type: pending-upstream-fix
         data:


### PR DESCRIPTION
This PR adds pending-upstream-fix advisories for:

- GHSA-5xqw-8hwv-wg92 (CVE-2025-32387) 
- GHSA-4hfp-h4cw-hj8p (CVE-2025-32386)

Both CVEs affect helm.sh/helm/v3 and require upstream code changes to upgrade to version 3.18.4. A pending PR is awaiting upstream approval: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/pull/420

This addresses CVE Dashboard issues:
- https://github.com/chainguard-dev/CVE-Dashboard/issues/26364
- https://github.com/chainguard-dev/CVE-Dashboard/issues/26382