### PR TITLE
doc(ceph-20): Add appropriate events for CVE-2019-10222, CVE-2017-7519, CVE-2020-1700 and CVE-2017-12155

### DIFF
--- a/ceph-20.advisories.yaml
+++ b/ceph-20.advisories.yaml
@@ -21,6 +21,11 @@ advisories:
             componentType: apk
             componentLocation: /.PKGINFO
             scanner: grype
+      - timestamp: 2025-10-31T13:33:48Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-included-in-package
+          note: This vulnerability affects older versions of the tripleo-heat-template which is EOL and not included within the package. Tracking of the original fixes can be found at https://bugs.launchpad.net/tripleo/+bug/1720787
 
   - id: CGA-j24v-mvrj-ppfj
     aliases:


### PR DESCRIPTION
This PR adds advisories for each

* CVE-2017-12155: false positive, affected the (now EOL) [tripleo-heat-template](https://github.com/openstack-archive/tripleo-heat-templates)
* CVE-2017-7519 fixed [here](https://github.com/ceph/ceph/pull/15674), first introduced under tag v12.1.1
* CVE-2019-10222: tracked in this [upstream ticket](https://tracker.ceph.com/issues/40018), fix released in v15.2.0
* CVE-2020-1700: fixed [here](https://github.com/ceph/ceph/commit/55ad9b6937f09bbf81dea27b017ffa4e63d4f044) and released in v15.1.1
Related PRs: https://github.com/wolfi-dev/advisories/pull/21164,  https://github.com/wolfi-dev/advisories/pull/24246 and https://github.com/chainguard-dev/enterprise-advisories/pull/26206