### PR TITLE
nextcloud-server-32: update advisories

### DIFF
--- a/nextcloud-server-32.advisories.yaml
+++ b/nextcloud-server-32.advisories.yaml
@@ -20,6 +20,11 @@ advisories:
             componentType: npm
             componentLocation: /usr/src/nextcloud/apps/firstrunwizard/package.json
             scanner: grype
+      - timestamp: 2025-10-10T07:32:50Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: False positive identified due to naming/version mismatches between Nextcloud-specific packages and unrelated NPM packages. Nextcloud maintains actively updated versions, but inconsistent version tagging may be causing confusion. Needs version/tagging corrections from Nextcloud.
 
   - id: CGA-5452-5246-7m5q
     aliases:
@@ -37,6 +42,11 @@ advisories:
             componentType: npm
             componentLocation: /usr/src/nextcloud/apps/files_pdfviewer/package.json
             scanner: grype
+      - timestamp: 2025-10-10T07:32:50Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: False positive identified due to naming/version mismatches between Nextcloud-specific packages and unrelated NPM packages. Nextcloud maintains actively updated versions, but inconsistent version tagging may be causing confusion. Needs version/tagging corrections from Nextcloud.
 
   - id: CGA-63hj-9c6j-vpj5
     aliases:
@@ -54,3 +64,8 @@ advisories:
             componentType: npm
             componentLocation: /usr/src/nextcloud/apps/twofactor_totp/package.json
             scanner: grype
+      - timestamp: 2025-10-10T07:32:50Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: False positive identified due to naming/version mismatches between Nextcloud-specific packages and unrelated NPM packages. Nextcloud maintains actively updated versions, but inconsistent version tagging may be causing confusion. Needs version/tagging corrections from Nextcloud.


### PR DESCRIPTION
Update advisories for: GHSA-46fq-v4pg-gr3j, GHSA-qqc2-7f54-r7wp and
GHSA-x92j-g74p-p2hq

 False positive identified due to naming/version mismatches between
 Nextcloud-specific packages and unrelated NPM packages. Nextcloud
 maintains actively updated versions, but inconsistent version tagging
 may be causing confusion. Needs version/tagging corrections from
 Nextcloud.

 These are the nextcloud projects detected erroneously:

* twofactor_totp: https://apps.nextcloud.com/apps/twofactor_totp
* fistrunwizard: https://github.com/nextcloud/firstrunwizard
* files_pdfviewer: https://github.com/nextcloud/files_pdfviewer
