### PR TITLE
feat(k8sgpt): update advisory for GHSA-9h84-qmv7-982p and GHSA-f9f8-9pmf-xv68

### DIFF
--- a/k8sgpt.advisories.yaml
+++ b/k8sgpt.advisories.yaml
@@ -363,6 +363,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/k8sgpt
             scanner: grype
+      - timestamp: 2025-08-19T13:40:20Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability originates from the Helm dependency. Upgrading Helm breaks the build due to a transitive conflict with k8s.io/client-go, which introduces incompatibility with Prometheus libraries. Once Prometheus addresses this (see issue #16767 and PR #16768) and the upstream resolves the issue, we’ll be able to upgrade and remediate the vulnerability.'
 
   - id: CGA-8wx4-v8f7-xm2w
     aliases:
@@ -946,6 +950,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/k8sgpt
             scanner: grype
+      - timestamp: 2025-08-19T13:40:20Z
+        type: pending-upstream-fix
+        data:
+          note: 'The vulnerability originates from the Helm dependency. Upgrading Helm breaks the build due to a transitive conflict with k8s.io/client-go, which introduces incompatibility with Prometheus libraries. Once Prometheus addresses this (see issue #16767 and PR #16768) and the upstream resolves the issue, we’ll be able to upgrade and remediate the vulnerability.'
 
   - id: CGA-xff4-q2mx-jxpg
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for GHSA-9h84-qmv7-982p and GHSA-f9f8-9pmf-xv68.

The vulnerability originates from the Helm dependency. Upgrading Helm breaks the build due to a transitive conflict with k8s.io/client-go, which introduces incompatibility with Prometheus libraries. Once Prometheus addresses this (see issue [#16767](https://github.com/prometheus/prometheus/issues/16767) and [PR #16768](https://github.com/prometheus/prometheus/pull/16768)) and the upstream resolves the issue, we’ll be able to upgrade and remediate the vulnerability.
