### PR TITLE
chore: tidy up advisory file

### DIFF
--- a/redpanda-25.1.advisories.yaml
+++ b/redpanda-25.1.advisories.yaml
@@ -21,10 +21,6 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/rpk
             scanner: grype
-      - timestamp: 2025-08-11T08:34:56Z
-        type: fixed
-        data:
-          fixed-version: 25.2.1-r1
 
   - id: CGA-mxcp-87jp-q4j9
     aliases:
@@ -43,7 +39,3 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/rpk
             scanner: grype
-      - timestamp: 2025-08-16T19:04:31Z
-        type: fixed
-        data:
-          fixed-version: 25.2.1-r2


### PR DESCRIPTION
25.1 is no longer the most recent version stream, so it has rotated out