### PR TITLE
feat(opensearch-dashboards-3): update advisory for GHSA-52f5-9888-hmc6

### DIFF
--- a/opensearch-dashboards-3.advisories.yaml
+++ b/opensearch-dashboards-3.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/share/opensearch-dashboards/plugins/alertingDashboards/node_modules/tmp/package.json
             scanner: grype
+      - timestamp: 2025-08-08T14:40:49Z
+        type: pending-upstream-fix
+        data:
+          note: The vulnerability originates from a pinned dependency version that is also consumed by other libraries within the dependency graph. Upstream must update this dependency to a secure version and reconcile any resulting compatibility issues across the dependency tree. Once these changes are implemented upstream, the vulnerability can be remediated accordingly.
 
   - id: CGA-hvx5-j33w-wf72
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for 

Dep is pinned to a specific version and it is a dependency of other libs in the dependency tree (https://github.com/opensearch-project/OpenSearch-Dashboards/blob/3.1.0/yarn.lock).
