### PR TITLE
doc(apicurio-registry): Add pending-upstream-fix event for GHSA-45p5-v273-3qqr

### DIFF
--- a/apicurio-registry.advisories.yaml
+++ b/apicurio-registry.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: java-archive
             componentLocation: /usr/share/java/apicurio-registry/lib/io.vertx.vertx-web-4.5.20.jar
             scanner: grype
+      - timestamp: 2025-10-29T14:17:01Z
+        type: pending-upstream-fix
+        data:
+          note: This vulnerability is fixed in vertx-web 4.5.22. However, upgrading from 4.5.20 to 4.5.22 results in build failures. Since vertx-web is a transitive dependency, upstream will need to update direct dependencies to versions that depend on vertx-web 4.5.22 or later.
 
   - id: CGA-3qmv-j289-r7c5
     aliases:


### PR DESCRIPTION
See [advisory PR](https://github.com/wolfi-dev/advisories/pull/24375) for GHSA-h5fg-jpgr-rv9c that also required vertx-web 4.5.22 for remediation.
Given this vulnerability requires the same dependency bump, added the same pending-upstream-fix advisory.
