### PR TITLE
feat(logstash-9.1): update advisory for GHSA-22h5-pq3x-2gf2, GHSA-gh9q-2xrm-x6qv and GHSA-mhwm-jh88-3gjf

### DIFF
--- a/logstash-9.1.advisories.yaml
+++ b/logstash-9.1.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/uri-0.12.3.gemspec
             scanner: grype
+      - timestamp: 2025-09-09T16:19:53Z
+        type: pending-upstream-fix
+        data:
+          note: The uri gem at version 0.12.2 is included as a default gem in JRuby's standard library. Because it's part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of uri (0.12.4+).
 
   - id: CGA-9972-86wh-c67w
     aliases:
@@ -57,6 +61,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
             scanner: grype
+      - timestamp: 2025-09-09T16:19:53Z
+        type: pending-upstream-fix
+        data:
+          note: The cgi gem at version 0.3.6 is included as a default gem in JRuby's standard library. Because it's part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of cgi (0.3.7+).
 
   - id: CGA-hw7m-xpfp-5jr2
     aliases:
@@ -75,6 +83,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
             scanner: grype
+      - timestamp: 2025-09-09T16:19:53Z
+        type: pending-upstream-fix
+        data:
+          note: The cgi gem at version 0.3.6 is included as a default gem in JRuby's standard library. Because it's part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of cgi (0.3.7+).
 
   - id: CGA-mq82-fgj6-fhmc
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for GHSA-22h5-pq3x-2gf2, GHSA-mhwm-jh88-3gjf and GHSA-gh9q-2xrm-x6qv
