### PR TITLE
open-webui: add fix-not-planned advisory for GHSA-wj6h-64fc-37mp

### DIFF
--- a/open-webui.advisories.yaml
+++ b/open-webui.advisories.yaml
@@ -153,6 +153,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/open-webui/lib/python3.11/site-packages/ecdsa-0.19.1.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-08-04T17:40:50Z
+        type: fix-not-planned
+        data:
+          note: "The python-ecdsa library is vulnerable to a Minerva timing attack on the P-256 curve through the ecdsa.SigningKey.sign_digest() API. The vulnerability affects ECDSA signatures, key generation, and ECDH operations, potentially allowing attackers to leak internal nonces and discover private keys through timing analysis. The upstream python-ecdsa project explicitly considers side-channel attacks out of scope and has stated there is no planned fix for this vulnerability."
 
   - id: CGA-qg34-qp8g-rhvg
     aliases:


### PR DESCRIPTION
## Summary

Adds a fix-not-planned advisory for CVE-2024-23342 / GHSA-wj6h-64fc-37mp affecting the ecdsa library in open-webui.

## Vulnerability Details

- **Component**: python-ecdsa @ 0.19.1
- **Vulnerability**: Minerva timing attack on P-256 curve
- **Attack Vector**: ecdsa.SigningKey.sign_digest() API timing analysis
- **Impact**: Potential private key discovery through nonce leakage

## Upstream Status

The upstream python-ecdsa project explicitly considers side-channel attacks **out of scope** and has stated there is **no planned fix** for this vulnerability. This makes it a permanent fix-not-planned advisory.

## Advisory Type

**fix-not-planned** - Upstream project policy excludes fixing side-channel attacks

## Verification

Advisory added to existing CGA-pxpq-4523-7gg6 detection event in open-webui.advisories.yaml