### PR TITLE
doc(cassandra-5.0): GHSA-25qh-j22f-pwp8

### DIFF
--- a/cassandra-5.0.advisories.yaml
+++ b/cassandra-5.0.advisories.yaml
@@ -44,6 +44,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/cassandra/lib/logback-core-1.2.12.jar
             scanner: grype
+      - timestamp: 2025-10-23T13:52:28Z
+        type: pending-upstream-fix
+        data:
+          note: The version bump from logback 1.2.12 to 1.5.x requires code changes and has not landed yet (https://github.com/apache/cassandra/pull/4432).
 
   - id: CGA-3gw6-5crj-7ph4
     aliases:


### PR DESCRIPTION
The version bump from logback 1.2.12 to 1.5.x requires code changes and has not landed yet (https://github.com/apache/cassandra/pull/4432).

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31543, https://github.com/wolfi-dev/os/pull/69681
