### PR TITLE
doc(jupyter-base-notebook): pending-upstream-fix advisory for GHSA-vxmc-5x29-h64v

### DIFF
--- a/jupyter-base-notebook.advisories.yaml
+++ b/jupyter-base-notebook.advisories.yaml
@@ -154,6 +154,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/lib/python3.12/site-packages/nbclassic/static/components/bootstrap/package.json
             scanner: grype
+      - timestamp: 2025-09-30T07:29:22Z
+        type: pending-upstream-fix
+        data:
+          note: This CVE affects bootstrap versions <= 3.4.1. The next fix version is bootstrap 4.0, which introduces breaking changes. Upstream will need to adapt the code to use a newer version of bootstrap.
 
   - id: CGA-qg24-ggf8-2fq7
     aliases:


### PR DESCRIPTION
This CVE affects bootstrap versions <= 3.4.1. The next fix version is bootstrap 4.0, which introduces breaking changes. Upstream will need to adapt the code to use a newer version of bootstrap.