### PR TITLE
airflow-3: add fix-not-planned advisory for GHSA-wj6h-64fc-37mp

### DIFF
--- a/airflow-3.advisories.yaml
+++ b/airflow-3.advisories.yaml
@@ -307,6 +307,10 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/lib/python3.12/site-packages/ecdsa-0.19.1.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-08-04T17:37:14Z
+        type: fix-not-planned
+        data:
+          note: "The python-ecdsa library is vulnerable to a Minerva timing attack on the P-256 curve through the ecdsa.SigningKey.sign_digest() API. The vulnerability affects ECDSA signatures, key generation, and ECDH operations, potentially allowing attackers to leak internal nonces and discover private keys through timing analysis. The upstream python-ecdsa project explicitly considers side-channel attacks out of scope and has stated there is no planned fix for this vulnerability."
 
   - id: CGA-vx49-fm46-cjjp
     aliases:


### PR DESCRIPTION
## Summary

Adds a fix-not-planned advisory for CVE-2024-23342 / GHSA-wj6h-64fc-37mp affecting the ecdsa library in airflow-3.

## Vulnerability Details

- **Component**: python-ecdsa @ 0.19.1
- **Vulnerability**: Minerva timing attack on P-256 curve
- **Attack Vector**: ecdsa.SigningKey.sign_digest() API timing analysis
- **Impact**: Potential private key discovery through nonce leakage

## Upstream Status

The upstream python-ecdsa project explicitly considers side-channel attacks **out of scope** and has stated there is **no planned fix** for this vulnerability. This makes it a permanent fix-not-planned advisory.

## Advisory Type

**fix-not-planned** - Upstream project policy excludes fixing side-channel attacks

## Verification

Advisory added to existing CGA-v657-g4qg-9wm6 detection event in airflow-3.advisories.yaml