### PR TITLE
py3-cassandra-medusa: add pending-upstream-fix advisory for GHSA-4xh5-x5gv-qwph

### DIFF
--- a/py3-cassandra-medusa.advisories.yaml
+++ b/py3-cassandra-medusa.advisories.yaml
@@ -474,6 +474,10 @@ advisories:
             componentType: python
             componentLocation: /home/cassandra/.venv/lib/python3.11/site-packages/pip-25.1.1.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-09-29T23:45:00Z
+        type: pending-upstream-fix
+        data:
+          note: "Remaining affected pip versions are transitive dependencies brought in via Python wheels. Upstream maintainers of these wheels are required to remediate."
 
   - id: CGA-fp53-8jf5-gj7f
     aliases:


### PR DESCRIPTION
## Summary

Adds pending-upstream-fix advisory for GHSA-4xh5-x5gv-qwph in py3-cassandra-medusa.

## GHSA-4xh5-x5gv-qwph - Pending Upstream Fix

**Type**: `pending-upstream-fix`

**Analysis**: The remaining affected pip versions are transitive dependencies brought in via Python wheels during the build process. These cannot be directly controlled by this package and require upstream maintainers of the wheels to update their pip dependencies.

**Related Package PR**: https://github.com/wolfi-dev/os/pull/67674 (epoch bump to pull in latest pip)
EDIT: I merged the[ higher release version](https://github.com/wolfi-dev/os/pull/67398) from the package queue instead
## Affected Component

- pip @ 25.1.1 (transitive dependency via Python wheels)
- Location: `/home/cassandra/.venv/lib/python3.11/site-packages/pip-25.1.1.dist-info/METADATA`

## Verification

The advisory documents that while the package has been rebuilt to pull in updated dependencies, any remaining vulnerable pip versions are embedded in upstream Python wheels that this package depends on.

Related: https://github.com/chainguard-dev/CVE-Dashboard/issues/30750