### PR TITLE
Copy over advisories from ceph

### DIFF
--- a/ceph-19.advisories.yaml
+++ b/ceph-19.advisories.yaml
@@ -44,6 +44,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-16T08:36:48Z
+        type: fixed
+        data:
+          fixed-version: 19.2.3-r7
 
   - id: CGA-jcpm-r3j6-w2q8
     aliases:


### PR DESCRIPTION
See related PR for `ceph`: https://github.com/wolfi-dev/advisories/pull/21164

* CVE-2017-12155: false positive, affected the (now EOL) [tripleo-heat-template](https://github.com/openstack-archive/tripleo-heat-templates)
* CVE-2017-7519 fixed [here](https://github.com/ceph/ceph/pull/15674), first introduced under tag v12.1.1
* CVE-2019-10222: tracked in this [upstream ticket](https://tracker.ceph.com/issues/40018), fix released in v15.2.0
* CVE-2020-1700: fixed [here](https://github.com/ceph/ceph/commit/55ad9b6937f09bbf81dea27b017ffa4e63d4f044) and released in v15.1.1