### PR TITLE
docs(local-static-provisioner): update advisory

### DIFF
--- a/local-static-provisioner.advisories.yaml
+++ b/local-static-provisioner.advisories.yaml
@@ -97,6 +97,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/main
             scanner: grype
+      - timestamp: 2025-09-01T13:56:40Z
+        type: pending-upstream-fix
+        data:
+          note: CVE-2025-5187 is fixed in version 1.31.12 onwards. However, upstream have explicitly pinned to 1.29.14 - 1.30 onwards includes incompatible API changes, so upstream will need to update the codebase to be able to use the newer versions
 
   - id: CGA-6pmq-p696-hw7x
     aliases:


### PR DESCRIPTION
https://github.com/advisories/GHSA-4x4m-3c2p-qppc is fixed in version 1.31.12 onwards. However, upstream have explicitly pinned to 1.29.14 - 1.30 onwards includes incompatible API changes, so upstream will need to update the codebase to be able to use the newer versions