### PR TITLE
sqlpad: remove advisory for rejected CVE

### DIFF
--- a/sqlpad.advisories.yaml
+++ b/sqlpad.advisories.yaml
@@ -92,28 +92,6 @@ advisories:
         data:
           fixed-version: 7.4.1-r2
 
-  - id: CGA-4mhg-855j-v4c7
-    aliases:
-      - CVE-2025-54369
-      - GHSA-m837-g268-mmv7
-    events:
-      - timestamp: 2025-07-27T09:13:21Z
-        type: detection
-        data:
-          type: scan/v1
-          data:
-            subpackageName: sqlpad
-            componentID: e9d73977f927d5ae
-            componentName: '@node-saml/node-saml'
-            componentVersion: 4.0.5
-            componentType: npm
-            componentLocation: /usr/bin/sqlpad-server/node_modules/@node-saml/node-saml/package.json
-            scanner: grype
-      - timestamp: 2025-07-28T13:30:14Z
-        type: fixed
-        data:
-          fixed-version: 7.5.6-r1
-
   - id: CGA-4r84-f582-f5vh
     aliases:
       - CVE-2024-45590


### PR DESCRIPTION
See https://www.cve.org/CVERecord?id=CVE-2025-54369 for more information.

Expected validation failure, will need an override:

```
❌ advisory data is not valid.

invalid change(s) in diff:
    sqlpad:
        CGA-4mhg-855j-v4c7:
            advisory was removed
```