### PR TITLE
akhq/celeborn: update advisories

### DIFF
--- a/akhq.advisories.yaml
+++ b/akhq.advisories.yaml
@@ -276,6 +276,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/akhq/akhq.jar
             scanner: grype
+      - timestamp: 2025-09-09T19:00:14Z
+        type: pending-upstream-fix
+        data:
+          note: The netty-codec-compression dependency is a transient dependency from Micronaut, we will need to wait for Micronaut to release a fixed version and akhq to upgrade their dependencies to use the new Micronaut version.
 
   - id: CGA-qp6f-2pwr-jwx7
     aliases:

--- a/celeborn-0.5.advisories.yaml
+++ b/celeborn-0.5.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/netty-codec-4.1.118.Final.jar
             scanner: grype
+      - timestamp: 2025-09-09T19:02:26Z
+        type: pending-upstream-fix
+        data:
+          note: This dependency is a transient dependency from the apache ratis-thirdparty-misc plugins, we will need to wait for a new version of ratis-thirdparty-misc to release a fixed version and celeborn to upgrade their dependencies to use the new ratis-thirdparty-misc version.
 
   - id: CGA-7gw9-4489-p7g8
     aliases:
@@ -219,6 +223,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/netty-codec-http-4.1.118.Final.jar
             scanner: grype
+      - timestamp: 2025-09-09T19:02:26Z
+        type: pending-upstream-fix
+        data:
+          note: This dependency is a transient dependency from the apache ratis-thirdparty-misc plugins, we will need to wait for a new version of ratis-thirdparty-misc to release a fixed version and celeborn to upgrade their dependencies to use the new ratis-thirdparty-misc version.
 
   - id: CGA-rc57-hr6c-69f6
     aliases:


### PR DESCRIPTION
Update advisory of akhq for GHSA-3p8m-j85q-pgmj
The netty-codec-compression dependency is a transient dependency from
Micronaut, we will need to wait for Micronaut to release a fixed version
and akhq to upgrade their dependencies to use the new Micronaut version.

Update advisory of celeborn for GHSA-3p8m-j85q-pgmj and GHSA-fghv-69vj-qj49
This dependency is a transient dependency from the apache
ratis-thirdparty-misc plugins, we will need to wait for a new version of
ratis-thirdparty-misc to release a fixed version and celeborn to upgrade
their dependencies to use the new ratis-thirdparty-misc version.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
