### PR TITLE
doc(apicurio-registry): Add pending-upstream-fix event for GHSA-h5fg-jpgr-rv9c

### DIFF
--- a/apicurio-registry.advisories.yaml
+++ b/apicurio-registry.advisories.yaml
@@ -440,6 +440,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/apicurio-registry/lib/io.vertx.vertx-web-4.5.20.jar
             scanner: grype
+      - timestamp: 2025-10-28T15:55:28Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability is fixed in vertx-web 4.5.22. However, upgrading from 4.5.20 to 4.5.22 results in build failures. Since vertx-web is a transitive dependency, upstream will need to update direct dependencies to versions that depend on vertx-web 4.5.22 or later.
 
   - id: CGA-x238-2v8w-3j6m
     aliases:


### PR DESCRIPTION
This vulnerability is fixed in vertx-web 4.5.22. However, upgrading from 4.5.20 to 4.5.22 results in build failures. Since vertx-web is a transitive dependency, upstream will need to update direct dependencies to versions that depend on vertx-web 4.5.22 or later.

PRs where vertx-web bump lead to build failures:
- https://github.com/wolfi-dev/os/pull/69910
- https://github.com/wolfi-dev/os/pull/70096