### PR TITLE
doc(freerdp): Add advisory for CVE-2025-4478

### DIFF
--- a/freerdp.advisories.yaml
+++ b/freerdp.advisories.yaml
@@ -95,6 +95,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-16T08:51:05Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: According to upstream, vulnerable code was not included in 2.x. See https://github.com/FreeRDP/FreeRDP/pull/11573#issuecomment-2904160524
 
   - id: CGA-rxw9-g9v7-83fc
     aliases:


### PR DESCRIPTION
Upstream remediated this CVE in PR https://github.com/FreeRDP/FreeRDP/pull/11573.
This was fixed in 3.16. 
According to comment https://github.com/FreeRDP/FreeRDP/pull/11573#issuecomment-2904160524, 2.x is not vulnerable.