### PR TITLE
docker-selenium: add pending-upstream-fix advisory for GHSA-prj3-ccx8-p6x4

### DIFF
--- a/docker-selenium.advisories.yaml
+++ b/docker-selenium.advisories.yaml
@@ -89,3 +89,11 @@ advisories:
             componentType: java-archive
             componentLocation: /external_jars/https/repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.110.Final/netty-codec-http2-4.1.110.Final.jar
             scanner: grype
+      - timestamp: 2025-08-15T01:25:00Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            The netty-codec-http2 vulnerability comes from the selenium-server dependency. Docker-selenium
+            is a collection of Docker images and scripts that packages selenium-server, not a Maven/Bazel
+            project itself. The fix needs to be applied in the selenium package first, which will then
+            flow through to docker-selenium when it's updated to use the fixed selenium-server version.


### PR DESCRIPTION
The netty-codec-http2 vulnerability comes from the selenium-server dependency that docker-selenium packages.

Docker-selenium is a collection of Docker images and scripts, not a Maven/Bazel project itself. The attempted fix in PR #63147 failed because it incorrectly added a maven/pombump step when there's no pom.xml file.

The fix needs to be applied in the selenium package first, which will then flow through to docker-selenium when it's updated to use the fixed selenium-server version.

Related PR (with fix): https://github.com/wolfi-dev/os/pull/63147