### PR TITLE
opensearch-dashboards-3: update advisory

### DIFF
--- a/opensearch-dashboards-3.advisories.yaml
+++ b/opensearch-dashboards-3.advisories.yaml
@@ -109,6 +109,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/share/opensearch-dashboards/node_modules/axios/package.json
             scanner: grype
+      - timestamp: 2025-09-15T13:41:57Z
+        type: pending-upstream-fix
+        data:
+          note: We are unable to bump the axios dependency as it results in a build failure. We will need to wait for upstream to bump the dependency in order to resolve this CVE.
 
   - id: CGA-vwj2-6mjr-g9qx
     aliases:


### PR DESCRIPTION
Update advisory for GHSA-4hjh-wcwx-xvwj
We are unable to bump the axios dependency as it results in a build
failure. We will need to wait for upstream to bump the dependency in
order to resolve this CVE.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
