### PR TITLE
python-3.10/python-3.11/python-3.12: update advisories

### DIFF
--- a/python-3.10.advisories.yaml
+++ b/python-3.10.advisories.yaml
@@ -363,6 +363,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-10T11:31:56Z
+        type: fixed
+        data:
+          fixed-version: 3.10.19-r0
 
   - id: CGA-qw6p-5649-8qqv
     aliases:

--- a/python-3.11.advisories.yaml
+++ b/python-3.11.advisories.yaml
@@ -66,6 +66,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-10T11:43:18Z
+        type: fixed
+        data:
+          fixed-version: 3.11.14-r0
 
   - id: CGA-8v84-p6q7-fc4w
     aliases:

--- a/python-3.12.advisories.yaml
+++ b/python-3.12.advisories.yaml
@@ -76,6 +76,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-10T11:32:25Z
+        type: fixed
+        data:
+          fixed-version: 3.12.12-r0
 
   - id: CGA-6cxp-qqq9-5mq3
     aliases:


### PR DESCRIPTION
Update advisories for CVE-2025-8291
We have updated our packages to the fixed versions.

The fixes have been backported upstream to the following point versions:

* 3.10.19: https://github.com/python/cpython/commit/bca11ae7d575d87ed93f5dd6a313be6246e3e388
* 3.11.14: https://github.com/python/cpython/commit/1d29afb0d6218aa8fb5e1e4a6133a4778d89bb46
* 3.12.12: https://github.com/python/cpython/commit/8392b2f0d35678407d9ce7d95655a5b77de161b4

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
