### PR TITLE
feat(filebrowser): update advisory for GHSA-3v48-283x-f2w4

### DIFF
--- a/filebrowser.advisories.yaml
+++ b/filebrowser.advisories.yaml
@@ -321,6 +321,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/filebrowser
             scanner: grype
+      - timestamp: 2025-08-06T08:08:46Z
+        type: pending-upstream-fix
+        data:
+          note: 'No fix is currently available upstream. The vulnerability is being tracked at: https://github.com/filebrowser/filebrowser/issues/5239. It allows password-protected file shares to expose direct download links without enforcing access controls. Users should evaluate the risk of sensitive file exposure and consider disabling password-protected sharing until a patch is released. Once this is done, we will update the package and remediate the CVE.'
 
   - id: CGA-p6cp-g4vh-9345
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for GHSA-3v48-283x-f2w4.

Fix should be monitored here: https://github.com/filebrowser/filebrowser/issues/5239
