### PR TITLE
openjpeg/advisory update

### DIFF
--- a/openjpeg.advisories.yaml
+++ b/openjpeg.advisories.yaml
@@ -64,6 +64,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-08-21T20:13:20Z
+        type: pending-upstream-fix
+        data:
+          note: 'Upstream will need to address vulnerability or dispute CVE but has not provided any update on the issue: https://github.com/uclouvain/openjpeg/issues/1471.'
 
   - id: CGA-q24v-xmh9-rm8g
     aliases:


### PR DESCRIPTION
adv: openjpeg - CVE-2023-39328