### PR TITLE
gnupg: add pending-upstream-fix advisory for CVE-2025-30258

### DIFF
--- a/gnupg.advisories.yaml
+++ b/gnupg.advisories.yaml
@@ -72,3 +72,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-03T16:16:54Z
+        type: pending-upstream-fix
+        data:
+          note: The fix version of gnupg is on 2.5.x, a developmental branch, upstream maintainers must backport required changes to the 2.4.x branch to remediate.


### PR DESCRIPTION
This advisory documents that the fix version for CVE-2025-30258 is on the gnupg 2.5.x developmental branch. Upstream maintainers need to backport the required changes to the stable 2.4.x branch to remediate this vulnerability in our production packages.