### PR TITLE
keycloak-26.3: update advisory

### DIFF
--- a/keycloak-26.3.advisories.yaml
+++ b/keycloak-26.3.advisories.yaml
@@ -50,6 +50,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/bitnami/keycloak/lib/lib/main/org.keycloak.keycloak-model-storage-services-26.3.3.jar
             scanner: grype
+      - timestamp: 2025-09-01T14:13:28Z
+        type: pending-upstream-fix
+        data:
+          note: KeycloakRealmImport vulnerability in keycloak-model-storage-services affects versions <=26.3.2. No fix currently available, pending upstream fix.
 
   - id: CGA-mhvg-p72w-mqcr
     aliases:


### PR DESCRIPTION
Update advisories for CVE-2025-9162
There is currently no fix available for this vulnerability, we are
pending for an upstream fix.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
