### PR TITLE
adv update: qemu CVE-2024-6519/GHSA-v9pm-v9p5-h96x

### DIFF
--- a/qemu.advisories.yaml
+++ b/qemu.advisories.yaml
@@ -176,3 +176,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-14T13:46:31Z
+        type: pending-upstream-fix
+        data:
+          note: QEMU upstream has not released a patch for this vulnerability. The vulnerability requires changes to the LSI53C895A SCSI controller emulation code. Consider using alternative SCSI controllers (e.g., virtio-scsi) instead of LSI53C895A as a workaround until upstream fixes the vulnerability


### PR DESCRIPTION
adv: qemu - CVE-2024-6519/GHSA-v9pm-v9p5-h96x - pending upstream fix