### PR TITLE
druid: add pending-upstream-fix advisory for GHSA-vp98-w2p3-mv35

### DIFF
--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -216,6 +216,16 @@ advisories:
         data:
           note: This vulnerability relates to protobuf-java 3.7.1, included by the shaded JAR hadoop-client-runtime-3.3.6.jar.
 
+  - id: CGA-5mfc-3r4g-h4g8
+    aliases:
+      - CVE-2023-26464
+      - GHSA-vp98-w2p3-mv35
+    events:
+      - timestamp: 2025-09-03T19:13:47Z
+        type: pending-upstream-fix
+        data:
+          note: This log4j dependency is a transitive dependency brought in from ambari-metrics-common-2.7.0.0.0.jar. this is the most recent version of ambari-metrics-common. Upstream maintainers must release a ambari-metrics-common release with an updated version of log4j in order for this to be remediated.
+
   - id: CGA-5mgm-j25w-77hj
     aliases:
       - CVE-2023-52428

--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -1258,7 +1258,7 @@ advisories:
       - timestamp: 2025-09-03T19:13:47Z
         type: pending-upstream-fix
         data:
-          note: This log4j dependency is a transitive dependency brought in from ambari-metrics-common-2.7.0.0.0.jar. this is the most recent version of ambari-metrics-common. Upstream maintainers must release a ambari-metrics-common release with an updated version of log4j in order for this to be remediated.
+          note: This log4j dependency is a transitive dependency brought in from ambari-metrics-common-2.7.0.0.0.jar. This is the most recent version of ambari-metrics-common. To resolve this, upstream maintainers must release an updated version of ambari-metrics-common that contains the latest Log4j.
 
   - id: CGA-wxxf-g4g4-cxhp
     aliases:

--- a/druid.advisories.yaml
+++ b/druid.advisories.yaml
@@ -216,16 +216,6 @@ advisories:
         data:
           note: This vulnerability relates to protobuf-java 3.7.1, included by the shaded JAR hadoop-client-runtime-3.3.6.jar.
 
-  - id: CGA-5mfc-3r4g-h4g8
-    aliases:
-      - CVE-2023-26464
-      - GHSA-vp98-w2p3-mv35
-    events:
-      - timestamp: 2025-09-03T19:13:47Z
-        type: pending-upstream-fix
-        data:
-          note: This log4j dependency is a transitive dependency brought in from ambari-metrics-common-2.7.0.0.0.jar. this is the most recent version of ambari-metrics-common. Upstream maintainers must release a ambari-metrics-common release with an updated version of log4j in order for this to be remediated.
-
   - id: CGA-5mgm-j25w-77hj
     aliases:
       - CVE-2023-52428
@@ -1265,6 +1255,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/druid/extensions/ambari-metrics-emitter/ambari-metrics-common-2.7.0.0.0.jar
             scanner: grype
+      - timestamp: 2025-09-03T19:13:47Z
+        type: pending-upstream-fix
+        data:
+          note: This log4j dependency is a transitive dependency brought in from ambari-metrics-common-2.7.0.0.0.jar. this is the most recent version of ambari-metrics-common. Upstream maintainers must release a ambari-metrics-common release with an updated version of log4j in order for this to be remediated.
 
   - id: CGA-wxxf-g4g4-cxhp
     aliases:


### PR DESCRIPTION
Add advisory for log4j vulnerability in druid package.

The log4j dependency is bundled within ambari-metrics-common-2.7.0.0.0.jar and requires upstream coordination to resolve.