### PR TITLE
python3.13/python3.14: update advisory

### DIFF
--- a/python-3.13.advisories.yaml
+++ b/python-3.13.advisories.yaml
@@ -252,6 +252,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-10T14:10:44Z
+        type: fixed
+        data:
+          fixed-version: 3.13.8-r1
 
   - id: CGA-q98g-97v3-rvq3
     aliases:

--- a/python-3.14.advisories.yaml
+++ b/python-3.14.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-10T14:11:06Z
+        type: fixed
+        data:
+          fixed-version: 3.14.0-r2


### PR DESCRIPTION
Update advisory for CVE-2025-8291
There is currently no upstream release for the 3.13 and 3.14 with the
fix for CVE-2025-8291.
Upstream has backported the fix into 3.13 and 3.14 branches, and we are
cherry-picking the remediations while we wait for upstream to cut a point
release with the fixes.

We have done the cherry-picking here:
https://github.com/wolfi-dev/os/pull/68553/files

With the upstream picks from:

Python-3.13:
https://github.com/python/cpython/commit/333d4a6f4967d3ace91492a39ededbcf3faa76a6

Python-3.14 from:
https://github.com/python/cpython/commit/d11e69d6203080e3ec450446bfed0516727b85c3

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
