### PR TITLE
pip advisories: update advisory for CVE-2025-8869

### DIFF
--- a/dask-gateway.advisories.yaml
+++ b/dask-gateway.advisories.yaml
@@ -150,6 +150,10 @@ advisories:
             componentType: python
             componentLocation: /usr/share/dask-gateway/.venv/lib/python3.13/site-packages/pip-25.2.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-03T07:47:27Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream has released fixes that have landed into their main branch. We are now pending for upstream to cut a release with 25.3 which will have the fixes for this vulnerability.
 
   - id: CGA-7c9w-c64m-rwq2
     aliases:

--- a/datadog-agent.advisories.yaml
+++ b/datadog-agent.advisories.yaml
@@ -1325,6 +1325,10 @@ advisories:
             componentType: python
             componentLocation: /opt/datadog-agent/embedded/lib/python3.12/site-packages/pip-25.2.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-03T07:47:27Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream has released fixes that have landed into their main branch. We are now pending for upstream to cut a release with 25.3 which will have the fixes for this vulnerability.
 
   - id: CGA-x8r9-xppj-cww2
     aliases:

--- a/kubeflow-katib.advisories.yaml
+++ b/kubeflow-katib.advisories.yaml
@@ -85,6 +85,10 @@ advisories:
             componentType: python
             componentLocation: /opt/katib/cmd/earlystopping/medianstop/v1beta1/lib/python3.11/site-packages/pip-25.2.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-03T07:47:27Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream has released fixes that have landed into their main branch. We are now pending for upstream to cut a release with 25.3 which will have the fixes for this vulnerability.
 
   - id: CGA-587g-vmpg-rmrv
     aliases:

--- a/py3-pip.advisories.yaml
+++ b/py3-pip.advisories.yaml
@@ -85,6 +85,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/pip-25.2.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-03T07:47:27Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream has released fixes that have landed into their main branch. We are now pending for upstream to cut a release with 25.3 which will have the fixes for this vulnerability.
 
   - id: CGA-p6wh-jxvc-2c6c
     aliases:

--- a/pypy-3.10.advisories.yaml
+++ b/pypy-3.10.advisories.yaml
@@ -108,6 +108,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/pypy3.10/site-packages/pip-25.2.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-03T07:47:27Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream has released fixes that have landed into their main branch. We are now pending for upstream to cut a release with 25.3 which will have the fixes for this vulnerability.
 
   - id: CGA-rq87-9m93-fwwx
     aliases:

--- a/pypy-3.11.advisories.yaml
+++ b/pypy-3.11.advisories.yaml
@@ -37,6 +37,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/pypy3.11/site-packages/pip-25.2.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-03T07:47:27Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream has released fixes that have landed into their main branch. We are now pending for upstream to cut a release with 25.3 which will have the fixes for this vulnerability.
 
   - id: CGA-c9jr-4p2c-44mh
     aliases:


### PR DESCRIPTION
Update advisory of CVE-2025-8869 for the packages:
dask-gateway
datadog-agent
kubeflow-katib
py3-pip
pypy-3.10
pypy-3.11

Upstream has released fixes that have landed into their main branch. We
are now pending for upstream to cut a release with 25.3 which will have
the fixes for this vulnerability.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
