### PR TITLE
Adv(Pending upstream Fix): GHSA-4vq8-7jfc-9cvp traefik-3.5

### DIFF
--- a/traefik-3.5.advisories.yaml
+++ b/traefik-3.5.advisories.yaml
@@ -21,6 +21,15 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/traefik
             scanner: grype
+      - timestamp: 2025-08-19T08:14:56Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            We are unable to upgrade the Docker dependency in our Traefik package to v28.0.0 to fix the CVE,
+            as it introduces breaking API changes. Docker v28.0.0 removes several types and fields—such as `ContainerNode`, `NetworkListOptions`, and `EventsOptions`
+            that Traefik’s Docker provider still relies on. These removals cause multiple compilation errors across several files in Traefik’s codebase.
+            The highest version we can upgrade to without breaking the build is Docker v27.5.1, which unfortunately does not address the CVE. As a result,
+            this issue cannot be resolved without upstream changes in Traefik to support the newer Docker API.
 
   - id: CGA-pmxx-pv94-8cpv
     aliases:


### PR DESCRIPTION
Note: We are unable to upgrade the Docker dependency in our Traefik package to v28.0.0 to fix the CVE, as it introduces breaking API changes. Docker v28.0.0 removes several types and fields—such as ContainerNode, NetworkListOptions, and EventsOptions—that Traefik’s Docker provider still relies on. These removals cause multiple compilation errors across several files in Traefik’s codebase. The highest version we can upgrade to without breaking the build is Docker v27.5.1, which unfortunately does not address the CVE. As a result, this issue cannot be resolved without upstream changes in Traefik to support the newer Docker API.