### PR TITLE
py3-pip: update advisory

### DIFF
--- a/py3-pip.advisories.yaml
+++ b/py3-pip.advisories.yaml
@@ -105,6 +105,10 @@ advisories:
             componentType: python
             componentLocation: /usr/lib/python3.10/site-packages/pip-25.2.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-16T12:15:45Z
+        type: pending-upstream-fix
+        data:
+          note: Upstream has released fixes that have landed into their main branch. We are now pending for upstream to cut a release with 25.3 which will have the fixes for this vulnerability.
 
   - id: CGA-p6wh-jxvc-2c6c
     aliases:


### PR DESCRIPTION
Update advisory for CVE-2025-8869
Unfortunately we do not have a way to express in scanners and in our
systems that a python package has cherry-picks from upstream that fixes
vulnerabilities in python. So we will have for upstream to release pip
25.3 so that we have a way for our system and scanners to ensure that a
patched version is present.

This is the PR where we have patched py3-pip with the upstream patches:
https://github.com/wolfi-dev/os/pull/67721
