### PR TITLE
feat(gitlab-runner-18.3): update advisory for GHSA-4vq8-7jfc-9cvp

### DIFF
--- a/gitlab-runner-18.3.advisories.yaml
+++ b/gitlab-runner-18.3.advisories.yaml
@@ -39,3 +39,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gitlab-runner-helper
             scanner: grype
+      - timestamp: 2025-09-03T13:04:36Z
+        type: pending-upstream-fix
+        data:
+          note: The vulnerability originates from a Docker dependency. Attempts to upgrade have resulted in build failures, indicating that upstream must align the codebase and resolve the dependency issues. Once these changes are addressed upstream, we will be able to upgrade and remediate the CVE.


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for GHSA-4vq8-7jfc-9cvp
