### PR TITLE
chore(kserve-modelmesh): Advisory for CGA-v2hv-cwjf-vh29

### DIFF
--- a/kserve-modelmesh.advisories.yaml
+++ b/kserve-modelmesh.advisories.yaml
@@ -204,7 +204,7 @@ advisories:
       - timestamp: 2025-08-07T02:50:38Z
         type: pending-upstream-fix
         data:
-          note: Netty 4.1.118.Final and newer provide:wq a gRPC implementation that is incompatible with kserve modelmesh.
+          note: Netty 4.1.118.Final and newer provide a gRPC implementation that is incompatible with kserve modelmesh.
 
   - id: CGA-v3gv-5vpv-r7rp
     aliases:


### PR DESCRIPTION
Newer versions of netty provide a grpc implementation that is incompatible with kserve modelmesh