### PR TITLE
docs[libssh]: add advisory for CVE-2025-8114

### DIFF
--- a/libssh.advisories.yaml
+++ b/libssh.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-19T14:03:16Z
+        type: pending-upstream-fix
+        data:
+          note: Although details of this vulnerability have been publicly disclosed, no fix has yet been released.
 
   - id: CGA-5gpg-p7r2-f5wp
     aliases:


### PR DESCRIPTION
Upstream have not yet released the fix for this: https://git.libssh.org/projects/libssh.git/refs/