### PR TITLE
hadoop-fips-3.3.6: add pending-upstream-fix advisory for GHSA-vp98-w2p3-mv35

### DIFF
--- a/hadoop-fips-3.3.6.advisories.yaml
+++ b/hadoop-fips-3.3.6.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: 2.0.2
+
+package:
+  name: hadoop-fips-3.3.6
+
+advisories:
+  - id: CGA-57p9-7ffq-r63v
+    aliases:
+      - CVE-2023-26464
+      - GHSA-vp98-w2p3-mv35
+    events:
+      - timestamp: 2025-09-05T00:52:57Z
+        type: pending-upstream-fix
+        data:
+          note: The log4j vulnerability requires upgrading to a major version that introduces breaking changes. This fix requires upstream Hadoop maintainers to implement compatibility with the newer log4j version to avoid breaking existing functionality.


### PR DESCRIPTION
## Summary

Adds pending-upstream-fix advisory for hadoop-fips-3.3.6 to document the log4j vulnerability GHSA-vp98-w2p3-mv35.

## Details

The log4j vulnerability requires upgrading to a major version that introduces breaking changes. This fix requires upstream Hadoop maintainers to implement compatibility with the newer log4j version to avoid breaking existing functionality.

## Advisory Type

- **Type**: pending-upstream-fix
- **CVE**: GHSA-vp98-w2p3-mv35 (CVE-2023-26464)  
- **Rationale**: Major version upgrade required for fix creates compatibility issues requiring upstream coordination