### PR TITLE
airflow-3: update advisories

### DIFF
--- a/airflow-3.advisories.yaml
+++ b/airflow-3.advisories.yaml
@@ -135,6 +135,12 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.0.1-r1
+      - timestamp: 2025-10-23T11:56:46Z
+        type: pending-upstream-fix
+        data:
+          note: |-
+            We are currently unable to bump the Werkzeug dependency as there are some hard constraints on the connnexion dependency for the FAB auth manager APIs.
+            More information can be found in a comment by upstream maintainers here: https://github.com/apache/airflow/pull/51681\#issuecomment-3411116656
 
   - id: CGA-gcv3-m4w5-hfr2
     aliases:
@@ -157,6 +163,12 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.0.1-r1
+      - timestamp: 2025-10-23T11:56:46Z
+        type: pending-upstream-fix
+        data:
+          note: |-
+            We are currently unable to bump the Werkzeug dependency as there are some hard constraints on the connnexion dependency for the FAB auth manager APIs.
+            More information can be found in a comment by upstream maintainers here: https://github.com/apache/airflow/pull/51681\#issuecomment-3411116656
 
   - id: CGA-gx9p-ww82-5jv2
     aliases:
@@ -288,6 +300,12 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.0.1-r1
+      - timestamp: 2025-10-23T11:56:46Z
+        type: pending-upstream-fix
+        data:
+          note: |-
+            We are currently unable to bump the Werkzeug dependency as there are some hard constraints on the connnexion dependency for the FAB auth manager APIs.
+            More information can be found in a comment by upstream maintainers here: https://github.com/apache/airflow/pull/51681\#issuecomment-3411116656
 
   - id: CGA-pcx4-jwph-2g77
     aliases:
@@ -377,6 +395,12 @@ advisories:
         type: fixed
         data:
           fixed-version: 3.0.1-r1
+      - timestamp: 2025-10-23T11:56:46Z
+        type: pending-upstream-fix
+        data:
+          note: |-
+            We are currently unable to bump the Werkzeug dependency as there are some hard constraints on the connnexion dependency for the FAB auth manager APIs.
+            More information can be found in a comment by upstream maintainers here: https://github.com/apache/airflow/pull/51681\#issuecomment-3411116656
 
   - id: CGA-rw79-7pm4-6wf7
     aliases:


### PR DESCRIPTION
Update advisories for GHSA-hrfv-mqp8-q5rw, GHSA-f9vj-2wh5-fj8j,
GHSA-2g68-c3qc-8985 and GHSA-q34m-jh98-gwm2.

We are currently unable to bump the Werkzeug dependency as there are
some hard constraints on the connnexion dependency for the FAB auth
manager APIs.

More information can be found in a comment by upstream maintainers here:
https://github.com/apache/airflow/pull/51681\#issuecomment-3411116656

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
