### PR TITLE
splunk-otel-collector/GHSA-9g4h-h484-3578/GHSA-vp5w-xcfc-73wf: pending-upstream-fix advisories

### DIFF
--- a/splunk-otel-collector.advisories.yaml
+++ b/splunk-otel-collector.advisories.yaml
@@ -249,6 +249,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-10-28T00:28:48Z
+        type: pending-upstream-fix
+        data:
+          note: 'Upstream dependency management has attempted to build splunk-otel-collector with vault 1.21.0 and has encountered build failures. Upstream maintainers must implement compatibility with fix version of affected dependency. Url: https://github.com/signalfx/splunk-otel-collector/pull/6876'
 
   - id: CGA-9vfj-c8cq-79pm
     aliases:
@@ -690,6 +694,10 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/otelcol
             scanner: grype
+      - timestamp: 2025-10-28T00:29:26Z
+        type: pending-upstream-fix
+        data:
+          note: 'Upstream dependency management has attempted to build splunk-otel-collector with vault 1.21.0 and has encountered build failures. Upstream maintainers must implement compatibility with fix version of affected dependency. Url: https://github.com/signalfx/splunk-otel-collector/pull/6876'
 
   - id: CGA-xgcq-m8cr-rf2h
     aliases:


### PR DESCRIPTION
## Summary
Adds `pending-upstream-fix` advisories for GHSA-9g4h-h484-3578 and GHSA-vp5w-xcfc-73wf in splunk-otel-collector package.

## Issue
Both vulnerabilities affect github.com/hashicorp/vault @ v1.20.4. Upstream attempted to upgrade to vault 1.21.0 (which contains the fixes) but encountered build failures that prevent the upgrade.

## Evidence
### Build Failure Documentation
Upstream PR #6876 documents the attempt to build splunk-otel-collector with vault 1.21.0, which resulted in build failures. This blocks the ability to incorporate the fixed vault versions.

**Source**: [signalfx/splunk-otel-collector PR #6876](https://github.com/signalfx/splunk-otel-collector/pull/6876)

### Affected Vulnerabilities
- **GHSA-9g4h-h484-3578**: High severity vulnerability in vault v1.20.4
- **GHSA-vp5w-xcfc-73wf**: High severity vulnerability in vault v1.20.4

## Related Issues
- Fixes #31616
- Fixes #31618