### PR TITLE
trino: add advisory for CVE-2025-48924

### DIFF
--- a/trino.advisories.yaml
+++ b/trino.advisories.yaml
@@ -529,17 +529,17 @@ advisories:
         data:
           type: scan/v1
           data:
-            subpackageName: trino-plugin-redis
+            subpackageName: trino-plugin-ranger
             componentID: dc8189c3253ff237
-            componentName: commons-lang3
-            componentVersion: 3.17.0
+            componentName: commons-lang
+            componentVersion: 2.6
             componentType: java-archive
-            componentLocation: /usr/lib/trino/lib/org.apache.commons_commons-lang3-3.17.0.jar
+            componentLocation: /usr/lib/trino/lib/commons-lang_commons-lang-2.6.jar
             scanner: grype
-      - timestamp: 2025-07-17T19:56:32Z
-        type: fixed
+      - timestamp: 2025-10-02T12:42:17Z
+        type: pending-upstream-fix
         data:
-          fixed-version: 476-r2
+          note: 'This affects the trino-plugin-ranger package. As per the advisory commons-lang has no patched version and as per the description, upstream package maintainers of commons-lang recommend to upgrade to commons-lang3 version 3.18.0 or greater. The trino project has to upgrade their dependency in order to fixe this CVE. More information on the advisory: https://github.com/advisories/GHSA-j288-q9x7-2f5v'
 
   - id: CGA-828p-4xp8-m457
     aliases:


### PR DESCRIPTION
Add advisory for CVE-2025-48924.

In similar fashion to https://github.com/wolfi-dev/advisories/pull/20983

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
