### PR TITLE
feat(external-secrets-operator-0.18): update advisory for GHSA-fcxq-v2r3-cc8h

### DIFF
--- a/external-secrets-operator-0.18.advisories.yaml
+++ b/external-secrets-operator-0.18.advisories.yaml
@@ -44,3 +44,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/external-secrets
             scanner: grype
+      - timestamp: 2025-08-20T08:07:48Z
+        type: pending-upstream-fix
+        data:
+          note: The vulnerability in External Secrets Operator allows unauthorized secret access across namespaces through missing namespace restrictions in List() calls. The fix is available in version 0.19.2, however due to significant functional changes between 0.18.x and 0.19.x, upstream maintainers will need to backport the security fix to the 0.18.x release stream for this package to receive the fix. The vulnerability affects PushSecret and SecretStore controllers' List() operations which could allow attackers to exfiltrate sensitive data from arbitrary namespaces.


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for GHSA-fcxq-v2r3-cc8h
