### PR TITLE
airflow-3: add pending-upstream-fix advisory for GHSA-765j-9r45-w2q2

### DIFF
--- a/airflow-3.advisories.yaml
+++ b/airflow-3.advisories.yaml
@@ -65,6 +65,10 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/lib/python3.12/site-packages/Flask_AppBuilder-4.6.3.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-03T22:53:00Z
+        type: pending-upstream-fix
+        data:
+          note: flask-appbuilder is a transitive dependency brought in via apache-airflow-providers-fab's most recent release, v2.4.4. To remediate, v3.0.0 must release and upstream airflow maintainers need to implement compatibility with the new major version where applicable.
 
   - id: CGA-5x99-mqvf-h8cx
     aliases:


### PR DESCRIPTION
## Summary

Adds `pending-upstream-fix` advisory for GHSA-765j-9r45-w2q2 in airflow-3.

## Issue

flask-appbuilder is a transitive dependency brought in via apache-airflow-providers-fab. The current release (v2.4.4) uses an affected version of flask-appbuilder, and remediation requires the upcoming v3.0.0 release with compatibility changes.

## Evidence

### Current Affected Version (v2.4.4)

apache-airflow-providers-fab v2.4.4 requires flask-appbuilder with the vulnerable version:

```
flask-appbuilder>=4.5.0,<5.0.0
```

**Source**: [PyPI - apache-airflow-providers-fab 2.4.4](https://pypi.org/project/apache-airflow-providers-fab/2.4.4/#:~:text=flask%2Dappbuilder,%3D%3D4.6.3%3B)

### Upcoming Fixed Version (v3.0.0-rc1)

apache-airflow-providers-fab v3.0.0-rc1 has updated the dependency to the fixed version:

```
flask-appbuilder>=5.0.0,<6.0.0
```

**Source**: [PyPI - apache-airflow-providers-fab 3.0.0rc1](https://pypi.org/project/apache-airflow-providers-fab/3.0.0rc1/#:~:text=flask%2Dappbuilder,%3D%3D5.0.0%3B)

### Upstream Readiness

Upstream airflow maintainers have prepared for the v3.0.0 update with compatibility changes:

**Preparation PR**: [apache/airflow#56241](https://github.com/apache/airflow/pull/56241/files)

This PR demonstrates that upstream is actively working toward v3.0.0 release readiness with the necessary compatibility implementations for the new major version of flask-appbuilder.

## Resolution

Wait for apache-airflow-providers-fab v3.0.0 official release, then update airflow-3 to use the new version with flask-appbuilder 5.0.0+ which contains the security fix.