### PR TITLE
doc(ruby3.2-elasticsearch): Add pending-upstream-fix event for GHSA-56r7-h6mw-rcfv

### DIFF
--- a/ruby3.2-elasticsearch.advisories.yaml
+++ b/ruby3.2-elasticsearch.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-16T05:10:28Z
+        type: pending-upstream-fix
+        data:
+          note: Remediating this vulnerability requires upgrading to elasticsearch 9.1.5. Upstream has not created a release with elasticsearch 9.1.5 yet.
 
   - id: CGA-6wjx-rfwc-3h26
     aliases:


### PR DESCRIPTION
Remediating this vulnerability requires upgrading to elasticsearch 9.1.5. Upstream has not created a release with elasticsearch 9.1.5 yet.
Attempts to bump to 9.1.5 fail as [elasticsearch-api gem](https://rubygems.org/gems/elasticsearch-api) does not have a 9.1.5 release yet.
See closed PR with failed build: https://github.com/wolfi-dev/os/pull/69118