### PR TITLE
feat(flyway): update advisory for CVE-2025-48924 and CVE-2025-53864

### DIFF
--- a/flyway.advisories.yaml
+++ b/flyway.advisories.yaml
@@ -206,6 +206,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This vulnerability exists in databricks-jdbc-2.6.40 which is bundled/shaded inside flyway drivers. As a pre-built binary artifact, the embedded dependencies cannot be updated independently. This requires a new upstream release of databricks-jdbc driver with updated bundled dependencies.
+      - timestamp: 2025-09-30T15:47:22Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability exists in databricks-jdbc-2.7.3 which is bundled/shaded inside flyway drivers. As a pre-built binary artifact, the embedded dependencies cannot be updated independently. This requires a new upstream release of databricks-jdbc driver with updated bundled dependencies.
 
   - id: CGA-p3gx-2p4q-w594
     aliases:
@@ -250,6 +254,10 @@ advisories:
         type: pending-upstream-fix
         data:
           note: This vulnerability exists in databricks-jdbc-2.6.40 which is bundled/shaded inside flyway drivers. As a pre-built binary artifact, the embedded dependencies cannot be updated independently. This requires a new upstream release of databricks-jdbc driver with updated bundled dependencies.
+      - timestamp: 2025-09-30T15:48:36Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability exists in databricks-jdbc-2.7.3 which is bundled/shaded inside flyway drivers. As a pre-built binary artifact, the embedded dependencies cannot be updated independently. This requires a new upstream release of databricks-jdbc driver with updated bundled dependencies.
 
   - id: CGA-pvmc-36v5-xpxp
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisory for CVE-2025-53864 and CVE-2025-48924 after remediation PR: https://github.com/wolfi-dev/os/pull/67486.
