### PR TITLE
apache-nifi-registry: update advisories

### DIFF
--- a/apache-nifi-registry.advisories.yaml
+++ b/apache-nifi-registry.advisories.yaml
@@ -71,6 +71,13 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/nifi-registry/nifi-registry-2.5.0/ext/aws/lib/netty-codec-http-4.2.2.Final.jar
             scanner: grype
+      - timestamp: 2025-09-08T02:45:37Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            The fix for this CVE requires upgrading netty-codec-http to 4.2.5.Final.
+            However, this dependency is bundled as part of the AWS extension JAR and cannot be independently updated through dependency management.
+            We need to wait for Apache NiFi 2.6.0 to be officially released before we can apply this security fix.
 
   - id: CGA-4chp-2v5c-g3c7
     aliases:
@@ -89,6 +96,13 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/nifi-registry/nifi-registry-2.5.0/ext/aws/lib/netty-codec-compression-4.2.2.Final.jar
             scanner: grype
+      - timestamp: 2025-09-08T02:48:42Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            The fix for this CVE requires upgrading netty-codec-compression to 4.2.5.Final.
+            However, this dependency is bundled as part of the AWS extension JAR and cannot be independently updated through dependency management.
+            We need to wait for Apache NiFi 2.6.0 to be officially released before we can apply this security fix.
 
   - id: CGA-4fcv-jq36-r7hx
     aliases:


### PR DESCRIPTION
Advisory for GHSA-fghv-69vj-qj49
The fix for this CVE requires upgrading netty-codec-http to 4.2.5.Final.
However, this dependency is bundled as part of the AWS extension JAR and
cannot be independently updated through dependency management. We need
to wait for Apache NiFi 2.6.0 to be officially released before we can
apply this security fix.

Advisory for GHSA-3p8m-j85q-pgmj
The fix for this CVE requires upgrading netty-codec-compression to
4.2.5.Final. However, this dependency is bundled as part of the AWS
extension JAR and cannot be independently updated through dependency
management. We need to wait for Apache NiFi 2.6.0 to be officially
released before we can apply this security fix.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
