### PR TITLE
vitess-22/GHSA-g4jq-h2w9-997c/GHSA-jqfw-vq24-v9c3: pending-upstream-fix advisories

### DIFF
--- a/vitess-22.advisories.yaml
+++ b/vitess-22.advisories.yaml
@@ -65,6 +65,10 @@ advisories:
             componentType: npm
             componentLocation: /vt/web/vtadmin/node_modules/vite/package.json
             scanner: grype
+      - timestamp: 2025-09-11T18:22:18Z
+        type: pending-upstream-fix
+        data:
+          note: The vite dependency is required to be on the 4.x version stream per dependency requirement from vite-plugin-eslint@1.8.1, which is the latest version. Upstream maintainers will need to implement support for vite 5.x in vite-plugin-eslint to remediate.
 
   - id: CGA-529w-2929-7hc6
     aliases:
@@ -83,6 +87,10 @@ advisories:
             componentType: npm
             componentLocation: /vt/web/vtadmin/node_modules/vite/package.json
             scanner: grype
+      - timestamp: 2025-09-11T18:22:00Z
+        type: pending-upstream-fix
+        data:
+          note: The vite dependency is required to be on the 4.x version stream per dependency requirement from vite-plugin-eslint@1.8.1, which is the latest version. Upstream maintainers will need to implement support for vite 5.x in vite-plugin-eslint to remediate.
 
   - id: CGA-74w6-mp7h-g4vg
     aliases:


### PR DESCRIPTION
## Summary

Add pending-upstream-fix advisories for two vite CVEs affecting vitess-22:
- GHSA-g4jq-h2w9-997c 
- GHSA-jqfw-vq24-v9c3 

## Root Cause

The vite dependency is constrained to the 4.x version stream due to a dependency requirement from vite-plugin-eslint@1.8.1, which is the latest available version of that plugin.

## Resolution Path

Upstream maintainers will need to implement support for vite 5.x in vite-plugin-eslint before these CVEs can be remediated in vitess-22.

## Advisory Type

- **Type**: `pending-upstream-fix`
