### PR TITLE
airflow-3/CVE-2023-48022 advisory update

### DIFF
--- a/airflow-3.advisories.yaml
+++ b/airflow-3.advisories.yaml
@@ -440,9 +440,9 @@ advisories:
             subpackageName: airflow-3
             componentID: ba2d1ca7236c4da6
             componentName: ray
-            componentVersion: 2.49.0
+            componentVersion: 2.47.1
             componentType: python
-            componentLocation: /opt/airflow/lib/python3.12/site-packages/ray-2.49.0.dist-info/METADATA
+            componentLocation: /opt/airflow/lib/python3.12/site-packages/ray-2.47.1.dist-info/METADATA
             scanner: grype
       - timestamp: 2025-10-03T09:31:48Z
         type: false-positive-determination


### PR DESCRIPTION
Ray is a transitive dependency with complex open constraint intra-dependency requirements. This was correct at the time of detection as 3.0.6-r1 had ray 2.49.0:
```
jamie.albert@Jamies-MacBook-Pro enterprise-packages % docker run -it --entrypoint sh --pull always cgr.dev/chainguard-private/airflow:3.0.6-r1
3.0.6-r1: Pulling from chainguard-private/airflow
Digest: sha256:80109140b3bbc2cfb25b329bec5e54d31bc0259b8a18c2d549cea08d5615af2a
Status: Image is up to date for cgr.dev/chainguard-private/airflow:3.0.6-r1
/ $ ls -ld  /opt/airflow/lib/python3.12/site-packages/ray*
drwxrwxrwx 1 airflow root 4096 Sep  2 11:35 /opt/airflow/lib/python3.12/site-packages/ray
drwxrwxrwx 1 airflow root 4096 Sep  2 11:35 /opt/airflow/lib/python3.12/site-packages/ray-2.49.0.dist-info
/ $ 
```
With how this dependency is handled by airflow's providers, it is not unexpected for the version of ray to shift somewhat. I can certainly update the advisory to reflect the current version of ray in the airflow-3 image

Airflow-3 v3.1.1 now has ray 2.47.1. Advisory updated to reflect this