### PR TITLE
py3-pip: add fixed advisory for py3.13-pip-base subpackge

### DIFF
--- a/py3-pip.advisories.yaml
+++ b/py3-pip.advisories.yaml
@@ -85,6 +85,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/pip-25.2.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-03T04:56:37Z
+        type: fixed
+        data:
+          fixed-version: 25.2-r1
 
   - id: CGA-p6wh-jxvc-2c6c
     aliases:


### PR DESCRIPTION
Signed-off-by: David Negreira <david.negreira@chainguard.dev>
