### PR TITLE
openjdk-8: update advisories

### DIFF
--- a/openjdk-8.advisories.yaml
+++ b/openjdk-8.advisories.yaml
@@ -43,6 +43,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-4855-g9x9-jcvp
     aliases:
@@ -61,6 +66,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-54pm-rxx7-5ph2
     aliases:
@@ -145,6 +155,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-5ph7-mpw6-hqcm
     aliases:
@@ -185,6 +200,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-6m9g-xxxf-x3h8
     aliases:
@@ -225,6 +245,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:55:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u180 and was addressed in openjdk-8 version 8u181. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-82wx-978w-6pgc
     aliases:
@@ -243,6 +268,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-f4v5-vmqg-hp9r
     aliases:
@@ -261,6 +291,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-g6p4-m46f-4jmh
     aliases:
@@ -323,6 +358,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:55:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u180 and was addressed in openjdk-8 version 8u181. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-hq6j-c6fw-x9gp
     aliases:
@@ -352,6 +392,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-j9j6-ghj2-fjvg
     aliases:
@@ -370,6 +415,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-jfwv-xwv8-3gg3
     aliases:
@@ -388,6 +438,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:55:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u180 and was addressed in openjdk-8 version 8u181. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-p48c-96mf-2mqv
     aliases:
@@ -561,6 +616,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-qwp7-r45h-hfhv
     aliases:
@@ -601,6 +661,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-vv3x-4f93-9hf5
     aliases:
@@ -619,6 +684,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-wg4g-wxjm-37xq
     aliases:
@@ -637,6 +707,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:55:06Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u180 and was addressed in openjdk-8 version 8u181. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-wh4h-q24p-73mj
     aliases:
@@ -677,6 +752,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-x74r-26jc-x9px
     aliases:
@@ -717,6 +797,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.
 
   - id: CGA-xf54-4278-8p52
     aliases:
@@ -735,3 +820,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-07T07:54:26Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This CVE affected openjdk-8 versions up to 8u170 and was addressed in openjdk-8 version 8u171. Our current openjdk-8 package version 8.452.09 (8u452) includes the security fixes that resolve this vulnerability.


### PR DESCRIPTION
Mark CVEs as false positives since fixes are included in current version 8.452.09 (8u452):

Fixed in 8u171 (14 CVEs): CVE-2018-2811, CVE-2018-2794, CVE-2018-2790,
CVE-2018-2952, CVE-2018-2796, CVE-2018-2940, CVE-2018-2797, CVE-2018-2815,
CVE-2018-2795, CVE-2018-2799, CVE-2018-2826, CVE-2018-2825, CVE-2018-2798,
CVE-2018-2814

Fixed in 8u181 (4 CVEs): CVE-2018-2964, CVE-2018-2972, CVE-2018-2973,
CVE-2018-2941

All vulnerable code versions are not used in current package.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
