### PR TITLE
docs: add libreoffice advisory

### DIFF
--- a/libreoffice-25.8.advisories.yaml
+++ b/libreoffice-25.8.advisories.yaml
@@ -21,3 +21,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-09-01T13:24:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This is a false positive - the vulnerability was fixed in OpenOffice 4.1.15. It continues to be detected in more recent versions because upstream vulnerability databases do not record any version bounds for this CVE


### PR DESCRIPTION
This 12-year-old vulnerability was addressed in LibreOffice 4.x series.

Unfortunately, the GHSA for [CVE-2012-5639](https://github.com/advisories/GHSA-rvg2-vh9m-cq32) doesn't have any version bounds attached to it