### PR TITLE
dotnet-bootstrap-8/CVE-2025-26646 false positive advisory update

### DIFF
--- a/dotnet-bootstrap-8.advisories.yaml
+++ b/dotnet-bootstrap-8.advisories.yaml
@@ -88,3 +88,8 @@ advisories:
             componentType: dotnet
             componentLocation: /usr/share/dotnet-bootstrap/dotnet/sdk/8.0.117/Containers/containerize/containerize.deps.json
             scanner: grype
+      - timestamp: 2025-08-08T23:49:32Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: CVE-2025-26646 affects Microsoft.Build.Tasks.Core 17.3.4 and 17.7.0, but vulnerability scanners are flagging metadata references and non-existent file paths. Investigation reveals all actual executable Microsoft.Build.Tasks.Core DLL files in the dotnet-8 package use version 17.8.31.31313 (patched version). The CodeAnalysis deps.json files point to non-existent 17.3.4 packages that cannot be loaded at runtime. This is Stale dependency metadata that doesn't reflect actual built components. Runtime verification confirms Assembly.LoadFrom() successfully loads 17.8.31 while attempting to load 17.3.4 throws FileNotFoundException. All 15 Microsoft.Build.Tasks.Core DLL files in the container are version 17.8.31.31313 with the security fix.


### PR DESCRIPTION
## Add false positive advisory for CVE-2025-26646

This PR adds a false positive determination for CVE-2025-26646 (GHSA-h4j7-5rxr-p4wc) affecting Microsoft.Build.Tasks.Core in .NET SDK 8.

### Background

CVE-2025-26646 is a spoofing vulnerability in Microsoft.Build.Tasks.Core versions 17.3.4 and below, and 17.7.0 and below in the 17.7.x branch. The vulnerability is fixed in version 17.8.31+.

### False Positive Evidence

Comprehensive investigation reveals that vulnerability scanners are incorrectly flagging this CVE due to:

1. **Phantom package references**: Scanners detect version 17.3.4 in dependency metadata files (deps.json) that reference non-existent package directories
2. **Non-existent file paths**: Advisory references point to files that don't exist in the actual container
3. **Metadata vs reality gap**: All actual executable Microsoft.Build.Tasks.Core DLL files are version 17.8.31 (patched)

### Verification

- **All 15 Microsoft.Build.Tasks.Core DLL files** in the container are version 17.8.31.31313
- **Runtime verification** confirms the .NET runtime loads version 17.8.31, not the vulnerable versions
- **Phantom version test** confirms version 17.3.4 cannot be loaded (FileNotFoundException)
- **File system verification** shows no 17.3.4 or 17.7.0 files exist anywhere in the container

### Conclusion

The dotnet-bootstrap-8 package is **not vulnerable** to CVE-2025-26646. All executable code uses the patched version 17.8.31, while scanners are incorrectly flagging stale metadata references to non-existent vulnerable versions.

This determination helps prevent unnecessary security remediation efforts based on scanner false positives.