### PR TITLE
docs: Add advisory for CVE-2025-45993

### DIFF
--- a/giflib.advisories.yaml
+++ b/giflib.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-23T10:52:06Z
+        type: pending-upstream-fix
+        data:
+          note: As detailed in the original PoC (https://gitlab.com/mthandazo/project-pov), CVE-2025-45993 only affects the gif2rgb utility. This utility is not included in our giflib package, but is instead provided by the giflib-utils subpackage. The upstream project have not yet released a fix (see https://sourceforge.net/p/giflib/bugs/188/)
 
   - id: CGA-grwf-fxvc-rrc2
     aliases:


### PR DESCRIPTION
CVE-2025-45993 [is a heap overflow](https://gitlab.com/mthandazo/project-pov) in the `gif2rgb` utility provided by upstream project `giflib`.

Upstream have an [outstanding ticket](https://sourceforge.net/p/giflib/bugs/188/) to address this issue.

Although some other distros include this utility in their `giflib` packages, we do not and instead provide it via the `giflib-utils` subpackage.

This means that images with `giflib` in the SBOM **are not** vulnerable to this CVE. 

However, as we cannot currently advisory sub packages separately, to avoid falsely reporting false-positive for `giflib-utils` this PR adds a `pending-upstream-fix` with a note clarifying that only `giflib-utils` is affected.