### PR TITLE
airflow-3: update advisories

### DIFF
--- a/airflow-3.advisories.yaml
+++ b/airflow-3.advisories.yaml
@@ -147,6 +147,12 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/lib/python3.12/site-packages/Werkzeug-2.2.3.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-23T12:06:16Z
+        type: pending-upstream-fix
+        data:
+          note: |-
+            We are currently unable to bump the Werkzeug dependency as there are some hard constraints on the connnexion dependency for the FAB auth manager APIs.
+            More information can be found in a comment by upstream maintainers here: https://github.com/apache/airflow/pull/51681\#issuecomment-3411116656
 
   - id: CGA-gcv3-m4w5-hfr2
     aliases:
@@ -181,6 +187,12 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/lib/python3.12/site-packages/Werkzeug-2.2.3.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-23T12:06:16Z
+        type: pending-upstream-fix
+        data:
+          note: |-
+            We are currently unable to bump the Werkzeug dependency as there are some hard constraints on the connnexion dependency for the FAB auth manager APIs.
+            More information can be found in a comment by upstream maintainers here: https://github.com/apache/airflow/pull/51681\#issuecomment-3411116656
 
   - id: CGA-gx9p-ww82-5jv2
     aliases:
@@ -324,6 +336,12 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/lib/python3.12/site-packages/Werkzeug-2.2.3.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-23T12:06:16Z
+        type: pending-upstream-fix
+        data:
+          note: |-
+            We are currently unable to bump the Werkzeug dependency as there are some hard constraints on the connnexion dependency for the FAB auth manager APIs.
+            More information can be found in a comment by upstream maintainers here: https://github.com/apache/airflow/pull/51681\#issuecomment-3411116656
 
   - id: CGA-pcx4-jwph-2g77
     aliases:
@@ -425,6 +443,12 @@ advisories:
             componentType: python
             componentLocation: /opt/airflow/lib/python3.12/site-packages/Werkzeug-2.2.3.dist-info/METADATA
             scanner: grype
+      - timestamp: 2025-10-23T12:06:16Z
+        type: pending-upstream-fix
+        data:
+          note: |-
+            We are currently unable to bump the Werkzeug dependency as there are some hard constraints on the connnexion dependency for the FAB auth manager APIs.
+            More information can be found in a comment by upstream maintainers here: https://github.com/apache/airflow/pull/51681\#issuecomment-3411116656
 
   - id: CGA-rw79-7pm4-6wf7
     aliases:


### PR DESCRIPTION
Update advisories for GHSA-hrfv-mqp8-q5rw, GHSA-f9vj-2wh5-fj8j,
GHSA-2g68-c3qc-8985 and GHSA-q34m-jh98-gwm2

We are currently unable to bump the Werkzeug dependency as there are
some hard constraints on the connnexion dependency for the FAB auth
manager APIs.

More information can be found in a comment by upstream maintainers here:
https://github.com/apache/airflow/pull/51681\#issuecomment-3411116656

We also had to re-work our airflow-3 package to ensure that we are
respecting the constraints so that we don't bump package versions to an
unsupported version.
More information here:
https://github.com/wolfi-dev/os/pull/69508

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
