### PR TITLE
doc(clamav-1.5): Add fixed advisory for CVE-2016-1405

### DIFF
--- a/clamav-1.5.advisories.yaml
+++ b/clamav-1.5.advisories.yaml
@@ -21,3 +21,7 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-17T06:38:04Z
+        type: fixed
+        data:
+          fixed-version: 1.5.1-r0


### PR DESCRIPTION
CVE-2016-1405 was fixed in ClamAV 0.99. Current package version 1.5.0 contains the fix and is not vulnerable.
See: https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160531-wsa-esa