### PR TITLE
doc(gitlab-runner-18.5): Add false-positive-determination event for CVE-2024-36623

### DIFF
--- a/gitlab-runner-18.5.advisories.yaml
+++ b/gitlab-runner-18.5.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: go-module
             componentLocation: /usr/bin/docker-machine
             scanner: grype
+      - timestamp: 2025-10-28T05:48:24Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-version-not-used
+          note: This vulnerability is being detected erroneously since this issue has been fixed since docker 25.0.4 and we currently ship v25.0.6
 
   - id: CGA-p4c9-wmm4-wqhr
     aliases:


### PR DESCRIPTION
The vulnerability is patched in 25.0.4 and the detection event specifies component version v25.0.6+incompatible.
This vulnerability is being detected erroneously.
See related advisory for version 18.3: https://github.com/wolfi-dev/advisories/blame/ecf38f1940c2ad8cf2d3711ffb893ddab9a8a7ed/gitlab-runner-18.3.advisories.yaml#L28