### PR TITLE
docs: add false positive advisories

### DIFF
--- a/ruby-3.2.advisories.yaml
+++ b/ruby-3.2.advisories.yaml
@@ -88,6 +88,17 @@ advisories:
         data:
           fixed-version: 3.2.2-r0
 
+  - id: CGA-cp5v-2q2h-78cq
+    aliases:
+      - CVE-2023-5363
+      - GHSA-xw78-pcr6-wrg8
+    events:
+      - timestamp: 2025-09-02T15:16:59Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: Some scanners misattribute the Ruby OpenSSL gem version as being the OpenSSL version, generating an alert for this vulnerability. Others may also detect a version string in Ruby's bundled OpenSSL shared object, however this is not used. At the time of writing, the underlying OpenSSL version is 3.5.2 which is not vulnerable to CVE-2023-5363
+
   - id: CGA-hcpq-57j9-pjwg
     aliases:
       - CVE-2025-27219
@@ -293,6 +304,17 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.2.5-r1
+
+  - id: CGA-w39w-h4jj-9r57
+    aliases:
+      - CVE-2025-0306
+      - GHSA-vvxp-46w2-6p8r
+    events:
+      - timestamp: 2025-09-02T15:17:51Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Some scanners misattribute the Ruby OpenSSL gem version as being the OpenSSL version, generating an alert for this vulnerability. At the time of writing, the underlying OpenSSL version is 3.5.2 which is not vulnerable.
 
   - id: CGA-w76p-w4vr-qcc5
     aliases:

--- a/ruby3.2-llhttp.advisories.yaml
+++ b/ruby3.2-llhttp.advisories.yaml
@@ -1,0 +1,60 @@
+schema-version: 2.0.2
+
+package:
+  name: ruby3.2-llhttp
+
+advisories:
+  - id: CGA-7p5m-4c2p-qmhc
+    aliases:
+      - CVE-2021-22959
+      - GHSA-mhxq-vjjq-pcvf
+    events:
+      - timestamp: 2025-09-02T15:26:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Some scanners may misattribute the version of the Ruby llhttp gem as being the version of the underlying llhttp C library. This vulnerability was fixed in llhttp version 6.0.7. At time of writing the version of the underlying libray is 8.1.0
+
+  - id: CGA-c667-5j4c-33wr
+    aliases:
+      - CVE-2022-32215
+      - GHSA-5492-mr68-4m2h
+    events:
+      - timestamp: 2025-09-02T15:25:31Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Some scanners may misattribute the version of the Ruby llhttp gem as being the version of the underlying llhttp C library. This vulnerability was fixed in llhttp version 6.0.7. At time of writing the version of the underlying libray is 8.1.0
+
+  - id: CGA-v839-9x2c-5wmp
+    aliases:
+      - CVE-2022-32214
+      - GHSA-q5vx-44v4-gch4
+    events:
+      - timestamp: 2025-09-02T15:26:04Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Some scanners may misattribute the version of the Ruby llhttp gem as being the version of the underlying llhttp C library. This vulnerability was fixed in llhttp version 6.0.7. At time of writing the version of the underlying libray is 8.1.0
+
+  - id: CGA-xfh5-c59p-2h8p
+    aliases:
+      - CVE-2022-32213
+      - GHSA-5689-v88g-g6rv
+    events:
+      - timestamp: 2025-09-02T15:27:23Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Some scanners may misattribute the version of the Ruby llhttp gem as being the version of the underlying llhttp C library. This vulnerability was fixed in llhttp version 6.0.7. At time of writing the version of the underlying libray is 8.1.0
+
+  - id: CGA-xhvh-j6jg-4xm9
+    aliases:
+      - CVE-2021-22960
+      - GHSA-px8h-5r3g-hj68
+    events:
+      - timestamp: 2025-09-02T15:26:54Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: Some scanners may misattribute the version of the Ruby llhttp gem as being the version of the underlying llhttp C library. This vulnerability was fixed in llhttp version 6.0.7. At time of writing the version of the underlying libray is 8.1.0


### PR DESCRIPTION
Add advisories to cover false-positive-detections made by a supported scanner.