### PR TITLE
selenium: update advisories

### DIFF
--- a/selenium.advisories.yaml
+++ b/selenium.advisories.yaml
@@ -99,6 +99,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/selenium/bin/selenium_server_deploy.jar
             scanner: grype
+      - timestamp: 2025-09-10T00:02:40Z
+        type: pending-upstream-fix
+        data:
+          note: 'We are unable to bump netty-codec or netty-codec-http to a newer version without breaking the build. Upstream already has a fix in place for a future version, and we should await for a new build with the fixed versions. More information: https://github.com/SeleniumHQ/selenium/pull/16194'
 
   - id: CGA-m696-rcvm-w26c
     aliases:
@@ -117,3 +121,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/selenium/bin/selenium_server_deploy.jar
             scanner: grype
+      - timestamp: 2025-09-10T00:02:40Z
+        type: pending-upstream-fix
+        data:
+          note: 'We are unable to bump netty-codec or netty-codec-http to a newer version without breaking the build. Upstream already has a fix in place for a future version, and we should await for a new build with the fixed versions. More information: https://github.com/SeleniumHQ/selenium/pull/16194'


### PR DESCRIPTION
Update advisories GHSA-3p8m-j85q-pgmj and GHSA-fghv-69vj-qj49
We are unable to bump netty-codec or netty-codec-http to a newer version
without breaking the build. Upstream already has a fix in place for a
future version, and we should await for a new build with the fixed
versions. More information:
https://github.com/SeleniumHQ/selenium/pull/16194

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
