### PR TITLE
sonarqube: update advisories

### DIFF
--- a/sonarqube.advisories.yaml
+++ b/sonarqube.advisories.yaml
@@ -65,6 +65,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/modules/transport-netty4/netty-codec-http-4.1.118.Final.jar
             scanner: grype
+      - timestamp: 2025-09-10T00:12:21Z
+        type: pending-upstream-fix
+        data:
+          note: This is a transitive dependency of ElasticSearch and must be fixed in the upstream project.
 
   - id: CGA-58f2-7g45-3fm6
     aliases:
@@ -237,6 +241,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/modules/transport-netty4/netty-codec-4.1.118.Final.jar
             scanner: grype
+      - timestamp: 2025-09-10T00:12:21Z
+        type: pending-upstream-fix
+        data:
+          note: This is a transitive dependency of ElasticSearch and must be fixed in the upstream project.
 
   - id: CGA-cm5r-p42v-5pxm
     aliases:


### PR DESCRIPTION
Update advisories for GHSA-3p8m-j85q-pgmj and GHSA-fghv-69vj-qj49 This
is a transitive dependency of ElasticSearch and must be fixed in the
upstream project.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
