### PR TITLE
vault-1.16/GHSA-9g4h-h484-3578: fix-not-planned advisory (EOL)

### DIFF
--- a/vault-1.16.advisories.yaml
+++ b/vault-1.16.advisories.yaml
@@ -1,0 +1,15 @@
+schema-version: 2.0.2
+
+package:
+  name: vault-1.16
+
+advisories:
+  - id: CGA-2h55-x7g9-m948
+    aliases:
+      - CVE-2025-11621
+      - GHSA-9g4h-h484-3578
+    events:
+      - timestamp: 2025-10-28T00:42:35Z
+        type: fix-not-planned
+        data:
+          note: Vault 1.16 reached end-of-life on June 10, 2024 and no longer receives security updates. Users should migrate to supported versions.


### PR DESCRIPTION
## Summary
Adds `fix-not-planned` advisory for GHSA-9g4h-h484-3578 in vault-1.16 package.

## Issue
Vault 1.16 reached end-of-life on June 10, 2024 and no longer receives security updates from upstream.

## Evidence
### EOL Status
According to endoflife.date, Vault 1.16 reached EOL on 2024-06-10.

**Source**: [endoflife.date - Hashicorp Vault](https://endoflife.date/hashicorp-vault)

### Affected Vulnerability
- **GHSA-9g4h-h484-3578**: High severity vulnerability in vault v1.20.4 (affects vault @ 1.16.3 as well)

## Resolution
Users should migrate to a supported version of Vault. Supported versions can be found at https://endoflife.date/hashicorp-vault