### PR TITLE
feat(ghostscript): update advisories for CVE-2025-59798, CVE-2025-59799, CVE-2025-59800

### DIFF
--- a/ghostscript.advisories.yaml
+++ b/ghostscript.advisories.yaml
@@ -61,6 +61,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-03T10:03:24Z
+        type: pending-upstream-fix
+        data:
+          note: Integer overflow leading to heap-based buffer overflow in ocr_begin_page (devices/gdevpdfocr.c). This vulnerability affects Ghostscript through version 10.05.1. No patched release version has been identified. Awaiting upstream to publish an official fixed release. Once available, the package will be updated to remediate this CVE.
 
   - id: CGA-fcj4-4m67-f7hj
     aliases:
@@ -127,6 +131,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-03T10:02:47Z
+        type: pending-upstream-fix
+        data:
+          note: Stack-based buffer overflow in pdf_write_cmap (devices/vector/gdevpdtw.c). This vulnerability affects Ghostscript through version 10.05.1. No patched release version has been identified. Awaiting upstream to publish an official fixed release. Once available, the package will be updated to remediate this CVE.
 
   - id: CGA-j32c-xq5m-2jgf
     aliases:
@@ -167,6 +175,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-03T10:03:09Z
+        type: pending-upstream-fix
+        data:
+          note: Stack-based buffer overflow in pdfmark_coerce_dest (devices/vector/gdevpdfm.c) via a large size value. This vulnerability affects Ghostscript through version 10.05.1. No patched release version has been identified. Awaiting upstream to publish an official fixed release. Once available, the package will be updated to remediate this CVE.
 
   - id: CGA-rw95-w8gq-472x
     aliases:


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Update advisories for CVE-2025-59798, CVE-2025-59799, and CVE-2025-59800 to pending-upstream-fix status. These vulnerabilities affect Ghostscript through version 10.05.1 but no patched release version has been identified yet.