### PR TITLE
openssl: update advisories

### DIFF
--- a/openssl.advisories.yaml
+++ b/openssl.advisories.yaml
@@ -28,6 +28,15 @@ advisories:
         data:
           fixed-version: 3.3.1-r3
 
+  - id: CGA-3w65-8r9h-75gq
+    aliases:
+      - CVE-2025-9230
+    events:
+      - timestamp: 2025-10-06T09:09:25Z
+        type: fixed
+        data:
+          fixed-version: 3.5.4-r0
+
   - id: CGA-4q7f-4r4p-28j4
     aliases:
       - CVE-2024-0727
@@ -130,6 +139,16 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.4.0-r6
+
+  - id: CGA-84v2-9g44-mmxh
+    aliases:
+      - CVE-2025-9232
+      - GHSA-76r2-c3cg-f5r9
+    events:
+      - timestamp: 2025-10-06T09:09:25Z
+        type: fixed
+        data:
+          fixed-version: 3.5.4-r0
 
   - id: CGA-97q5-67vw-m89f
     aliases:
@@ -370,6 +389,16 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.0.7-r0
+
+  - id: CGA-vphj-52vf-9m66
+    aliases:
+      - CVE-2025-9231
+      - GHSA-9mrx-mqmg-gwj9
+    events:
+      - timestamp: 2025-10-06T09:09:25Z
+        type: fixed
+        data:
+          fixed-version: 3.5.4-r0
 
   - id: CGA-whjp-f75j-mjxh
     aliases:


### PR DESCRIPTION
Update advisories for CVE-2025-9230 CVE-2025-9231 CVE-2025-9232

As per upstream, these vulnerabilites are fixed in version 3.5.4 of openssl.
More info: https://openssl-library.org/news/secadv/20250930.txt

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
