### PR TITLE
wordpress: add pending-upstream-fix advisories for CVE-2025-58246 and CVE-2025-58674

### DIFF
--- a/wordpress.advisories.yaml
+++ b/wordpress.advisories.yaml
@@ -44,6 +44,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-09-30T00:00:00Z
+        type: pending-upstream-fix
+        data:
+          note: "The NVD states that the upstream maintainers, the WordPress core security team, is aware of the issue and working on a fix."
 
   - id: CGA-6fj7-2fc2-hgq2
     aliases:
@@ -199,3 +203,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-09-30T00:00:00Z
+        type: pending-upstream-fix
+        data:
+          note: "The NVD states that the upstream maintainers, the WordPress core security team, is aware of the issue and working on a fix."


### PR DESCRIPTION
## Summary

Adds pending-upstream-fix advisories for CVE-2025-58246 and CVE-2025-58674 in WordPress.

## CVE-2025-58246 and CVE-2025-58674 - Pending Upstream Fix

**Type**: `pending-upstream-fix`

**Analysis**: The NVD states that the upstream maintainers, the WordPress core security team, is aware of both issues and working on fixes.

## Affected Component

- wordpress @ 6.8.2-r2
- wordpress-oci-entrypoint @ 6.8.2-r2

## References

- CVE-2025-58246: https://nvd.nist.gov/vuln/detail/CVE-2025-58246
- CVE-2025-58674: https://nvd.nist.gov/vuln/detail/CVE-2025-58674

## Verification

The advisories document that the WordPress core security team is actively working on fixes for both vulnerabilities.

Related issues:
- https://github.com/chainguard-dev/CVE-Dashboard/issues/30746
- https://github.com/chainguard-dev/CVE-Dashboard/issues/30744