### PR TITLE
fix(python-3.11):update advisory with fixed event for CVE-2025-8194

### DIFF
--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -188,6 +188,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: 'Upstream maintainers must release the backport PR for Python 3.11. The tarfile validation fix from gh-130577 is ready for 3.11 via PR #137172 but not yet merged and released. CVE-2025-8194 is fixed in Python 3.13.5+ but requires backporting to 3.11 branch. Reference: https://github.com/python/cpython/pull/137172'
+      - timestamp: 2025-08-29T14:26:13Z
+        type: fixed
+        data:
+          fixed-version: 3.11.13-r4
 
   - id: CGA-h6qq-2p9f-rrpx
     aliases:


### PR DESCRIPTION
## Changes

Adding fixed event, for the CVE fixed by: https://github.com/wolfi-dev/os/pull/64549