### PR TITLE
gnupg/GHSA-5rjg-pf4q-hgcr fix event

### DIFF
--- a/gnupg.advisories.yaml
+++ b/gnupg.advisories.yaml
@@ -72,3 +72,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-03T17:30:04Z
+        type: fixed
+        data:
+          fixed-version: 2.4.8-r1


### PR DESCRIPTION
The fix for this CVE, which is referenced in the NVD page for CVE-2025-30258 _”Fix a verification DoS due to a malicious subkey in the keyring.  [[T7527]](https://dev.gnupg.org/T7527)_“ is included in the 2.4.8 release, [seen in this announcement](https://lists.gnupg.org/pipermail/gnupg-announce/2025q3/000496.html#:~:text=Noteworthy%20changes%20in%20version%202.4.8%20(2025%2D05%2D14)%0A%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%0A%0A%20%20*%20gpg%3A%20Fix%20a%20verification%20DoS%20due%20to%20a%20malicious%20subkey%20in%20the%0A%20%20%20%20keyring.%20%20%5BT7527%5D) under noteworthy changes for 2.4.8, in this 2.4.8 [release page here](https://dev.gnupg.org/T7428) and for reference the [commit on the 2.4.8 branch](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commitdiff;h=da0164efc7f32013bc24d97b9afa9f8d67c318bb)