### PR TITLE
adv celeborn 0.6/version streaming setup

### DIFF
--- a/celeborn-0.6.advisories.yaml
+++ b/celeborn-0.6.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/hadoop-client-runtime-3.4.2.jar
             scanner: grype
+      - timestamp: 2025-10-27T14:20:15Z
+        type: pending-upstream-fix
+        data:
+          note: jackson-core is brought into celeborn via hadoop, which is already on the most recent version 3.4.2. Upstream maintainers of hadoop and celeborn will need to update the jackson-core version.
 
   - id: CGA-6x4w-p6ww-h8w6
     aliases:
@@ -61,6 +65,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/hadoop-client-runtime-3.4.2.jar
             scanner: grype
+      - timestamp: 2025-10-27T14:18:05Z
+        type: pending-upstream-fix
+        data:
+          note: jackson-core is brought into celeborn via hadoop, which is already on the most recent version 3.4.2. Upstream maintainers of hadoop and celeborn will need to update the jackson-core version.
 
   - id: CGA-83gp-5pgm-4v7j
     aliases:
@@ -101,6 +109,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/hadoop-client-runtime-3.4.2.jar
             scanner: grype
+      - timestamp: 2025-10-27T14:38:54Z
+        type: pending-upstream-fix
+        data:
+          note: jetty-http is used directly by celeborn and is also brought in by hadoop. jetty 9 is EOL and upstream maintainers need to transition to jetty 12 to receive CVE fixes. See https://github.com/jetty/jetty.project/issues/12783.
 
   - id: CGA-jj82-g9w9-4xfr
     aliases:
@@ -119,6 +131,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/hadoop-client-runtime-3.4.2.jar
             scanner: grype
+      - timestamp: 2025-10-27T14:23:03Z
+        type: pending-upstream-fix
+        data:
+          note: nimbus-jose-jwt is brought into celeborn via hadoop, which is already on the most recent version 3.4.2. Upstream maintainers of hadoop and celeborn will need to update the jackson-core version.
 
   - id: CGA-q5j9-wq6q-3g58
     aliases:
@@ -137,6 +153,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/celeborn/jars/hadoop-client-runtime-3.4.2.jar
             scanner: grype
+      - timestamp: 2025-10-27T14:21:30Z
+        type: pending-upstream-fix
+        data:
+          note: commons-lang3 is brought into celeborn via hadoop, which is already on the most recent version 3.4.2. Upstream maintainers of hadoop and celeborn will need to update the jackson-core version.
 
   - id: CGA-v929-wm8j-8mwj
     aliases:


### PR DESCRIPTION
celeborn-0.6 is newly version streamed and existing advisories under version 0.5 need to be updated for the new 0.6 version.

CVEs covered in this PR: GHSA-3p8m-j85q-pgmj, GHSA-fghv-69vj-qj49, GHSA-prj3-ccx8-p6x4, GHSA-j288-q9x7-2f5v, GHSA-h46c-h94j-95f3, GHSA-wf8f-6423-gfxg, GHSA-qh8g-58pp-2wxh, GHSA-xwmg-2g98-w7v9
