### PR TITLE
doc(firefox): false-positive-determination event for firefox to remediate CVE-2025-10859

### DIFF
--- a/firefox.advisories.yaml
+++ b/firefox.advisories.yaml
@@ -966,6 +966,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-06T08:27:03Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability specifically affects Firefox for iOS and does not apply to the Linux desktop version packaged in Wolfi. The affected code paths are iOS-specific and not present in the desktop Firefox build.
 
   - id: CGA-85p4-82f5-pggg
     aliases:


### PR DESCRIPTION
This vulnerability specifically affects Firefox for iOS and does not apply to the Linux desktop version packaged in Wolfi. The affected code paths are iOS-specific and not present in the desktop Firefox build.