### PR TITLE
doc(ffmpeg-7): Add pending-upstream-fix event for CVE-2025-59729, CVE-2025-59731, CVE-2025-59732, CVE-2025-59733 and CVE-2025-59734

### DIFF
--- a/ffmpeg-7.advisories.yaml
+++ b/ffmpeg-7.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-09T07:01:38Z
+        type: pending-upstream-fix
+        data:
+          note: A patch for this CVE is not yet available for ffmpeg 7.1.2. For immediate remediation, the recommended action is to upgrade to version 8.0 or later.
 
   - id: CGA-4pvm-894f-2v43
     aliases:
@@ -39,6 +43,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-09T07:01:38Z
+        type: pending-upstream-fix
+        data:
+          note: A patch for this CVE is not yet available for ffmpeg 7.1.2. For immediate remediation, the recommended action is to upgrade to version 8.0 or later.
 
   - id: CGA-6p44-9m9h-858r
     aliases:
@@ -57,6 +65,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-09T07:01:38Z
+        type: pending-upstream-fix
+        data:
+          note: A patch for this CVE is not yet available for ffmpeg 7.1.2. For immediate remediation, the recommended action is to upgrade to version 8.0 or later.
 
   - id: CGA-fwmh-x9q2-2xqv
     aliases:
@@ -75,6 +87,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-09T07:01:38Z
+        type: pending-upstream-fix
+        data:
+          note: A patch for this CVE is not yet available for ffmpeg 7.1.2. For immediate remediation, the recommended action is to upgrade to version 8.0 or later.
 
   - id: CGA-pfj3-hw8x-4mv8
     aliases:
@@ -136,3 +152,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-09T07:01:38Z
+        type: pending-upstream-fix
+        data:
+          note: A patch for this CVE is not yet available for ffmpeg 7.1.2. For immediate remediation, the recommended action is to upgrade to version 8.0 or later.


### PR DESCRIPTION
CVE advisories for CVE-2025-59729, CVE-2025-59731, CVE-2025-59732, CVE-2025-59733 and CVE-2025-59734 recommend upgrading to version 8.0 or beyond. The advisory note in this PR makes the same recommendation for immediate remediation.