### PR TITLE
doc(mattermost-10.12): Add fp advisory for CVE-2022-4045 and CVE-2022-4019

### DIFF
--- a/mattermost-10.12.advisories.yaml
+++ b/mattermost-10.12.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-09-23T16:35:01Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This vulnerability was remediated in mattermost v7.4.0 and later. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4019'
 
   - id: CGA-6v98-ffvr-7w2j
     aliases:
@@ -96,3 +101,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-09-23T16:36:07Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This vulnerability was remediated in mattermost v7.4.0 and later. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4045'


### PR DESCRIPTION
These CVEs have been remediated and advised in a similar way for other Mattermost versions.
See: https://github.com/wolfi-dev/advisories/blob/main/mattermost-10.9.advisories.yaml
