### PR TITLE
cluster-api-aws-controller/advsiory update

### DIFF
--- a/cluster-api-aws-controller.advisories.yaml
+++ b/cluster-api-aws-controller.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/cluster-api-aws-controller
             scanner: grype
+      - timestamp: 2025-08-05T14:26:22Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream uses ignition v0.35.0 and ignition v2. The v0.35.0 is for backwards compatibility. Upstream will deprecate this in the future but this is currently required until that time.
 
   - id: CGA-8c53-425r-xjx7
     aliases:


### PR DESCRIPTION
adv: cluster-api-aws-controller - CVE-2022-1706