### PR TITLE
dotnet-8/dotnet-9: add advisory

### DIFF
--- a/dotnet-8.advisories.yaml
+++ b/dotnet-8.advisories.yaml
@@ -14,6 +14,16 @@ advisories:
         data:
           fixed-version: 8.0.7-r0
 
+  - id: CGA-hw2c-vw97-5823
+    aliases:
+      - CVE-2025-55315
+      - GHSA-5rrx-jjjq-q2r5
+    events:
+      - timestamp: 2025-11-04T10:05:46Z
+        type: fixed
+        data:
+          fixed-version: 8.0.121-r0
+
   - id: CGA-jh5q-2rrw-hwjq
     aliases:
       - CVE-2024-30105

--- a/dotnet-9.advisories.yaml
+++ b/dotnet-9.advisories.yaml
@@ -30,6 +30,16 @@ advisories:
         data:
           fixed-version: 9.0.2-r0
 
+  - id: CGA-w393-6pwm-qp58
+    aliases:
+      - CVE-2025-55315
+      - GHSA-5rrx-jjjq-q2r5
+    events:
+      - timestamp: 2025-11-04T10:05:11Z
+        type: fixed
+        data:
+          fixed-version: 9.0.111-r0
+
   - id: CGA-x92v-q46w-q69x
     aliases:
       - CVE-2024-43499


### PR DESCRIPTION
Add advisory for CVE-2025-55315
Explicitly express which package version in dotnet-8 and dotnet-9 has the fix.

Signed-off-by: David Negreira <david.negreira@chainguard.dev>
