### PR TITLE
Add fixed event manually to jitsucom-bulker advisories

### DIFF
--- a/jitsucom-bulker.advisories.yaml
+++ b/jitsucom-bulker.advisories.yaml
@@ -163,6 +163,15 @@ advisories:
         data:
           fixed-version: 2.7.0-r1
 
+  - id: CGA-c5g5-rjpw-2wgv
+    aliases:
+      - GHSA-2464-8j7c-4cjm
+    events:
+      - timestamp: 2025-08-26T15:56:20Z
+        type: fixed
+        data:
+          fixed-version: 2.11.0-r2
+
   - id: CGA-c9hw-rw9x-jfr4
     aliases:
       - GHSA-fv92-fjc5-jj9h


### PR DESCRIPTION
The detection event wasn't added automatically so proactively add fixed event for GHSA-2464-8j7c-4cjm instead of relying on automation.