### PR TITLE
k3s-1.33: add pending-upstream-fix for CVE-2025-54410 and CVE-2024-36623

### DIFF
--- a/k3s-1.33.advisories.yaml
+++ b/k3s-1.33.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/k3s
             scanner: grype
+      - timestamp: 2025-09-03T12:08:24Z
+        type: pending-upstream-fix
+        data:
+          note: We have tried remediating this dependency but it results in build failures. Upstream needs to publish a version with this CVE fixed.
 
   - id: CGA-4hw3-vxq6-qr47
     aliases:
@@ -39,3 +43,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/k3s
             scanner: grype
+      - timestamp: 2025-09-03T12:07:58Z
+        type: pending-upstream-fix
+        data:
+          note: We have tried remediating this dependency but it results in build failures. Upstream needs to publish a version with this CVE fixed.


### PR DESCRIPTION
Both CVE-2024-36623 and CVE-2025-54410 are pending upstream fix.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
