### PR TITLE
doc(logstash-9.2): Copy advisories from logstash-9.1

### DIFF
--- a/logstash-9.2.advisories.yaml
+++ b/logstash-9.2.advisories.yaml
@@ -21,6 +21,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/rexml-3.3.9.gemspec
             scanner: grype
+      - timestamp: 2025-11-04T13:37:03Z
+        type: pending-upstream-fix
+        data:
+          note: The rexml dependency has been upgraded at v3.4.2. The rexml gem at v3.3.9 remained is included as a default gem in JRuby’s standard library. Because it’s part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of rexml.
 
   - id: CGA-9qjm-5g3w-4hmm
     aliases:
@@ -39,6 +43,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
             scanner: grype
+      - timestamp: 2025-11-04T13:40:30Z
+        type: pending-upstream-fix
+        data:
+          note: The cgi gem at version 0.3.6 is included as a default gem in JRuby's standard library. Because it's part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of cgi (0.3.7+).
 
   - id: CGA-jwvm-7x8c-w2fp
     aliases:
@@ -57,6 +65,10 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/uri-0.12.3.gemspec
             scanner: grype
+      - timestamp: 2025-11-04T13:44:33Z
+        type: pending-upstream-fix
+        data:
+          note: The uri gem at version 0.12.2 is included as a default gem in JRuby's standard library. Because it's part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of uri (0.12.4+).
 
   - id: CGA-xr6m-r5jp-pf9j
     aliases:
@@ -75,3 +87,7 @@ advisories:
             componentType: gem
             componentLocation: /opt/bitnami/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default/cgi-0.3.6-java.gemspec
             scanner: grype
+      - timestamp: 2025-11-04T13:38:30Z
+        type: pending-upstream-fix
+        data:
+          note: The cgi gem at version 0.3.6 is included as a default gem in JRuby's standard library. Because it's part of JRuby itself rather than a separately managed gem, an updated JRuby release is required to incorporate the remediated version of cgi (0.3.7+).


### PR DESCRIPTION
Copy over [advisories from logstash-9.1](https://github.com/chainguard-dev/enterprise-advisories/blob/main/logstash-9.1.advisories.yaml)
This adds pending-upstream-fix events for:
- GHSA-c2f4-jgmc-q2r5
- GHSA-mhwm-jh88-3gjf
- GHSA-22h5-pq3x-2gf2
- GHSA-gh9q-2xrm-x6qv