### PR TITLE
sqlpad: add pending-upstream-fix advisory for CVE-2025-57350

### DIFF
--- a/sqlpad.advisories.yaml
+++ b/sqlpad.advisories.yaml
@@ -393,6 +393,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/bin/sqlpad-server/node_modules/csvtojson/package.json
             scanner: grype
+      - timestamp: 2025-09-29T23:55:00Z
+        type: pending-upstream-fix
+        data:
+          note: "Upstream maintainers of csvtojson must implement a fix for this vulnerability before remediation is possible."
 
   - id: CGA-q894-55h8-4v53
     aliases:


### PR DESCRIPTION
## Summary

Adds pending-upstream-fix advisory for CVE-2025-57350 in sqlpad.

## CVE-2025-57350 - Pending Upstream Fix

**Type**: `pending-upstream-fix`

**Analysis**: This vulnerability affects csvtojson @ 2.0.10, a Node.js dependency of sqlpad. The csvtojson package maintainers must implement and release a fix before this vulnerability can be remediated in sqlpad.

**Related Package PR**: https://github.com/wolfi-dev/os/pull/67680 (epoch bump for tar-fs fix)

## Affected Component

- csvtojson @ 2.0.10
- Location: `/usr/bin/sqlpad-server/node_modules/csvtojson/package.json`

## Verification

The advisory documents that remediation depends on upstream csvtojson maintainers implementing a fix.

Related: https://github.com/chainguard-dev/CVE-Dashboard/issues/30720