### PR TITLE
keycloak: add pending-upstream-fix advisory for GHSA-qj5r-2r5p-phc7

### DIFF
--- a/keycloak.advisories.yaml
+++ b/keycloak.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/keycloak/lib/lib/main/org.keycloak.keycloak-services-26.3.2.jar
             scanner: grype
+      - timestamp: 2025-08-08T19:20:40Z
+        type: pending-upstream-fix
+        data:
+          note: "This vulnerability affects the keycloak-services component version 26.3.2. The GitHub Advisory indicates no fix is currently available (firstPatchedVersion: null). This is a self-contained vulnerability in the Keycloak services JAR that requires upstream maintainers to develop and release a security fix. Unlike the EOL keycloak-21.1 package, this is an actively supported version that should receive security updates from upstream."
 
   - id: CGA-2q5v-2cg8-99xh
     aliases:


### PR DESCRIPTION
## Summary

Adds a pending-upstream-fix advisory for GHSA-qj5r-2r5p-phc7 (CVE-2025-8419) affecting the keycloak package version 26.3.2.

## CVE Details

**CVE**: CVE-2025-8419 / GHSA-qj5r-2r5p-phc7  
**Component**: keycloak-services @ 26.3.2  
**Severity**: MODERATE  
**Status**: pending-upstream-fix  

## Analysis

This vulnerability affects the keycloak-services component version 26.3.2. The GitHub Advisory indicates no fix is currently available (firstPatchedVersion: null). This is a self-contained vulnerability in the Keycloak services JAR that requires upstream maintainers to develop and release a security fix.

Unlike the EOL keycloak-21.1 package which was marked as fix-not-planned, this is an actively supported version that should receive security updates from upstream.

## Advisory Event Added

```yaml
- timestamp: 2025-08-08T19:20:40Z
  type: pending-upstream-fix
  data:
    note: "This vulnerability affects the keycloak-services component version 26.3.2. The GitHub Advisory indicates no fix is currently available (firstPatchedVersion: null). This is a self-contained vulnerability in the Keycloak services JAR that requires upstream maintainers to develop and release a security fix. Unlike the EOL keycloak-21.1 package, this is an actively supported version that should receive security updates from upstream."
```

## Verification

- [x] YAML file formatted with yam
- [x] Advisory follows established patterns
- [x] Timestamp is current and valid
- [x] Note explains the upstream dependency clearly