### PR TITLE
doc(npm): Add false-positive-determination for GHSA-29xp-372q-xqph

### DIFF
--- a/npm.advisories.yaml
+++ b/npm.advisories.yaml
@@ -48,6 +48,11 @@ advisories:
         type: pending-upstream-fix
         data:
           note: Since this package relies on upstream artifacts, the vulnerability must be remediated upstream by updating tar to version 7.5.2 or later.
+      - timestamp: 2025-11-04T09:27:38Z
+        type: false-positive-determination
+        data:
+          type: vulnerable-code-not-in-execution-path
+          note: 'npm does not utilize the affected code path. For more details, refer to the upstream discussions: https://github.com/nodejs/node/pull/60430#issuecomment-3455536702 and https://github.com/nodejs/node/pull/60012#issuecomment-3452094442'
 
   - id: CGA-ff5p-6mq6-jqwc
     aliases:


### PR DESCRIPTION
 GHSA-29xp-372q-xqph in npm was initally resolved as `pending-upstream-fix`. I have since discovered upstream discussions that establish that npm does not use the vulnerable code path. See https://github.com/nodejs/node/pull/60430#issuecomment-3455536702 and https://github.com/nodejs/node/pull/60012#issuecomment-3452094442
Proposing adding a `false-positive-determination` event.