### PR TITLE
doc(ipfs-cluster): Add pending-upstream-fix event for GHSA-47m2-4cr7-mhcw

### DIFF
--- a/ipfs-cluster.advisories.yaml
+++ b/ipfs-cluster.advisories.yaml
@@ -65,3 +65,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/ipfs-cluster-ctl
             scanner: grype
+      - timestamp: 2025-10-14T06:30:59Z
+        type: pending-upstream-fix
+        data:
+          note: github.com/quic-go/quic-go introduced breaking changes between 0.52.0 to 0.54.1. As a result, upgrading to 0.54.1 causes build failures. Upstream will have to migrate quic-go to 0.54.1 or later along with compatible versions of other dependencies


### PR DESCRIPTION
github.com/quic-go/quic-go introduced breaking changes between 0.52.0 to 0.54.1. As a result, upgrading to 0.54.1 causes build failures. Upstream will have to migrate quic-go to 0.54.1 or later along with compatible versions of other dependencies.

Upgrading quic-go results in compilation failures in code from other dependencies: webtransport-go, libp2p, cockroachdb/swiss

Upgrading github.com/quic-go/webtransport-go to v0.9.0 and github.com/libp2p/go-libp2p to v0.44.0 causes the following compilation error:
```
025/10/14 06:23:44 WARN ./clusterhost.go:57:11: undefined: identify.ActivationThresh
```

