### PR TITLE
airflow-3: add false-positive advisory for GHSA-6wgj-66m2-xxp2

### DIFF
--- a/airflow-3.advisories.yaml
+++ b/airflow-3.advisories.yaml
@@ -395,6 +395,17 @@ advisories:
         data:
           fixed-version: 3.0.1-r1
 
+  - id: CGA-wrxm-3576-f6w3
+    aliases:
+      - CVE-2023-48022
+      - GHSA-6wgj-66m2-xxp2
+    events:
+      - timestamp: 2025-10-03T04:49:27Z
+        type: false-positive-determination
+        data:
+          type: vulnerability-record-analysis-contested
+          note: The vendor's position is that this report is irrelevant because Ray, as stated in its documentation, is not intended for use outside of a strictly controlled network environment.
+
   - id: CGA-xqf6-7pmq-h43m
     aliases:
       - CVE-2025-50213


### PR DESCRIPTION
Add false-positive determination advisory for GHSA-6wgj-66m2-xxp2 (Ray vulnerability). The vendor's position is that this report is irrelevant because Ray, as stated in its documentation, is not intended for use outside of a strictly controlled network environment.