### PR TITLE
Add false-positive determination for CVE-2024-9453 in jenkins-2

### DIFF
--- a/jenkins-2.advisories.yaml
+++ b/jenkins-2.advisories.yaml
@@ -174,6 +174,16 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-21T14:30:50Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: |
+            The vulnerability specifically affects Red Hat OpenShift Jenkins,
+            which includes custom OpenShift-specific integration code not present in the upstream Jenkins project.
+            Our jenkins-2 package is built directly from the upstream jenkinsci/jenkins source code and does not
+            include the vulnerable OpenShift integration components. Therefore, this vulnerability is not applicable
+            to our package despite being flagged by scanners matching on the package name.
 
   - id: CGA-xmrq-2g6w-rj66
     aliases:


### PR DESCRIPTION
This commit adds a false-positive determination for CVE-2024-9453 (bearer token exposure in logs) in the jenkins-2 package. The vulnerability specifically affects Red Hat OpenShift Jenkins which contains custom OpenShift integration code that our package does not include.

Our jenkins-2.492 package is built directly from the upstream jenkinsci/jenkins source code without any OpenShift-specific components, making this vulnerability not applicable despite being flagged by security scanners that match on the package name.

This determination helps prevent false alarms in security scans and clarifies the security posture of our Jenkins package.