### PR TITLE
advisory(langfuse): GHSA-mm7p-fcc7-pg87 pending upstream fix

### DIFF
--- a/langfuse.advisories.yaml
+++ b/langfuse.advisories.yaml
@@ -46,6 +46,11 @@ advisories:
             componentType: npm
             componentLocation: /app/node_modules/.pnpm/nodemailer@6.9.15/node_modules/nodemailer/package.json
             scanner: grype
+      - timestamp: 2025-10-11T01:49:04Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            nodemailer cannot be directly upgraded to ^7.0.7 without causing significant test failures for upstream langfuse
 
   - id: CGA-9v4g-rf5q-9vx5
     aliases:


### PR DESCRIPTION
Upgrading nodemailer to ^7.0.7 causes test failures on upstream [1] CI.  Thus the CVE cannot be remediated until upstream
has validated the dependency.

[1] https://github.com/langfuse/langfuse/pull/9581

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/30977
