### PR TITLE
doc(jupyter-base-notebook): Pending upstream fix advisory for CGA-8x54-xgp7-85mr

### DIFF
--- a/jupyter-base-notebook.advisories.yaml
+++ b/jupyter-base-notebook.advisories.yaml
@@ -132,6 +132,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/lib/python3.12/site-packages/nbclassic/static/components/bootstrap/package.json
             scanner: grype
+      - timestamp: 2025-09-23T04:52:59Z
+        type: pending-upstream-fix
+        data:
+          note: Bootstrap 3.4.1 is end-of-life. Waiting for nbclassic upstream to migrate to Bootstrap 4+ or remediate the CVE through an alternative measure.
 
   - id: CGA-qg24-ggf8-2fq7
     aliases:


### PR DESCRIPTION
GHSA-q58r-hwc8-rm9j is vulnerability in npm module bootstrap 3.4.1.
Bootstrap 3.4.1 is end-of-life. 
Waiting for nbclassic upstream to migrate to Bootstrap 4+ or remediate the CVE through an alternative measure.