### PR TITLE
newrelic-fluent-bit-output: add pending-upstream-fix advisory for CVE-2025-47907

### DIFF
--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -251,6 +251,14 @@ advisories:
         type: true-positive-determination
         data:
           note: 'Govulncheck found vulnerable symbols in Go binaries at the following locations: in newrelic-fluent-bit-output-2.4.0-r2.apk, at fluent-bit/bin/out_newrelic.so, fluent-bit/bin/out_newrelic.so.'
+      - timestamp: 2025-08-11T22:17:00Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Affected Go 1.20.x version cannot be updated to fix version due to upstream version pinning:
+            https://github.com/newrelic/newrelic-fluent-bit-output/blob/cc6bcc1e735a8812dd2eab8022a575b44f8366c8/go.mod#L3
+            which directs to the following conversation: https://github.com/golang/go/issues/62130#issuecomment-1687335898
+            The upstream project explicitly requires Go 1.20 and cannot be built with newer Go versions that contain the fix.
 
   - id: CGA-8gp7-2w3f-4fh5
     aliases:


### PR DESCRIPTION
## Summary

Adds a pending-upstream-fix advisory for CVE-2025-47907 in newrelic-fluent-bit-output.

## Details

The Go 1.20.x version used by this package cannot be updated to fix CVE-2025-47907 due to upstream version pinning. The upstream project explicitly requires Go 1.20 and cannot be built with newer Go versions that contain the fix.

## References

- Upstream go.mod pinning: https://github.com/newrelic/newrelic-fluent-bit-output/blob/cc6bcc1e735a8812dd2eab8022a575b44f8366c8/go.mod#L3
- Go issue discussion: https://github.com/golang/go/issues/62130#issuecomment-1687335898

## Test

Advisory validation:
```bash
yam newrelic-fluent-bit-output.advisories.yaml
# No errors
```