### PR TITLE
bind: update advisories

### DIFF
--- a/bind.advisories.yaml
+++ b/bind.advisories.yaml
@@ -448,6 +448,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-27T10:08:09Z
+        type: fixed
+        data:
+          fixed-version: 9.20.15-r0
 
   - id: CGA-j6qj-7qw6-r656
     aliases:
@@ -693,6 +697,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-27T10:08:09Z
+        type: fixed
+        data:
+          fixed-version: 9.20.15-r0
 
   - id: CGA-vwxr-9367-7cw3
     aliases:
@@ -711,6 +719,10 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-27T10:08:09Z
+        type: fixed
+        data:
+          fixed-version: 9.20.15-r0
 
   - id: CGA-w58r-x9jp-7rq5
     aliases:


### PR DESCRIPTION
Update advisories for CVE-2025-8677, CVE-2025-40780 and CVE-2025-40778

All these advisories are fixed with bind version 9.20.15 which is the
version that we currently build and ship.
More information for each advisory and the fixed versions can be found
in the knowledge base of ISC:

* CVE-2025-8677: https://kb.isc.org/docs/cve-2025-8677
* CVE-2025-40780: https://kb.isc.org/docs/cve-2025-40780
* CVE-2025-40778: https://kb.isc.org/docs/cve-2025-40778

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
