### PR TITLE
sonarqube/GHSA-56r7-h6mw-rcfv pending-upstream-fix

### DIFF
--- a/sonarqube.advisories.yaml
+++ b/sonarqube.advisories.yaml
@@ -43,6 +43,11 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/sonarqube/elasticsearch/lib/elasticsearch-8.16.6.jar
             scanner: grype
+      - timestamp: 2025-10-15T17:17:44Z
+        type: pending-upstream-fix
+        data:
+          note: |
+            The fix versions of the ElasticSearch dependency within SonarQube introduce breaking JDK dependency requirements. Upstream maintainers must implement compatibility change requirements seen here: https://sonarsource.atlassian.net/browse/SONAR-24276
 
   - id: CGA-4c7h-39vq-xmgx
     aliases:


### PR DESCRIPTION
adv(sonarqube): GHSA-56r7-h6mw-rcfv requires upstream to bump elasticsearch version
    
Elasticsearch version is set by upstream [1] and needs to be updated to fix this CVE
    
[1] https://github.com/SonarSource/sonarqube/blob/master/gradle.properties#L15

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31060