### PR TITLE
doc(splunk-otel-collector): Add pending-upstream-fix event for GHSA-vp5w-xcfc-73wf and GHSA-9g4h-h484-3578

### DIFF
--- a/splunk-otel-collector.advisories.yaml
+++ b/splunk-otel-collector.advisories.yaml
@@ -249,6 +249,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-10-27T16:29:20Z
+        type: pending-upstream-fix
+        data:
+          note: The vulnerability originates from the Vault dependency. Upgrading Vault to 1.21.0 causes build failures due to incompatible API changes. Automated upstream PR https://github.com/signalfx/splunk-otel-collector/pull/6876 is open to bump Vault to 1.21.0. This vulnerability should be remediated once the upstream PR lands.
 
   - id: CGA-9vfj-c8cq-79pm
     aliases:
@@ -690,6 +694,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-10-27T16:29:20Z
+        type: pending-upstream-fix
+        data:
+          note: The vulnerability originates from the Vault dependency. Upgrading Vault to 1.21.0 causes build failures due to incompatible API changes. Automated upstream PR https://github.com/signalfx/splunk-otel-collector/pull/6876 is open to bump Vault to 1.21.0. This vulnerability should be remediated once the upstream PR lands.
 
   - id: CGA-xgcq-m8cr-rf2h
     aliases:


### PR DESCRIPTION
The vulnerability originates from the Vault dependency. Upgrading Vault to 1.21.0 causes build failures due to incompatible API changes. Automated upstream PR https://github.com/signalfx/splunk-otel-collector/pull/6876 is open to bump Vault to 1.21.0. This vulnerability should be remediated once the upstream PR lands.

Attempted builds with Vault 1.21 fail with the following error:
```
WARNING 2025-10-25T07:51:37.864147542Z [resource.labels.containerName: workspace] /var/cache/melange/gomodcache/github.com/prometheus/prometheus@v0.305.1-0.20250808193045-294f36e80261/discovery/kubernetes/kubernetes.go:837:36: not enough arguments in call to cache.DefaultWatchErrorHandler
WARNING 2025-10-25T07:51:37.864158455Z [resource.labels.containerName: workspace] have (*"k8s.io/client-go/tools/cache".Reflector, error)
WARNING 2025-10-25T07:51:37.864164795Z [resource.labels.containerName: workspace] want (context.Context, *"k8s.io/client-go/tools/cache".Reflector, error)
```
See PR: https://github.com/wolfi-dev/os/pull/70005