### PR TITLE
ffmpeg-7: update advisory

### DIFF
--- a/ffmpeg-7.advisories.yaml
+++ b/ffmpeg-7.advisories.yaml
@@ -42,3 +42,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-09-19T06:27:19Z
+        type: fixed
+        data:
+          fixed-version: 7.1.1-r12


### PR DESCRIPTION
Update advisory for CVE-2025-1594
Fixed via https://github.com/wolfi-dev/os/pull/66637

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
