### PR TITLE
doc(keycloak-26.4): Add pending-upstream-fix advisory for GHSA-h5fg-jpgr-rv9c and GHSA-45p5-v273-3qqr

### DIFF
--- a/keycloak-26.4.advisories.yaml
+++ b/keycloak-26.4.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/quarkus-app/lib/main/io.vertx.vertx-web-4.5.21.jar
             scanner: grype
+      - timestamp: 2025-10-27T13:24:45Z
+        type: pending-upstream-fix
+        data:
+          note: Vulnerable vertx-web version 4.5.21 is being pulled in through quarkus-vertx-http dependency. Latest available quarkus-vertx-http version 3.29 still depends on a vulnerable vertx-web version 4.5.21. Upgrading vertx-web to 4.5.22 causes build failures. Upstream will have to upgrade quarkus-vertx-http to a version that doesn't pull vertx-web 4.5.21.
 
   - id: CGA-4hr2-g58h-mp99
     aliases:
@@ -115,3 +119,7 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/quarkus-app/lib/main/io.vertx.vertx-web-4.5.21.jar
             scanner: grype
+      - timestamp: 2025-10-27T13:24:45Z
+        type: pending-upstream-fix
+        data:
+          note: Vulnerable vertx-web version 4.5.21 is being pulled in through quarkus-vertx-http dependency. Latest available quarkus-vertx-http version 3.29 still depends on a vulnerable vertx-web version 4.5.21. Upgrading vertx-web to 4.5.22 causes build failures. Upstream will have to upgrade quarkus-vertx-http to a version that doesn't pull vertx-web 4.5.21.


### PR DESCRIPTION
Attempting to upgrade vertx-web in keycloak 26.4 causes test failures. See PR: https://github.com/wolfi-dev/os/pull/70048 hence adding a pending-upstream-fix advisory.