### PR TITLE
newrelic-fluent-bit-output: update advisory

### DIFF
--- a/newrelic-fluent-bit-output.advisories.yaml
+++ b/newrelic-fluent-bit-output.advisories.yaml
@@ -165,6 +165,14 @@ advisories:
         type: true-positive-determination
         data:
           note: 'Govulncheck found vulnerable symbols in Go binaries at the following locations: in newrelic-fluent-bit-output-2.4.0-r2.apk, at fluent-bit/bin/out_newrelic.so, fluent-bit/bin/out_newrelic.so.'
+      - timestamp: 2025-09-21T15:10:57Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            Affected Go 1.20.x version cannot be updated to fix version due to upstream version pinning:
+            https://github.com/newrelic/newrelic-fluent-bit-output/blob/cc6bcc1e735a8812dd2eab8022a575b44f8366c8/go.mod#L3
+            which directs to the following conversation: https://github.com/golang/go/issues/62130#issuecomment-1687335898
+            The upstream project explicitly requires Go 1.20 and cannot be built with newer Go versions that contain the fix.
 
   - id: CGA-5gpf-9p38-x5qq
     aliases:


### PR DESCRIPTION
Update advisory for CVE-2025-467906
Affected Go 1.20.x version cannot be updated to fix version due to
upstream version pinning:
https://github.com/newrelic/newrelic-fluent-bit-output/blob/cc6bcc1e735a8812dd2eab8022a575b44f8366c8/go.mod#L3
which directs to the following conversation:
https://github.com/golang/go/issues/62130#issuecomment-1687335898 The
upstream project explicitly requires Go 1.20 and cannot be built with
newer Go versions that contain the fix.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
