### PR TITLE
opensearch-3: add pending-upstream-fix advisories for netty transitive dependencies

### DIFF
--- a/opensearch-3.advisories.yaml
+++ b/opensearch-3.advisories.yaml
@@ -127,6 +127,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/opensearch/plugins/opensearch-repository-azure/netty-codec-4.1.121.Final.jar
             scanner: grype
+      - timestamp: 2025-09-10T22:09:56Z
+        type: pending-upstream-fix
+        data:
+          note: "The netty-codec vulnerability is a transitive dependency brought in through dependencies in OpenSearch's submodules. Bumping to the fix version of netty causes build failures. Upstream maintainers will need to implement compatibility into the affected submodules."
 
   - id: CGA-h7m4-7gfh-6f23
     aliases:
@@ -177,6 +181,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/opensearch/plugins/opensearch-repository-azure/netty-codec-http-4.1.121.Final.jar
             scanner: grype
+      - timestamp: 2025-09-10T22:09:56Z
+        type: pending-upstream-fix
+        data:
+          note: "The netty-codec-http vulnerability is a transitive dependency brought in through dependencies in OpenSearch's submodules. Bumping to the fix version of netty causes build failures. Upstream maintainers will need to implement compatibility into the affected submodules."
 
   - id: CGA-vcw2-p8c6-rfr5
     aliases:


### PR DESCRIPTION
## Summary

Add pending-upstream-fix advisories for both GHSA-fghv-69vj-qj49 and GHSA-3p8m-j85q-pgmj affecting opensearch-3.

## Root Cause
Both netty vulnerabilities are transitive dependencies brought in through dependencies in OpenSearch's submodules. Bumping to the fix version of netty causes build failures.

## Resolution Required
Upstream maintainers will need to implement compatibility into the affected submodules.
