### PR TITLE
grafana-pyroscope-1.13: update advisory

### DIFF
--- a/grafana-pyroscope-1.13.advisories.yaml
+++ b/grafana-pyroscope-1.13.advisories.yaml
@@ -25,6 +25,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'The oauth2-proxy is a transient dependency and any attempts to bump result in build failure. We will have to wait for upstream to work on bumping their dependency tree. There is currently an issue open upstream to try to bump this dependency but it is still a work in progress: https://github.com/grafana/pyroscope/pull/4335'
+      - timestamp: 2025-08-05T07:14:15Z
+        type: fixed
+        data:
+          fixed-version: 1.13.5-r2
 
   - id: CGA-ccqq-v98r-p677
     aliases:


### PR DESCRIPTION
Update advisory for GHSA-7rh7-c77v-6434
Fixed on: https://github.com/wolfi-dev/os/pull/61668

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
