### PR TITLE
keycloak-config-cli/CVE-2025-11226/GHSA-25qh-j22f-pwp8: add pending-upstream-fix advisory

### DIFF
--- a/keycloak-config-cli.advisories.yaml
+++ b/keycloak-config-cli.advisories.yaml
@@ -245,3 +245,7 @@ advisories:
         type: fixed
         data:
           fixed-version: 6.4.0-r50
+      - timestamp: 2025-10-29T16:45:34Z
+        type: pending-upstream-fix
+        data:
+          note: Upgrading logback-core to the fix version of this dependency results in image failures. Upstream maintainers need to implement functionality related to logback-core v1.5.19


### PR DESCRIPTION
## Summary
Adds `pending-upstream-fix` advisory for CVE-2025-11226/GHSA-25qh-j22f-pwp8 in keycloak-config-cli package.

## Details
Upgrading logback-core to the fix version (1.5.19+) results in image failures. Upstream keycloak-config-cli maintainers need to implement functionality related to logback-core v1.5.19 before this vulnerability can be resolved.

Attempted upgrade in https://github.com/wolfi-dev/os/pull/69697 caused build/runtime failures and was reverted in https://github.com/wolfi-dev/os/pull/70293. The dependency upgrade introduces breaking changes or incompatibilities that require upstream code modifications.