### PR TITLE
doc(gitlab-runner-18.5): GHSA-4vq8-7jfc-9cvp

### DIFF
--- a/gitlab-runner-18.5.advisories.yaml
+++ b/gitlab-runner-18.5.advisories.yaml
@@ -60,3 +60,7 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/gitlab-runner-helper
             scanner: grype
+      - timestamp: 2025-10-22T19:59:30Z
+        type: pending-upstream-fix
+        data:
+          note: gitlab-runner depends on https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/tags and https://gitlab.com/gitlab-org/ci-cd/runner-tools/base-images/-/tags for Docker images and their versions need to be tightly coupled.  Currently, base-images does not have a newer version to pick up Docker=>28.0.0.


### PR DESCRIPTION
gitlab-runner depends on https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/tags and https://gitlab.com/gitlab-org/ci-cd/runner-tools/base-images/-/tags for Docker images and their versions need to be tightly coupled.  Currently, base-images does not have a newer version to pick up Docker=>28.0.0.

Relates: https://github.com/wolfi-dev/os/pull/69540
