### PR TITLE
doc(minio): Add fixed event for CVE-2025-62506

### DIFF
--- a/minio.advisories.yaml
+++ b/minio.advisories.yaml
@@ -590,6 +590,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-23T04:48:24Z
+        type: fixed
+        data:
+          fixed-version: 0.20251015.172955-r0
 
   - id: CGA-w2v2-x5jw-cm43
     aliases:


### PR DESCRIPTION
Current minio commit used in the package is [9e49d5e7a648f00e26f2246f4dc28e6b07f8c84a](https://github.com/wolfi-dev/os/blob/da1e6cd1302b050f6309bf35d0afd1dc77ec7e13/minio.yaml#L34) which is ahead of the commit c1a49490c78e that has the CVE patch according to the CVE-2025-62506 advisory.
<img width="1626" height="534" alt="Screenshot 2025-10-23 at 10 21 45" src="https://github.com/user-attachments/assets/2f0b7c9b-0069-4c8e-8a3e-ec7a73b14d2d" />


