### PR TITLE
gitlab-runner-18.3: update advisory

### DIFF
--- a/gitlab-runner-18.3.advisories.yaml
+++ b/gitlab-runner-18.3.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine
             scanner: grype
+      - timestamp: 2025-09-08T22:21:21Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This vulnerability is being detected erroneously since this issue has been fixed since docker 25.0.4 and we currently ship v25.0.6
 
   - id: CGA-fhgg-cgj3-gr3x
     aliases:


### PR DESCRIPTION
Update advisory for CVE-2024-36623
This vulnerability is being detected erroneously since this issue has
been fixed since docker 25.0.4 and we currently ship v25.0.6

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
