### PR TITLE
adv(sqlpad): GHSA-9965-vmph-33xx validator lacks upstream fix

### DIFF
--- a/sqlpad.advisories.yaml
+++ b/sqlpad.advisories.yaml
@@ -131,6 +131,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/bin/sqlpad-server/node_modules/validator/package.json
             scanner: grype
+      - timestamp: 2025-10-16T01:09:27Z
+        type: pending-upstream-fix
+        data:
+          note: 'Upstream fix for validator is in progress: https://github.com/validatorjs/validator.js/pull/2608'
 
   - id: CGA-5grf-qqgg-78vf
     aliases:


### PR DESCRIPTION
There is no fixed version to the CVE, although a PR is in progress for validator [1]

[1] https://github.com/advisories/GHSA-9965-vmph-33xx

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31325
