### PR TITLE
openjdk-11: update advisories

### DIFF
--- a/openjdk-11.advisories.yaml
+++ b/openjdk-11.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:23:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.5 and was addressed in openjdk-11 version 11.0.6. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-2phc-2c45-977c
     aliases:
@@ -39,6 +44,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-35qf-ggjq-7xrf
     aliases:
@@ -80,6 +90,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-3hrp-647v-42qm
     aliases:
@@ -98,6 +113,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-44r8-3p5q-wh9h
     aliases:
@@ -126,6 +146,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-4r5r-p9q3-mffv
     aliases:
@@ -144,6 +169,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:23:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.5 and was addressed in openjdk-11 version 11.0.6. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-4v82-53j9-9r9q
     aliases:
@@ -172,6 +202,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-5v4g-ppw8-g7xw
     aliases:
@@ -190,6 +225,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-5vf3-f5v3-g54x
     aliases:
@@ -208,6 +248,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:26:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.11 and was addressed in openjdk-11 version 11.0.12. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-73g2-v22h-jx69
     aliases:
@@ -236,6 +281,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-7gjx-74jp-96r9
     aliases:
@@ -264,6 +314,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-7x8h-8jvv-52gv
     aliases:
@@ -304,6 +359,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-8pvf-729c-mg2j
     aliases:
@@ -332,6 +392,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-923q-vj97-h37c
     aliases:
@@ -370,6 +435,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-9c9w-p43h-gfvj
     aliases:
@@ -388,6 +458,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-9rw6-g2j9-xfh5
     aliases:
@@ -406,6 +481,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-cgw8-8w4f-64v8
     aliases:
@@ -424,6 +504,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:25:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.10 and was addressed in openjdk-11 version 11.0.11. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-cm3v-mg5f-wfpq
     aliases:
@@ -442,6 +527,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:23:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.5 and was addressed in openjdk-11 version 11.0.6. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-f5w4-73pp-wcxj
     aliases:
@@ -480,6 +570,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-h74x-c435-r327
     aliases:
@@ -508,6 +603,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:26:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.11 and was addressed in openjdk-11 version 11.0.12. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-hxvj-52g6-mx6m
     aliases:
@@ -526,6 +626,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-j8gc-6hc3-27qw
     aliases:
@@ -544,6 +649,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-jqhc-xv7j-3x3r
     aliases:
@@ -572,6 +682,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:26:19Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.11 and was addressed in openjdk-11 version 11.0.12. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-pc4p-gjv3-p6x8
     aliases:
@@ -590,6 +705,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:25:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.10 and was addressed in openjdk-11 version 11.0.11. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-prjm-5q85-q9g8
     aliases:
@@ -608,6 +728,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:23:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.5 and was addressed in openjdk-11 version 11.0.6. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-rh94-vp99-76w5
     aliases:
@@ -626,6 +751,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-rjq6-pffx-3q2q
     aliases:
@@ -644,6 +774,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:22:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.4 and was addressed in openjdk-11 version 11.0.5. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-v333-j54p-w387
     aliases:
@@ -672,6 +807,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:23:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.5 and was addressed in openjdk-11 version 11.0.6. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.
 
   - id: CGA-xgp4-74qp-5wm8
     aliases:
@@ -690,3 +830,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:23:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-11 versions up to 11.0.5 and was addressed in openjdk-11 version 11.0.6. Our current openjdk-11 package version 11.0.28 includes the security fixes that resolve this vulnerability.


### PR DESCRIPTION
Mark CVEs as false positives since fixes are included in current version 11.0.28:

Fixed in 11.0.5 (18 CVEs): CVE-2019-2978, CVE-2019-2977, CVE-2019-2987,
CVE-2019-2949, CVE-2019-2958, CVE-2019-2894, CVE-2019-2973, CVE-2019-2999,
CVE-2019-2988, CVE-2019-2933, CVE-2019-2975, CVE-2019-2983, CVE-2019-2945,
CVE-2019-2989, CVE-2019-2981, CVE-2019-2964, CVE-2019-2992, CVE-2019-2962

Fixed in 11.0.6 (6 CVEs): CVE-2020-2583, CVE-2020-2604, CVE-2020-2593,
CVE-2020-2601, CVE-2020-2654, CVE-2020-2590

Fixed in 11.0.11 (2 CVEs): CVE-2021-2163, CVE-2021-2161

Fixed in 11.0.12 (3 CVEs): CVE-2021-2341, CVE-2021-2369, CVE-2021-2388

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
