### PR TITLE
celeborn-0.5: add pending-upstream-fix advisory for GHSA-prj3-ccx8-p6x4

### DIFF
--- a/celeborn-0.5.advisories.yaml
+++ b/celeborn-0.5.advisories.yaml
@@ -157,6 +157,15 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/netty-codec-http2-4.1.118.Final.jar
             scanner: grype
+      - timestamp: 2025-08-15T20:02:33Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Celeborn uses netty-all 4.1.109.Final which bundles all netty components including netty-codec-http2.
+            Attempting to override just netty-codec-http2 to 4.1.124.Final via pombump causes build failures due to
+            version mismatches with the bundled netty-all dependency. The fix requires updating the entire netty
+            version property in the upstream project from 4.1.109.Final to 4.1.124.Final+ to maintain consistency
+            across all netty components. This needs to be done upstream in Apache Celeborn.
 
   - id: CGA-p77w-9v75-gj5c
     aliases:


### PR DESCRIPTION
## Summary

Adds pending-upstream-fix advisory for GHSA-prj3-ccx8-p6x4 (CVE-2025-55163) affecting celeborn-0.5, explaining why the automated remediation attempt in PR #63116 failed.

## Analysis

The automated PR attempted to fix the vulnerability by adding this to pombump-deps.yaml:
```yaml
- groupId: io.netty
  artifactId: netty-codec-http2
  version: 4.1.124.Final
```

However, this approach fails because:

1. **Celeborn uses netty-all**: The project depends on `netty-all:4.1.109.Final` which bundles ALL netty components
2. **Version mismatch**: Overriding just `netty-codec-http2` to 4.1.124.Final creates inconsistency with other netty components still at 4.1.109.Final
3. **Build failure**: The mismatch causes compilation errors (missing J2ObjC annotations dependency)

## Root Cause

From upstream pom.xml:
```xml
<netty.version>4.1.109.Final</netty.version>
...
<dependency>
  <groupId>io.netty</groupId>
  <artifactId>netty-all</artifactId>
  <version>${netty.version}</version>
</dependency>
```

The entire `netty.version` property needs to be updated to 4.1.124.Final+ in the upstream Apache Celeborn project to maintain consistency across all netty components.

## Advisory Details

- **CVE**: CVE-2025-55163 / GHSA-prj3-ccx8-p6x4
- **Component**: netty-codec-http2 @ 4.1.118.Final
- **Type**: pending-upstream-fix
- **Rationale**: Requires upstream to update entire netty version, not just individual components

## References

- Failed automated PR: https://github.com/wolfi-dev/os/pull/63116
- Apache Celeborn upstream: https://github.com/apache/celeborn