### PR TITLE
doc(py3-pip): Add fixed event for CVE-2025-8869

### DIFF
--- a/py3-pip.advisories.yaml
+++ b/py3-pip.advisories.yaml
@@ -69,6 +69,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-09-30T14:33:24Z
+        type: fixed
+        data:
+          fixed-version: 25.2-r1
 
   - id: CGA-p6wh-jxvc-2c6c
     aliases:


### PR DESCRIPTION
This CVE was fixed through cherry-picking the patch. As such scanners won't be able to look at the component version to determine if CVE was fixed. So manually add the fixed event. https://github.com/wolfi-dev/os/pull/67721