### PR TITLE
adv(dependency-track): GHSA-25qh-j22f-pwp8

### DIFF
--- a/dependency-track.advisories.yaml
+++ b/dependency-track.advisories.yaml
@@ -296,6 +296,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/dependency-track/dependency-track-bundled.jar
             scanner: grype
+      - timestamp: 2025-10-24T19:36:01Z
+        type: pending-upstream-fix
+        data:
+          note: This is a transitive dependency brought in by us.springett:alpine-server, which has already been updated to the latest version. Therefore, upstream maintainers must release a fix to remediate this CVE.
 
   - id: CGA-w8q8-p4r5-xxg9
     aliases:


### PR DESCRIPTION
This is a transitive dependency brought in by us.springett:alpine-server, which has already been updated to the latest version.[1]

[1] https://mvnrepository.com/artifact/us.springett/alpine-server/3.3.0

Relates: https://github.com/chainguard-dev/CVE-Dashboard/issues/31553
