### PR TITLE
doc(npm): Add pending-upstream-fx event for GHSA-29xp-372q-xqph

### DIFF
--- a/npm.advisories.yaml
+++ b/npm.advisories.yaml
@@ -44,6 +44,10 @@ advisories:
             componentType: npm
             componentLocation: /usr/lib/node_modules/npm/node_modules/tar/package.json
             scanner: grype
+      - timestamp: 2025-11-03T11:19:46Z
+        type: pending-upstream-fix
+        data:
+          note: Since this package relies on upstream artifacts, the vulnerability must be remediated upstream by updating tar to version 7.5.2 or later.
 
   - id: CGA-ff5p-6mq6-jqwc
     aliases:


### PR DESCRIPTION
Since this package relies on upstream artifacts, the vulnerability must be remediated upstream by updating tar to version 7.5.2 or later.
I attempted to upgrade tar by using sed to update package.json but that did not actually upgrade tar.
Or directly using `npm update` to update upgrade tar to 7.5.2 but this results in a build failure.
See PR: https://github.com/wolfi-dev/os/pull/70826
