### PR TITLE
mattermost-11.0/CVE-2022-4045/CVE-2022-4019: false-positive advisories

### DIFF
--- a/mattermost-11.0.advisories.yaml
+++ b/mattermost-11.0.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-21T20:43:48Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This vulnerability was remediated in mattermost v7.x. Specifically, in versions 7.1.4, 7.2.1, 7.3.1, and 7.4.0. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4019'
 
   - id: CGA-rqjf-872q-6q9v
     aliases:
@@ -39,3 +44,8 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-21T20:44:14Z
+        type: false-positive-determination
+        data:
+          type: component-vulnerability-mismatch
+          note: 'This vulnerability was remediated in mattermost v7.4.0 and later. For more information, please refer to: https://www.clouddefense.ai/cve/2022/CVE-2022-4045'


### PR DESCRIPTION
## Summary

Adds false-positive advisories for CVE-2022-4019 and CVE-2022-4045 in mattermost-11.0.

These vulnerabilities existed in previous mattermost versions and are the same case here in 11.0 - they were remediated in mattermost v7.x and do not affect later versions.

## Existing Patterns

These advisories follow the same pattern established in earlier mattermost versions:
- **mattermost-10.9**: https://github.com/chainguard-dev/enterprise-advisories/blob/94819b1cd53e77d2099f7ce7ffaf570fc364febc/mattermost-10.9.advisories.yaml#L57-L76

## CVEs Addressed

**CVE-2022-4019**
- Remediated in v7.1.4, v7.2.1, v7.3.1, and v7.4.0
- Reference: https://www.clouddefense.ai/cve/2022/CVE-2022-4019

**CVE-2022-4045**
- Remediated in v7.4.0 and later
- Reference: https://www.clouddefense.ai/cve/2022/CVE-2022-4045