### PR TITLE
docs(kubernetes-dns-node-cache): add advisory for CVE-2025-5187

### DIFF
--- a/kubernetes-dns-node-cache.advisories.yaml
+++ b/kubernetes-dns-node-cache.advisories.yaml
@@ -603,6 +603,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/node-cache
             scanner: grype
+      - timestamp: 2025-08-29T13:21:24Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE is resolved in k8s.io/kubernetes/ v1.31.12 onwards. However, the upstream maintainers have used a replace directive in go.mod to explicitly pin to v1.30.12 as a result of an attempted upgrade causing issues. The upstream maintainers will need to resolve those issues before this dependency can be upgraded
 
   - id: CGA-wcwj-qxf4-fp8c
     aliases:


### PR DESCRIPTION
Upstream have [pinned the k8s module to 1.30.12](https://github.com/kubernetes/dns/pull/706) because dependabot tried upgrading to 1.31.12 and broke things

They'll need to rectify those issues before the dependency can be upgraded