### PR TITLE
doc(keycloak-26.4): Add pending-upstream-fix events for GHSA-c6cm-5gc7-c3f4 and GHSA-rg35-5v25-mqvp

### DIFF
--- a/keycloak-26.4.advisories.yaml
+++ b/keycloak-26.4.advisories.yaml
@@ -43,6 +43,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/iamguarded/keycloak/lib/lib/main/org.keycloak.keycloak-quarkus-server-26.4.2.jar
             scanner: grype
+      - timestamp: 2025-10-31T17:53:24Z
+        type: pending-upstream-fix
+        data:
+          note: A patch for this vulnerability is not yet available. The upstream project will need to implement code changes to address it.
 
   - id: CGA-4hr2-g58h-mp99
     aliases:
@@ -83,6 +87,10 @@ advisories:
             componentType: java-archive
             componentLocation: /opt/iamguarded/keycloak/lib/lib/main/org.keycloak.keycloak-services-26.4.2.jar
             scanner: grype
+      - timestamp: 2025-10-31T17:53:24Z
+        type: pending-upstream-fix
+        data:
+          note: A patch for this vulnerability is not yet available. The upstream project will need to implement code changes to address it.
 
   - id: CGA-9647-2wx5-r2m4
     aliases:


### PR DESCRIPTION
Patches are not yet available for GHSA-c6cm-5gc7-c3f4 and GHSA-rg35-5v25-mqvp hence added pending-upstream-fix events